### PR TITLE
fix: PullRequest githubId 타입을 BigInt로 DB 마이그레이션 및 저장소 연동 페이지 추가

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -33,7 +33,7 @@ export const authConfig = {
         await prisma.user.update({
           where: { id: user.id },
           data: {
-            githubId: Number(profile.id),
+            githubId: BigInt(profile.id as string | number),
             email: profile.email as string | undefined,
           },
         })


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [x] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

GitHub API에서 반환하는 `githubId` 값이 JavaScript의 안전 정수 범위(`Number.MAX_SAFE_INTEGER`)를 초과할 수 있어, Prisma 스키마의 `User`, `Repository`, `PullRequest` 모델의 `githubId` 필드 타입을 `Int`에서 `BigInt`로 변경합니다.

또한 저장소 연동 페이지 UI 및 API 연동, 무한스크롤 등 GitHub 연동 관련 기능을 함께 포함합니다.

closes #33

## 변경 사항

- `prisma/schema.prisma`: `User`, `Repository`, `PullRequest` 모델의 `githubId` 타입을 `Int` → `BigInt`로 변경
- `app/api/github/repos/route.ts`: `BigInt` 직렬화 처리 및 `repositoryId` 응답 필드 추가
- `app/api/repositories/route.ts`: BigInt 관련 처리 수정
- `app/api/webhook/github/route.ts`: BigInt 타입 대응
- `lib/auth.ts`: 매 로그인 시 `githubToken` 갱신, OAuth scope에 `admin:repo_hook` 추가
- `app/(protected)/repositories/page.tsx`: 저장소 연동 페이지 추가
- `components/github/`: `RepoCard`, `RepoCardSkeleton`, `RepoList`, `RepoListHeader`, `RepoSearchBar`, `RepositoriesPageHeader` 컴포넌트 추가
- `components/pulls/`: `PRCardSkeleton`, `PRSearchInput`, `PRStatusTabs` 컴포넌트 분리 및 추가
- `components/ui/InfiniteScrollTrigger.tsx`: 무한스크롤 공통 컴포넌트 추출
- `hooks/useConnectRepository.ts`, `useDisconnectRepository.ts`, `useRepositories.ts`: 저장소 관련 훅 추가
- `types/repos.ts`: 저장소 타입 정의 추가
- `__tests__`: BigInt 변경에 따른 테스트 수정

## 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 테스트

- [x] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

## 참고 사항

- GitHub의 `id` 필드는 32bit int 범위를 초과할 수 있으므로 BigInt 사용이 필수입니다.
- BigInt 값은 JSON 직렬화 시 별도 처리가 필요합니다 (`String(bigintValue)` 변환 적용).
- Prisma 마이그레이션 실행 필요: `npx prisma migrate dev`