### PR TITLE
feat: Octokit 설정 및 GitHub API 클라이언트 구성

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,33 @@
+import { Octokit } from "@octokit/rest"
+import { prisma } from "./prisma"
+import { auth } from "./auth"
+
+/**
+ * userId로 DB에서 githubToken을 조회하여 인증된 Octokit 인스턴스를 생성한다.
+ */
+export async function getOctokit(userId: string): Promise<Octokit> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { githubToken: true },
+  })
+
+  if (!user?.githubToken) {
+    throw new Error("GitHub 토큰이 없습니다. GitHub 계정을 다시 연동해주세요.")
+  }
+
+  return new Octokit({ auth: user.githubToken })
+}
+
+/**
+ * 현재 세션의 사용자로 인증된 Octokit 인스턴스를 생성한다.
+ * Server Component / API Route / Server Action에서 사용.
+ */
+export async function getAuthenticatedOctokit(): Promise<Octokit> {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    throw new Error("인증되지 않은 사용자입니다. 로그인이 필요합니다.")
+  }
+
+  return getOctokit(session.user.id)
+}


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)

## 관련 마일스톤

- [x] Week 3-4: GitHub 연동

## 개요

NextAuth의 GitHub OAuth 토큰과 연동하여 재사용 가능한 Octokit 기반 GitHub API 클라이언트 모듈을 구성한다.

## 변경 사항

- `lib/github.ts` 신규 작성
  - `getOctokit(userId)`: DB에서 githubToken 조회 후 인증된 Octokit 인스턴스 생성
  - `getAuthenticatedOctokit()`: 현재 세션 기반으로 Octokit 인스턴스 생성 (Server Component / API Route / Server Action용)
  - 토큰 미존재 및 미인증 시 명확한 에러 메시지 throw

## 테스트

- [x] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`npm run build` 통과)
- [x] ESLint 경고/에러 없음

## 참고 사항

- `@octokit/rest` v22.0.1 기존 설치 활용
- 토큰은 `lib/auth.ts`의 `linkAccount` 이벤트에서 `User.githubToken`에 저장됨
- 이후 Repository 연동, PR 조회 등에서 이 모듈을 활용 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)