### PR TITLE
[Feature] AI 분석 코어 (파싱 & 스코어링)

### DIFF
--- a/__tests__/lib/ai/parsers.test.ts
+++ b/__tests__/lib/ai/parsers.test.ts
@@ -1,0 +1,84 @@
+import { parseAIReviewResponse } from "@/lib/ai/parsers"
+
+const validResponse = {
+  issues: [
+    {
+      filePath: "src/utils.ts",
+      lineNumber: 42,
+      severity: "HIGH",
+      category: "BUG",
+      title: "Null dereference",
+      description: "value can be null",
+      suggestion: "add null check",
+      exampleCode: "if (value) { ... }",
+    },
+  ],
+  summary: "1개의 심각한 버그가 발견되었습니다.",
+  overallAssessment: "REQUEST_CHANGES",
+}
+
+describe("parseAIReviewResponse", () => {
+  it("유효한 JSON 문자열을 파싱한다", () => {
+    const result = parseAIReviewResponse(JSON.stringify(validResponse))
+
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].severity).toBe("HIGH")
+    expect(result.summary).toBe("1개의 심각한 버그가 발견되었습니다.")
+    expect(result.overallAssessment).toBe("REQUEST_CHANGES")
+  })
+
+  it("마크다운 ```json 코드 블록 안의 JSON을 파싱한다", () => {
+    const text = "```json\n" + JSON.stringify(validResponse) + "\n```"
+    const result = parseAIReviewResponse(text)
+
+    expect(result.issues).toHaveLength(1)
+    expect(result.overallAssessment).toBe("REQUEST_CHANGES")
+  })
+
+  it("마크다운 ``` 코드 블록 안의 JSON을 파싱한다", () => {
+    const text = "```\n" + JSON.stringify(validResponse) + "\n```"
+    const result = parseAIReviewResponse(text)
+
+    expect(result.issues).toHaveLength(1)
+  })
+
+  it("JSON 앞뒤에 텍스트가 있어도 파싱한다", () => {
+    const text = "Here is the review:\n" + JSON.stringify(validResponse) + "\nDone."
+    const result = parseAIReviewResponse(text)
+
+    expect(result.issues).toHaveLength(1)
+  })
+
+  it("잘못된 JSON이면 fallback을 반환한다", () => {
+    const result = parseAIReviewResponse("not valid json at all")
+
+    expect(result.issues).toHaveLength(0)
+    expect(result.overallAssessment).toBe("COMMENT")
+  })
+
+  it("Zod 스키마 불일치 시 fallback을 반환한다", () => {
+    const invalid = { ...validResponse, overallAssessment: "INVALID_VALUE" }
+    const result = parseAIReviewResponse(JSON.stringify(invalid))
+
+    expect(result.issues).toHaveLength(0)
+    expect(result.overallAssessment).toBe("COMMENT")
+  })
+
+  it("빈 issues 배열도 정상 파싱한다", () => {
+    const empty = { issues: [], summary: "문제 없음", overallAssessment: "APPROVE" }
+    const result = parseAIReviewResponse(JSON.stringify(empty))
+
+    expect(result.issues).toHaveLength(0)
+    expect(result.overallAssessment).toBe("APPROVE")
+  })
+
+  it("lineNumber가 null인 이슈도 파싱한다", () => {
+    const withNull = {
+      ...validResponse,
+      issues: [{ ...validResponse.issues[0], lineNumber: null }],
+    }
+    const result = parseAIReviewResponse(JSON.stringify(withNull))
+
+    expect(result.issues[0].lineNumber).toBeNull()
+  })
+})

