### PR TITLE
feat: 통계 페이지 백엔드 구현 (API + 데이터 레이어) (#66)

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,110 @@
+import { auth } from "@/lib/auth"
+import { NextResponse } from "next/server"
+import {
+  isValidRange,
+  fetchStatsOverview,
+  fetchPRTrend,
+  fetchQualityTrend,
+  fetchIssueDistribution,
+  fetchCodeChanges,
+  VALID_TYPES,
+  type StatsRange,
+  type StatsType,
+} from "@/lib/stats"
+
+/**
+ * @swagger
+ * /api/stats:
+ *   get:
+ *     summary: 통계 데이터 조회
+ *     description: PR / 코드 품질 / 이슈 등 통계 데이터를 반환합니다. type 파라미터로 조회 유형을 선택합니다.
+ *     tags:
+ *       - Stats
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [overview, pr-trend, quality-trend, issue-distribution, code-changes]
+ *           default: overview
+ *         description: 조회할 통계 유형
+ *       - in: query
+ *         name: range
+ *         schema:
+ *           type: string
+ *           enum: [7d, 30d, 90d, all]
+ *           default: 30d
+ *         description: 조회 기간
+ *       - in: query
+ *         name: repoId
+ *         schema:
+ *           type: string
+ *         description: 특정 저장소 ID로 필터링 (없으면 전체 저장소 합산)
+ *     responses:
+ *       200:
+ *         description: 통계 데이터 조회 성공
+ *       400:
+ *         description: 유효하지 않은 파라미터
+ *       401:
+ *         description: 인증되지 않은 사용자
+ *       500:
+ *         description: 서버 내부 오류
+ */
+export async function GET(request: Request) {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const type = searchParams.get("type") ?? "overview"
+    const rangeParam = searchParams.get("range") ?? "30d"
+    const repoId = searchParams.get("repoId") ?? undefined
+
+    if (!VALID_TYPES.includes(type as StatsType)) {
+      return NextResponse.json(
+        {
+          error: `유효하지 않은 type 값입니다. 허용값: ${VALID_TYPES.join(", ")}`,
+        },
+        { status: 400 }
+      )
+    }
+
+    if (!isValidRange(rangeParam)) {
+      return NextResponse.json(
+        { error: "유효하지 않은 range 값입니다. 허용값: 7d, 30d, 90d, all" },
+        { status: 400 }
+      )
+    }
+
+    const range = rangeParam as StatsRange
+    const userId = session.user.id
+
+    switch (type as StatsType) {
+      case "overview":
+        return NextResponse.json(
+          await fetchStatsOverview(userId, range, repoId)
+        )
+      case "pr-trend":
+        return NextResponse.json({
+          data: await fetchPRTrend(userId, range, repoId),
+        })
+      case "quality-trend":
+        return NextResponse.json({
+          data: await fetchQualityTrend(userId, range, repoId),
+        })
+      case "issue-distribution":
+        return NextResponse.json(
+          await fetchIssueDistribution(userId, range, repoId)
+        )
+      case "code-changes":
+        return NextResponse.json({
+          data: await fetchCodeChanges(userId, range, repoId),
+        })
+    }
+  } catch (err) {
+    console.error("[GET /api/stats]", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,374 @@
+import { prisma } from "@/lib/prisma"
+import type { AIReviewIssue } from "@/lib/ai/parsers"
+
+export type StatsRange = "7d" | "30d" | "90d" | "all"
+export type StatsType =
+  | "overview"
+  | "pr-trend"
+  | "quality-trend"
+  | "issue-distribution"
+  | "code-changes"
+
+export interface StatsOverview {
+  totalPRs: number
+  mergedPRs: number
+  mergeRate: number
+  avgQualityScore: number
+  totalIssues: number
+  resolvedComments: number
+  totalComments: number
+}
+
+export interface PRTrendItem {
+  week: string
+  open: number
+  merged: number
+  closed: number
+  draft: number
+}
+
+export interface QualityTrendItem {
+  date: string
+  avgScore: number
+  reviewCount: number
+}
+
+export interface IssueSeverityItem {
+  name: string
+  value: number
+  color: string
+}
+
+export interface IssueCategoryItem {
+  name: string
+  count: number
+}
+
+export interface IssueDistribution {
+  bySeverity: IssueSeverityItem[]
+  byCategory: IssueCategoryItem[]
+}
+
+export interface CodeChangesItem {
+  week: string
+  additions: number
+  deletions: number
+  files: number
+}
+
+export const VALID_RANGES = ["7d", "30d", "90d", "all"] as const
+export const VALID_TYPES: StatsType[] = [
+  "overview",
+  "pr-trend",
+  "quality-trend",
+  "issue-distribution",
+  "code-changes",
+]
+
+const SEVERITY_COLORS: Record<string, string> = {
+  CRITICAL: "#7c3aed",
+  HIGH: "#ef4444",
+  MEDIUM: "#f59e0b",
+  LOW: "#3b82f6",
+}
+
+const ISSUE_CATEGORIES = [
+  "BUG",
+  "PERFORMANCE",
+  "SECURITY",
+  "QUALITY",
+  "BEST_PRACTICE",
+] as const
+
+export function isValidRange(range: string): range is StatsRange {
+  return VALID_RANGES.includes(range as StatsRange)
+}
+
+function getStartDate(range: StatsRange): Date | undefined {
+  if (range === "all") return undefined
+  const days = range === "7d" ? 7 : range === "30d" ? 30 : 90
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+// 해당 날짜가 속한 주의 월요일을 반환
+function getWeekStart(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  d.setDate(diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function formatWeekLabel(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()}`
+}
+
+function formatDayLabel(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()}`
+}
+
+export async function fetchStatsOverview(
+  userId: string,
+  range: StatsRange,
+  repoId?: string
+): Promise<StatsOverview> {
+  const startDate = getStartDate(range)
+
+  const prDateFilter = startDate
+    ? { githubCreatedAt: { gte: startDate } }
+    : {}
+  const reviewDateFilter = startDate
+    ? { reviewedAt: { gte: startDate } }
+    : {}
+  const commentDateFilter = startDate
+    ? { createdAt: { gte: startDate } }
+    : {}
+
+  const prRepoFilter = {
+    repo: { userId, ...(repoId ? { id: repoId } : {}) },
+  }
+
+  const [prStats, reviewAgg, issueAgg, totalComments, resolvedComments] =
+    await Promise.all([
+      prisma.pullRequest.groupBy({
+        by: ["status"],
+        where: { ...prRepoFilter, ...prDateFilter },
+        _count: { id: true },
+      }),
+      prisma.review.aggregate({
+        where: {
+          pullRequest: prRepoFilter,
+          status: "COMPLETED",
+          ...reviewDateFilter,
+        },
+        _avg: { qualityScore: true },
+      }),
+      prisma.review.aggregate({
+        where: {
+          pullRequest: prRepoFilter,
+          status: "COMPLETED",
+          ...reviewDateFilter,
+        },
+        _sum: { issueCount: true },
+      }),
+      prisma.comment.count({
+        where: { pullRequest: prRepoFilter, ...commentDateFilter },
+      }),
+      prisma.comment.count({
+        where: {
+          pullRequest: prRepoFilter,
+          isResolved: true,
+          ...commentDateFilter,
+        },
+      }),
+    ])
+
+  const totalPRs = prStats.reduce((sum, s) => sum + s._count.id, 0)
+  const mergedPRs =
+    prStats.find((s) => s.status === "MERGED")?._count.id ?? 0
+  const mergeRate =
+    totalPRs > 0 ? Math.round((mergedPRs / totalPRs) * 1000) / 10 : 0
+
+  return {
+    totalPRs,
+    mergedPRs,
+    mergeRate,
+    avgQualityScore:
+      Math.round((reviewAgg._avg.qualityScore ?? 0) * 10) / 10,
+    totalIssues: issueAgg._sum.issueCount ?? 0,
+    resolvedComments,
+    totalComments,
+  }
+}
+
+export async function fetchPRTrend(
+  userId: string,
+  range: StatsRange,
+  repoId?: string
+): Promise<PRTrendItem[]> {
+  const startDate = getStartDate(range)
+
+  const prs = await prisma.pullRequest.findMany({
+    where: {
+      repo: { userId, ...(repoId ? { id: repoId } : {}) },
+      ...(startDate ? { githubCreatedAt: { gte: startDate } } : {}),
+    },
+    select: { status: true, githubCreatedAt: true, createdAt: true },
+    orderBy: { githubCreatedAt: { sort: "asc", nulls: "last" } },
+  })
+
+  const weekMap = new Map<string, PRTrendItem>()
+
+  for (const pr of prs) {
+    const date = pr.githubCreatedAt ?? pr.createdAt
+    const weekStart = getWeekStart(date)
+    const key = weekStart.toISOString()
+
+    if (!weekMap.has(key)) {
+      weekMap.set(key, {
+        week: formatWeekLabel(weekStart),
+        open: 0,
+        merged: 0,
+        closed: 0,
+        draft: 0,
+      })
+    }
+
+    const entry = weekMap.get(key)!
+    if (pr.status === "OPEN") entry.open++
+    else if (pr.status === "MERGED") entry.merged++
+    else if (pr.status === "CLOSED") entry.closed++
+    else if (pr.status === "DRAFT") entry.draft++
+  }
+
+  return Array.from(weekMap.values())
+}
+
+export async function fetchQualityTrend(
+  userId: string,
+  range: StatsRange,
+  repoId?: string
+): Promise<QualityTrendItem[]> {
+  const startDate = getStartDate(range)
+
+  const reviews = await prisma.review.findMany({
+    where: {
+      pullRequest: {
+        repo: { userId, ...(repoId ? { id: repoId } : {}) },
+      },
+      status: "COMPLETED",
+      ...(startDate ? { reviewedAt: { gte: startDate } } : {}),
+    },
+    select: { qualityScore: true, reviewedAt: true },
+    orderBy: { reviewedAt: "asc" },
+  })
+
+  const dayMap = new Map<string, { total: number; count: number }>()
+
+  for (const r of reviews) {
+    const d = new Date(r.reviewedAt)
+    d.setHours(0, 0, 0, 0)
+    const key = d.toISOString()
+
+    if (!dayMap.has(key)) dayMap.set(key, { total: 0, count: 0 })
+    const entry = dayMap.get(key)!
+    entry.total += r.qualityScore
+    entry.count++
+  }
+
+  return Array.from(dayMap.entries()).map(([key, val]) => ({
+    date: formatDayLabel(new Date(key)),
+    avgScore: Math.round((val.total / val.count) * 10) / 10,
+    reviewCount: val.count,
+  }))
+}
+
+export async function fetchIssueDistribution(
+  userId: string,
+  range: StatsRange,
+  repoId?: string
+): Promise<IssueDistribution> {
+  const startDate = getStartDate(range)
+
+  const reviewFilter = {
+    pullRequest: {
+      repo: { userId, ...(repoId ? { id: repoId } : {}) },
+    },
+    status: "COMPLETED" as const,
+    ...(startDate ? { reviewedAt: { gte: startDate } } : {}),
+  }
+
+  const [severityGroups, reviews] = await Promise.all([
+    prisma.review.groupBy({
+      by: ["severity"],
+      where: reviewFilter,
+      _count: { id: true },
+    }),
+    prisma.review.findMany({
+      where: reviewFilter,
+      select: { aiSuggestions: true },
+    }),
+  ])
+
+  const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+  const bySeverity: IssueSeverityItem[] = severityOrder
+    .map((name) => ({
+      name,
+      value:
+        severityGroups.find((g) => g.severity === name)?._count.id ?? 0,
+      color: SEVERITY_COLORS[name],
+    }))
+    .filter((item) => item.value > 0)
+
+  // aiSuggestions JSON에서 카테고리별 이슈 수 집계
+  const categoryCount = new Map<string, number>()
+
+  for (const r of reviews) {
+    const suggestions = r.aiSuggestions as { issues?: AIReviewIssue[] }
+    if (!suggestions?.issues) continue
+    for (const issue of suggestions.issues) {
+      const cat = issue.category
+      if ((ISSUE_CATEGORIES as readonly string[]).includes(cat)) {
+        categoryCount.set(cat, (categoryCount.get(cat) ?? 0) + 1)
+      }
+    }
+  }
+
+  const byCategory: IssueCategoryItem[] = ISSUE_CATEGORIES.map((name) => ({
+    name,
+    count: categoryCount.get(name) ?? 0,
+  })).filter((item) => item.count > 0)
+
+  return { bySeverity, byCategory }
+}
+
+export async function fetchCodeChanges(
+  userId: string,
+  range: StatsRange,
+  repoId?: string
+): Promise<CodeChangesItem[]> {
+  const startDate = getStartDate(range)
+
+  const prs = await prisma.pullRequest.findMany({
+    where: {
+      repo: { userId, ...(repoId ? { id: repoId } : {}) },
+      ...(startDate ? { githubCreatedAt: { gte: startDate } } : {}),
+    },
+    select: {
+      additions: true,
+      deletions: true,
+      changedFiles: true,
+      githubCreatedAt: true,
+      createdAt: true,
+    },
+    orderBy: { githubCreatedAt: { sort: "asc", nulls: "last" } },
+  })
+
+  const weekMap = new Map<string, CodeChangesItem>()
+
+  for (const pr of prs) {
+    const date = pr.githubCreatedAt ?? pr.createdAt
+    const weekStart = getWeekStart(date)
+    const key = weekStart.toISOString()
+
+    if (!weekMap.has(key)) {
+      weekMap.set(key, {
+        week: formatWeekLabel(weekStart),
+        additions: 0,
+        deletions: 0,
+        files: 0,
+      })
+    }
+
+    const entry = weekMap.get(key)!
+    entry.additions += pr.additions
+    entry.deletions += pr.deletions
+    entry.files += pr.changedFiles
+  }
+
+  return Array.from(weekMap.values())
+}


### PR DESCRIPTION
## 작업 유형
- [x] feat

## 개요
`/api/stats` 엔드포인트와 `lib/stats.ts` 데이터 레이어를 구현하여 실제 DB 기반 통계 데이터를 제공합니다.

## 변경 사항
- `lib/stats.ts` 신규
  - 타입 정의 5종 (`StatsOverview`, `PRTrendItem`, `QualityTrendItem`, `IssueDistribution`, `CodeChangesItem`)
  - Prisma 직접 조회 함수 5종 (서버 컴포넌트 / API 양쪽에서 재사용 가능)
    - `fetchStatsOverview` — 총 PR 수, 머지율, 평균 품질 점수, 이슈 수, 댓글 해결률
    - `fetchPRTrend` — 주별 PR 활동 추이 (status별 groupBy)
    - `fetchQualityTrend` — 날짜별 평균 품질 점수 (완료된 리뷰만)
    - `fetchIssueDistribution` — 심각도별 + `aiSuggestions` JSON 파싱으로 카테고리별 집계
    - `fetchCodeChanges` — 주별 코드 변경량 (additions / deletions / changedFiles)
- `app/api/stats/route.ts` 신규
  - `GET /api/stats?type=...&range=...&repoId=...`
  - `type`: overview | pr-trend | quality-trend | issue-distribution | code-changes
  - `range`: 7d | 30d | 90d | all (기본값 30d)
  - `repoId`: 특정 레포 필터링 (없으면 전체 합산)
  - 미인증 요청 401, 잘못된 파라미터 400 처리

## 테스트
- [ ] `type` 파라미터별 올바른 데이터 구조 반환 확인
- [ ] `range` / `repoId` 필터링 동작 확인
- [ ] 데이터 없을 때 빈 배열/0 반환 (에러 아님) 확인
- [ ] 미인증 요청 401 반환 확인

## 참고 사항
- 프론트엔드 이슈 #67에서 이 API를 사용할 예정
- 카테고리별 집계는 `aiSuggestions` JSON 필드를 JS 레벨에서 파싱하여 집계
- `lib/stats.ts` 함수들은 서버 컴포넌트(`page.tsx`)에서 Prisma 직접 호출로도 사용 가능

Closes #66