--- a/__tests__/lib/scoring.test.ts
+++ b/__tests__/lib/scoring.test.ts
@@ -1,0 +1,86 @@
+import { calculateScore } from "@/lib/scoring"
+import type { AIReviewIssue } from "@/lib/ai/parsers"
+
+const makeIssue = (severity: AIReviewIssue["severity"]): AIReviewIssue => ({
+  filePath: "src/file.ts",
+  lineNumber: 1,
+  severity,
+  category: "BUG",
+  title: "title",
+  description: "desc",
+  suggestion: "fix it",
+})
+
+describe("calculateScore", () => {
+  it("이슈 없음 → 점수 100, severity LOW", () => {
+    const result = calculateScore([])
+
+    expect(result.score).toBe(100)
+    expect(result.overallSeverity).toBe("LOW")
+    expect(result.issueCount).toBe(0)
+  })
+
+  it("HIGH 이슈 1개 → 점수 85, severity HIGH", () => {
+    const result = calculateScore([makeIssue("HIGH")])
+
+    expect(result.score).toBe(85)
+    expect(result.overallSeverity).toBe("HIGH")
+  })
+
+  it("MEDIUM 이슈 1개 → 점수 93, severity MEDIUM", () => {
+    const result = calculateScore([makeIssue("MEDIUM")])
+
+    expect(result.score).toBe(93)
+    expect(result.overallSeverity).toBe("MEDIUM")
+  })
+
+  it("LOW 이슈 1개 → 점수 97, severity LOW", () => {
+    const result = calculateScore([makeIssue("LOW")])
+
+    expect(result.score).toBe(97)
+    expect(result.overallSeverity).toBe("LOW")
+  })
+
+  it("HIGH 이슈 7개 → 점수 0 (음수 방지)", () => {
+    const issues = Array.from({ length: 7 }, () => makeIssue("HIGH"))
+    const result = calculateScore(issues)
+
+    expect(result.score).toBe(0)
+  })
+
+  it("혼합 이슈 (HIGH 1 + MEDIUM 2 + LOW 1) → 점수 72", () => {
+    // 100 - 15 - 7 - 7 - 3 = 68
+    const issues = [
+      makeIssue("HIGH"),
+      makeIssue("MEDIUM"),
+      makeIssue("MEDIUM"),
+      makeIssue("LOW"),
+    ]
+    const result = calculateScore(issues)
+
+    expect(result.score).toBe(68)
+    expect(result.overallSeverity).toBe("HIGH")
+    expect(result.issueCount).toBe(4)
+  })
+
+  it("MEDIUM + LOW만 있으면 severity MEDIUM", () => {
+    const issues = [makeIssue("MEDIUM"), makeIssue("LOW")]
+    const result = calculateScore(issues)
+
+    expect(result.overallSeverity).toBe("MEDIUM")
+  })
+
+  it("LOW만 있으면 severity LOW", () => {
+    const issues = [makeIssue("LOW"), makeIssue("LOW")]
+    const result = calculateScore(issues)
+
+    expect(result.overallSeverity).toBe("LOW")
+  })
+
+  it("issueCount가 정확히 반환된다", () => {
+    const issues = [makeIssue("HIGH"), makeIssue("LOW"), makeIssue("MEDIUM")]
+    const result = calculateScore(issues)
+
+    expect(result.issueCount).toBe(3)
+  })
+})

--- a/lib/ai/parsers.ts
+++ b/lib/ai/parsers.ts
@@ -1,0 +1,57 @@
+import { z } from "zod"
+
+const AIReviewIssueSchema = z.object({
+  filePath: z.string(),
+  lineNumber: z.number().nullable(),
+  severity: z.enum(["HIGH", "MEDIUM", "LOW"]),
+  category: z.enum(["BUG", "PERFORMANCE", "SECURITY", "QUALITY", "BEST_PRACTICE"]),
+  title: z.string(),
+  description: z.string(),
+  suggestion: z.string(),
+  exampleCode: z.string().nullable().optional(),
+})
+
+const AIReviewResponseSchema = z.object({
+  issues: z.array(AIReviewIssueSchema),
+  summary: z.string(),
+  overallAssessment: z.enum(["APPROVE", "REQUEST_CHANGES", "COMMENT"]),
+})
+
+export type AIReviewIssue = z.infer<typeof AIReviewIssueSchema>
+export type AIReviewResponse = z.infer<typeof AIReviewResponseSchema>
+
+const FALLBACK: AIReviewResponse = {
+  issues: [],
+  summary: "파싱에 실패하여 리뷰 결과를 가져올 수 없습니다.",
+  overallAssessment: "COMMENT",
+}
+
+function extractJson(text: string): string {
+  // 마크다운 코드 블록 안의 JSON 추출 (```json ... ``` 또는 ``` ... ```)
+  const codeBlockMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/)
+  if (codeBlockMatch) return codeBlockMatch[1].trim()
+
+  // 중괄호로 감싸진 첫 번째 JSON 객체 추출
+  const jsonMatch = text.match(/\{[\s\S]*\}/)
+  if (jsonMatch) return jsonMatch[0]
+
+  return text.trim()
+}
+
+export function parseAIReviewResponse(text: string): AIReviewResponse {
+  try {
+    const json = extractJson(text)
+    const parsed = JSON.parse(json)
+    const result = AIReviewResponseSchema.safeParse(parsed)
+
+    if (!result.success) {
+      console.error("[parseAIReviewResponse] Zod validation failed:", result.error.flatten())
+      return FALLBACK
+    }
+
+    return result.data
+  } catch (err) {
+    console.error("[parseAIReviewResponse] JSON parse failed:", err)
+    return FALLBACK
+  }
+}

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,0 +1,33 @@
+import type { AIReviewIssue } from "@/lib/ai/parsers"
+
+const DEDUCTIONS: Record<AIReviewIssue["severity"], number> = {
+  HIGH: 15,
+  MEDIUM: 7,
+  LOW: 3,
+}
+
+export type OverallSeverity = "HIGH" | "MEDIUM" | "LOW"
+
+export interface ScoreResult {
+  score: number
+  overallSeverity: OverallSeverity
+  issueCount: number
+}
+
+export function calculateScore(issues: AIReviewIssue[]): ScoreResult {
+  const issueCount = issues.length
+
+  const score = Math.max(
+    0,
+    issues.reduce((acc, issue) => acc - DEDUCTIONS[issue.severity], 100)
+  )
+
+  let overallSeverity: OverallSeverity = "LOW"
+  if (issues.some((i) => i.severity === "HIGH")) {
+    overallSeverity = "HIGH"
+  } else if (issues.some((i) => i.severity === "MEDIUM")) {
+    overallSeverity = "MEDIUM"
+  }
+
+  return { score, overallSeverity, issueCount }
+}


### PR DESCRIPTION
Closes #43

## 📝 기능 설명
Claude 응답에서 JSON을 추출·검증하는 파서(`lib/ai/parsers.ts`)와 품질 점수를 계산하는 스코어링 모듈(`lib/scoring.ts`)을 구현한다.

## 🎯 목표
- Claude 텍스트 응답에서 JSON 블록 추출 및 Zod 타입 검증
- 파싱 실패 시 빈 이슈 배열 fallback 처리
- 이슈 severity 기반 0-100 품질 점수 계산

## 📋 체크리스트
- [x] `lib/ai/parsers.ts` — JSON 추출 함수 (마크다운 코드 블록 포함 대응)
- [x] Zod 스키마 정의 (`AIReviewResponse`) 및 TypeScript 타입 export
- [x] 파싱 실패 fallback: 빈 이슈 배열 + 에러 로그
- [x] `lib/scoring.ts` — `calculateScore(issues)` 함수 구현
- [x] 감점 규칙: HIGH -15점, MEDIUM -7점, LOW -3점 (0점 하한)
- [x] 전체 severity 결정 로직 (HIGH ≥1 → HIGH, MEDIUM만 → MEDIUM, 그 외 → LOW)
- [x] `issueCount` 반환

## 🧪 테스트 시나리오
- [x] 유효한 JSON 응답 파싱 성공 확인
- [x] 마크다운 코드 블록(` ```json ``` `) 내 JSON 파싱 확인
- [x] 잘못된 JSON 시 fallback 반환 확인
- [x] 이슈 없음 → 점수 100 확인
- [x] HIGH 이슈 7개 → 점수 0 확인 (음수 방지)
- [x] 혼합 이슈 점수 계산 정확도 확인

## 📎 참고 자료
- [week5-6-ai-review-plan.md](./docs/week5-6-ai-review-plan.md) — Phase 1-2

## 💭 메모
- 총 26개 테스트 통과 (parsers 8개, scoring 9개, prompts 9개)