### PR TITLE
feat: 통계 페이지 및 레포지토리 동기화 기능

### DIFF
--- a/app/(protected)/stats/page.tsx
+++ b/app/(protected)/stats/page.tsx
@@ -1,0 +1,20 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+import { fetchStatsOverview } from "@/lib/stats"
+import StatsClient from "@/components/stats/StatsClient"
+
+export default async function StatsPage() {
+  const session = await auth()
+  if (!session?.user?.id) return null
+
+  const [overview, repos] = await Promise.all([
+    fetchStatsOverview(session.user.id, "30d"),
+    prisma.repository.findMany({
+      where: { userId: session.user.id },
+      select: { id: true, name: true, fullName: true },
+      orderBy: { name: "asc" },
+    }),
+  ])
+
+  return <StatsClient initialOverview={overview} repos={repos} />
+}

--- a/app/api/repositories/[id]/sync/route.ts
+++ b/app/api/repositories/[id]/sync/route.ts
@@ -1,0 +1,88 @@
+import { auth } from "@/lib/auth"
+import { getOctokit } from "@/lib/github"
+import { prisma } from "@/lib/prisma"
+import { NextResponse } from "next/server"
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { id } = await params
+
+    const repository = await prisma.repository.findUnique({
+      where: { id },
+      select: { id: true, userId: true, fullName: true },
+    })
+
+    if (!repository) {
+      return NextResponse.json(
+        { error: "Repository를 찾을 수 없습니다" },
+        { status: 404 }
+      )
+    }
+
+    if (repository.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: "해당 Repository에 대한 권한이 없습니다" },
+        { status: 403 }
+      )
+    }
+
+    // additions=0 AND deletions=0 AND changedFiles=0 인 PR만 보정 대상
+    const unsynced = await prisma.pullRequest.findMany({
+      where: {
+        repoId: id,
+        additions: 0,
+        deletions: 0,
+        changedFiles: 0,
+      },
+      select: { id: true, number: true },
+    })
+
+    if (unsynced.length === 0) {
+      return NextResponse.json({ updated: 0, total: 0 })
+    }
+
+    const [owner, repo] = repository.fullName.split("/")
+    const octokit = await getOctokit(session.user.id)
+
+    let updated = 0
+
+    for (const pr of unsynced) {
+      try {
+        const { data } = await octokit.pulls.get({
+          owner,
+          repo,
+          pull_number: pr.number,
+        })
+
+        // GitHub API가 반환하는 값이 실제로도 0인 PR은 건너뜀 (진짜 변경 없는 PR)
+        if (data.additions === 0 && data.deletions === 0 && data.changed_files === 0) {
+          continue
+        }
+
+        await prisma.pullRequest.update({
+          where: { id: pr.id },
+          data: {
+            additions: data.additions,
+            deletions: data.deletions,
+            changedFiles: data.changed_files,
+          },
+        })
+        updated++
+      } catch {
+        // 개별 PR 보정 실패는 건너뛰고 계속 진행
+      }
+    }
+
+    return NextResponse.json({ updated, total: unsynced.length })
+  } catch {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/components/github/RepoCard.tsx
+++ b/components/github/RepoCard.tsx
@@ -1,6 +1,10 @@
-import { FolderGit2, Github, Check, Trash2, Plus } from "lucide-react"
+"use client"
+
+import { useState } from "react"
+import { FolderGit2, Github, Check, Trash2, Plus, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { useSyncRepository } from "@/hooks/useSyncRepository"
 
 const LANGUAGE_COLORS: Record<string, string> = {
   TypeScript: "bg-blue-500",
@@ -29,9 +33,12 @@ export default function RepoCard({
   fullName,
   language,
   isConnected,
+  repositoryId,
   onConnect,
   onDisconnect,
 }: RepoCardProps) {
+  const [syncMessage, setSyncMessage] = useState<string | null>(null)
+  const { mutate: sync, isPending: isSyncing } = useSyncRepository()
   const dotColor = language ? (LANGUAGE_COLORS[language] ?? "bg-slate-400") : null
 
   return (
@@ -72,6 +79,37 @@ export default function RepoCard({
                 <Check size={12} aria-hidden />
                 연동됨
               </Badge>
+              {syncMessage && (
+                <span className="text-xs font-medium text-slate-500">
+                  {syncMessage}
+                </span>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={isSyncing || !repositoryId}
+                onClick={() => {
+                  if (!repositoryId) return
+                  sync(repositoryId, {
+                    onSuccess: ({ updated, total }) => {
+                      setSyncMessage(
+                        total === 0
+                          ? "보정할 PR 없음"
+                          : `${updated}/${total}건 보정 완료`
+                      )
+                      setTimeout(() => setSyncMessage(null), 3000)
+                    },
+                    onError: () => {
+                      setSyncMessage("동기화 실패")
+                      setTimeout(() => setSyncMessage(null), 3000)
+                    },
+                  })
+                }}
+                title="코드 변경량 동기화"
+                className="p-2.5 text-slate-400 hover:text-blue-500 hover:bg-blue-50 rounded-xl border border-transparent hover:border-blue-100 h-auto w-auto disabled:opacity-40"
+              >
+                <RefreshCw size={18} className={isSyncing ? "animate-spin" : ""} aria-hidden />
+              </Button>
               <Button
                 variant="ghost"
                 size="icon"

--- a/components/stats/StatsClient.tsx
+++ b/components/stats/StatsClient.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type {
+  StatsRange,
+  StatsOverview,
+  PRTrendItem,
+  QualityTrendItem,
+  IssueDistribution,
+  CodeChangesItem,
+} from "@/lib/stats"
+import StatsHeader from "./StatsHeader"
+import StatsSummaryCards from "./StatsSummaryCards"
+import PRTrendChart from "./charts/PRTrendChart"
+import PRStatusChart from "./charts/PRStatusChart"
+import QualityTrendChart from "./charts/QualityTrendChart"
+import IssueSeverityChart from "./charts/IssueSeverityChart"
+import CodeChangesChart from "./charts/CodeChangesChart"
+import IssueCategoryChart from "./charts/IssueCategoryChart"
+
+interface Repo {
+  id: string
+  name: string
+  fullName: string
+}
+
+interface StatsClientProps {
+  initialOverview: StatsOverview
+  repos: Repo[]
+}
+
+export default function StatsClient({
+  initialOverview,
+  repos,
+}: StatsClientProps) {
+  const [range, setRange] = useState<StatsRange>("30d")
+  const [repoId, setRepoId] = useState("")
+  const [overview, setOverview] = useState(initialOverview)
+  const [prTrend, setPRTrend] = useState<PRTrendItem[]>([])
+  const [qualityTrend, setQualityTrend] = useState<QualityTrendItem[]>([])
+  const [issueDistribution, setIssueDistribution] =
+    useState<IssueDistribution>({ bySeverity: [], byCategory: [] })
+  const [codeChanges, setCodeChanges] = useState<CodeChangesItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchAllData = useCallback(async () => {
+    setLoading(true)
+    const params = new URLSearchParams({ range })
+    if (repoId) params.set("repoId", repoId)
+
+    try {
+      const [overviewRes, prTrendRes, qualityRes, issueRes, codeRes] =
+        await Promise.all([
+          fetch(`/api/stats?type=overview&${params}`).then((r) => r.json()),
+          fetch(`/api/stats?type=pr-trend&${params}`).then((r) => r.json()),
+          fetch(`/api/stats?type=quality-trend&${params}`).then((r) =>
+            r.json()
+          ),
+          fetch(`/api/stats?type=issue-distribution&${params}`).then((r) =>
+            r.json()
+          ),
+          fetch(`/api/stats?type=code-changes&${params}`).then((r) =>
+            r.json()
+          ),
+        ])
+
+      setOverview(overviewRes)
+      setPRTrend(prTrendRes.data ?? [])
+      setQualityTrend(qualityRes.data ?? [])
+      setIssueDistribution(issueRes)
+      setCodeChanges(codeRes.data ?? [])
+    } catch (err) {
+      console.error("Failed to fetch stats:", err)
+    } finally {
+      setLoading(false)
+    }
+  }, [range, repoId])
+
+  useEffect(() => {
+    fetchAllData()
+  }, [fetchAllData])
+
+  return (
+    <div className="max-w-350 mx-auto space-y-4 sm:space-y-6">
+      <StatsHeader
+        range={range}
+        onRangeChange={setRange}
+        repoId={repoId}
+        onRepoIdChange={setRepoId}
+        repos={repos}
+      />
+
+      <div className={loading ? "opacity-60 transition-opacity" : "transition-opacity"}>
+        <StatsSummaryCards overview={overview} />
+      </div>
+
+      {/* PR 활동 추이 + PR 상태 분포 */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 sm:gap-6">
+        <PRTrendChart data={prTrend} loading={loading} />
+        <PRStatusChart data={prTrend} loading={loading} />
+      </div>
+
+      {/* 코드 품질 추이 + 이슈 심각도 분포 */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 sm:gap-6">
+        <QualityTrendChart data={qualityTrend} loading={loading} />
+        <IssueSeverityChart
+          data={issueDistribution.bySeverity}
+          loading={loading}
+        />
+      </div>
+
+      {/* 코드 변경량 추이 */}
+      <CodeChangesChart data={codeChanges} loading={loading} />
+
+      {/* 이슈 카테고리 분포 */}
+      <IssueCategoryChart
+        data={issueDistribution.byCategory}
+        loading={loading}
+      />
+    </div>
+  )
+}

--- a/components/stats/StatsHeader.tsx
+++ b/components/stats/StatsHeader.tsx
@@ -1,0 +1,67 @@
+import { textStyles } from "@/lib/styles"
+import type { StatsRange } from "@/lib/stats"
+
+const RANGE_OPTIONS: { label: string; value: StatsRange }[] = [
+  { label: "7일", value: "7d" },
+  { label: "30일", value: "30d" },
+  { label: "90일", value: "90d" },
+  { label: "전체", value: "all" },
+]
+
+interface StatsHeaderProps {
+  range: StatsRange
+  onRangeChange: (range: StatsRange) => void
+  repoId: string
+  onRepoIdChange: (repoId: string) => void
+  repos: { id: string; name: string; fullName: string }[]
+}
+
+export default function StatsHeader({
+  range,
+  onRangeChange,
+  repoId,
+  onRepoIdChange,
+  repos,
+}: StatsHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className={textStyles.pageTitle}>통계</h1>
+        <p className={textStyles.pageSubtitle}>
+          프로젝트의 코드 품질과 활동을 한눈에 확인하세요
+        </p>
+      </div>
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+        <div className="flex items-center gap-1 bg-white border border-slate-200 rounded-full p-1 shadow-sm">
+          {RANGE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => onRangeChange(opt.value)}
+              className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+                range === opt.value
+                  ? "bg-blue-500 text-white shadow-sm"
+                  : "text-slate-600 hover:bg-slate-100"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        {repos.length > 0 && (
+          <select
+            value={repoId}
+            onChange={(e) => onRepoIdChange(e.target.value)}
+            className="h-9 px-3 py-1 text-sm bg-slate-50 border border-slate-200 rounded-lg text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-300 cursor-pointer"
+          >
+            <option value="">전체 저장소</option>
+            {repos.map((repo) => (
+              <option key={repo.id} value={repo.id}>
+                {repo.fullName}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/stats/StatsSummaryCards.tsx
+++ b/components/stats/StatsSummaryCards.tsx
@@ -1,0 +1,94 @@
+import {
+  GitPullRequest,
+  Star,
+  AlertTriangle,
+  GitMerge,
+  MessageSquare,
+  TrendingUp,
+} from "lucide-react"
+import type { StatsOverview } from "@/lib/stats"
+
+interface StatsSummaryCardsProps {
+  overview: StatsOverview
+}
+
+export default function StatsSummaryCards({
+  overview,
+}: StatsSummaryCardsProps) {
+  const commentResRate =
+    overview.totalComments > 0
+      ? Math.round(
+          (overview.resolvedComments / overview.totalComments) * 1000
+        ) / 10
+      : 0
+
+  const cards = [
+    {
+      icon: GitPullRequest,
+      value: `${overview.totalPRs}`,
+      label: "총 PR 수",
+      badge: (
+        <span className="text-purple-600 text-xs font-semibold">
+          MERGED {overview.mergedPRs}건
+        </span>
+      ),
+    },
+    {
+      icon: Star,
+      value: `${overview.avgQualityScore}점`,
+      label: "평균 품질 점수",
+      badge: (
+        <span className="text-blue-600 text-xs font-semibold flex items-center gap-1">
+          <TrendingUp className="w-3 h-3" /> 품질 지표
+        </span>
+      ),
+    },
+    {
+      icon: AlertTriangle,
+      value: `${overview.totalIssues}`,
+      label: "총 이슈 수",
+      badge: (
+        <span className="text-amber-600 text-xs font-semibold">
+          발견된 이슈
+        </span>
+      ),
+    },
+    {
+      icon: GitMerge,
+      value: `${overview.mergeRate}%`,
+      label: "머지율",
+      badge: (
+        <span className="text-emerald-600 text-xs font-semibold flex items-center gap-1">
+          <MessageSquare className="w-3 h-3" />
+          댓글 해결률 {commentResRate}%
+        </span>
+      ),
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+      {cards.map((card, i) => (
+        <div
+          key={i}
+          className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-8 hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+        >
+          <div className="flex items-start justify-between mb-4 sm:mb-6">
+            <div className="w-10 h-10 sm:w-12 sm:h-12 bg-linear-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center shadow-lg shadow-blue-500/30">
+              <card.icon className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <div className="text-slate-900 text-3xl sm:text-4xl md:text-5xl font-bold leading-none">
+              {card.value}
+            </div>
+            <div className="text-slate-500 text-sm font-medium">
+              {card.label}
+            </div>
+            <div className="mt-3">{card.badge}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/stats/charts/CodeChangesChart.tsx
+++ b/components/stats/charts/CodeChangesChart.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts"
+import { textStyles } from "@/lib/styles"
+import { Skeleton } from "@/components/ui/skeleton"
+import { BarChart3 } from "lucide-react"
+import type { CodeChangesItem } from "@/lib/stats"
+
+interface CodeChangesChartProps {
+  data: CodeChangesItem[]
+  loading: boolean
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload?: any[]
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+
+  const item = payload[0]?.payload as CodeChangesItem | undefined
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3">
+      <div className="text-slate-900 font-bold text-sm mb-2">{label}</div>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-xs">
+          <div className="w-2.5 h-2.5 rounded-full bg-blue-400" />
+          <span className="text-slate-600">추가:</span>
+          <span className="font-semibold text-emerald-600">
+            +{item?.additions?.toLocaleString() ?? 0}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <div className="w-2.5 h-2.5 rounded-full bg-red-400" />
+          <span className="text-slate-600">삭제:</span>
+          <span className="font-semibold text-rose-600">
+            -{item?.deletions?.toLocaleString() ?? 0}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-slate-600">변경 파일:</span>
+          <span className="font-semibold text-slate-900">
+            {item?.files ?? 0}개
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function CodeChangesChart({
+  data,
+  loading,
+}: CodeChangesChartProps) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
+        코드 변경량 추이
+      </h3>
+      {loading ? (
+        <div className="w-full h-70 sm:h-85">
+          <Skeleton className="w-full h-full rounded-lg" />
+        </div>
+      ) : data.length === 0 ? (
+        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
+          <BarChart3 className="w-10 h-10 mb-3 text-slate-300" />
+          <p className="text-sm font-medium">데이터가 없습니다</p>
+        </div>
+      ) : (
+        <div className="w-full h-70 sm:h-85">
+          <ResponsiveContainer width="100%" height="100%" minHeight={200}>
+            <BarChart
+              data={data}
+              margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
+            >
+              <XAxis
+                dataKey="week"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                dy={10}
+              />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={false} />
+              <Legend
+                verticalAlign="top"
+                align="right"
+                iconType="circle"
+                iconSize={8}
+                wrapperStyle={{ fontSize: 12, paddingBottom: 12 }}
+              />
+              <Bar
+                dataKey="additions"
+                name="추가"
+                fill="#60a5fa"
+                radius={[4, 4, 0, 0]}
+                maxBarSize={40}
+              />
+              <Bar
+                dataKey="deletions"
+                name="삭제"
+                fill="#f87171"
+                radius={[4, 4, 0, 0]}
+                maxBarSize={40}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/stats/charts/IssueCategoryChart.tsx
+++ b/components/stats/charts/IssueCategoryChart.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts"
+import { textStyles } from "@/lib/styles"
+import { Skeleton } from "@/components/ui/skeleton"
+import { BarChart3 } from "lucide-react"
+import type { IssueCategoryItem } from "@/lib/stats"
+
+const CATEGORY_COLORS: Record<string, string> = {
+  BUG: "#ef4444",
+  SECURITY: "#7c3aed",
+  PERFORMANCE: "#f59e0b",
+  QUALITY: "#3b82f6",
+  BEST_PRACTICE: "#22c55e",
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  BUG: "Bug",
+  SECURITY: "Security",
+  PERFORMANCE: "Performance",
+  QUALITY: "Quality",
+  BEST_PRACTICE: "Best Practice",
+}
+
+interface IssueCategoryChartProps {
+  data: IssueCategoryItem[]
+  loading: boolean
+}
+
+export default function IssueCategoryChart({
+  data,
+  loading,
+}: IssueCategoryChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: CATEGORY_LABELS[item.name] ?? item.name,
+    color: CATEGORY_COLORS[item.name] ?? "#94a3b8",
+  }))
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
+        이슈 카테고리 분포
+      </h3>
+      {loading ? (
+        <div className="w-full h-70 sm:h-85">
+          <Skeleton className="w-full h-full rounded-lg" />
+        </div>
+      ) : chartData.length === 0 ? (
+        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
+          <BarChart3 className="w-10 h-10 mb-3 text-slate-300" />
+          <p className="text-sm font-medium">데이터가 없습니다</p>
+        </div>
+      ) : (
+        <div className="w-full h-70 sm:h-85">
+          <ResponsiveContainer width="100%" height="100%" minHeight={200}>
+            <BarChart
+              data={chartData}
+              layout="vertical"
+              margin={{ top: 5, right: 30, left: 20, bottom: 0 }}
+            >
+              <XAxis
+                type="number"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                allowDecimals={false}
+              />
+              <YAxis
+                type="category"
+                dataKey="label"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 13, fill: "#475569", fontWeight: 600 }}
+                width={100}
+              />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null
+                  const item = payload[0].payload
+                  return (
+                    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3">
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: item.color }}
+                        />
+                        <span className="text-sm font-semibold text-slate-900">
+                          {item.label}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {item.count}건
+                      </p>
+                    </div>
+                  )
+                }}
+                cursor={false}
+              />
+              <Bar dataKey="count" radius={[0, 6, 6, 0]} maxBarSize={32}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/stats/charts/IssueSeverityChart.tsx
+++ b/components/stats/charts/IssueSeverityChart.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts"
+import { textStyles } from "@/lib/styles"
+import { Skeleton } from "@/components/ui/skeleton"
+import { CircleDot } from "lucide-react"
+import type { IssueSeverityItem } from "@/lib/stats"
+
+interface IssueSeverityChartProps {
+  data: IssueSeverityItem[]
+  loading: boolean
+}
+
+export default function IssueSeverityChart({
+  data,
+  loading,
+}: IssueSeverityChartProps) {
+  const total = data.reduce((s, d) => s + d.value, 0)
+
+  return (
+    <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
+        이슈 심각도 분포
+      </h3>
+      {loading ? (
+        <div className="flex flex-col items-center gap-6">
+          <Skeleton className="w-48 h-48 rounded-full" />
+          <div className="space-y-3 w-full">
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="h-4 w-full rounded" />
+            ))}
+          </div>
+        </div>
+      ) : data.length === 0 ? (
+        <div className="h-70 flex flex-col items-center justify-center text-slate-400">
+          <CircleDot className="w-10 h-10 mb-3 text-slate-300" />
+          <p className="text-sm font-medium">데이터가 없습니다</p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-6">
+          <div className="relative w-55 h-55 sm:w-65 sm:h-65">
+            <ResponsiveContainer
+              width="100%"
+              height="100%"
+              minHeight={200}
+              minWidth={200}
+            >
+              <PieChart>
+                <Pie
+                  data={data}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="60%"
+                  outerRadius="85%"
+                  dataKey="value"
+                  startAngle={90}
+                  endAngle={-270}
+                  strokeWidth={0}
+                >
+                  {data.map((entry) => (
+                    <Cell key={entry.name} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null
+                    const { name, value, color } = payload[0].payload
+                    return (
+                      <div className="rounded-lg border bg-white px-3 py-2 shadow-md">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="h-3 w-3 rounded-full"
+                            style={{ backgroundColor: color }}
+                          />
+                          <span className="text-sm font-semibold text-slate-700">
+                            {name}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-sm text-slate-600">
+                          {value}건 (
+                          {Math.round((value / total) * 100)}%)
+                        </p>
+                      </div>
+                    )
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <span className="text-slate-900 text-3xl sm:text-4xl font-bold">
+                {total}건
+              </span>
+              <span className="text-slate-400 text-xs sm:text-sm">
+                전체 이슈
+              </span>
+            </div>
+          </div>
+          <div className="space-y-3 sm:space-y-4 w-full">
+            {data.map((item) => (
+              <div
+                key={item.name}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center gap-2 sm:gap-3">
+                  <div
+                    className="w-3 h-3 sm:w-4 sm:h-4 rounded-full shadow-sm"
+                    style={{ backgroundColor: item.color }}
+                  />
+                  <span className="text-xs sm:text-sm font-semibold text-slate-700">
+                    {item.name}
+                  </span>
+                </div>
+                <span className="text-xs sm:text-sm font-bold text-slate-900">
+                  {item.value}건
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/stats/charts/PRStatusChart.tsx
+++ b/components/stats/charts/PRStatusChart.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts"
+import { textStyles } from "@/lib/styles"
+import { Skeleton } from "@/components/ui/skeleton"
+import { CircleDot } from "lucide-react"
+import type { PRTrendItem } from "@/lib/stats"
+
+const STATUS_COLORS: Record<string, string> = {
+  Open: "#22c55e",
+  Merged: "#a855f7",
+  Closed: "#f43f5e",
+  Draft: "#94a3b8",
+}
+
+interface PRStatusChartProps {
+  data: PRTrendItem[]
+  loading: boolean
+}
+
+export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
+  const statusData = [
+    { name: "Open", value: data.reduce((s, w) => s + w.open, 0) },
+    { name: "Merged", value: data.reduce((s, w) => s + w.merged, 0) },
+    { name: "Closed", value: data.reduce((s, w) => s + w.closed, 0) },
+    { name: "Draft", value: data.reduce((s, w) => s + w.draft, 0) },
+  ].filter((d) => d.value > 0)
+
+  const total = statusData.reduce((s, d) => s + d.value, 0)
+
+  return (
+    <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
+        PR 상태 분포
+      </h3>
+      {loading ? (
+        <div className="flex flex-col items-center gap-6">
+          <Skeleton className="w-48 h-48 rounded-full" />
+          <div className="space-y-3 w-full">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-4 w-full rounded" />
+            ))}
+          </div>
+        </div>
+      ) : statusData.length === 0 ? (
+        <div className="h-70 flex flex-col items-center justify-center text-slate-400">
+          <CircleDot className="w-10 h-10 mb-3 text-slate-300" />
+          <p className="text-sm font-medium">데이터가 없습니다</p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-6">
+          <div className="relative w-55 h-55 sm:w-65 sm:h-65">
+            <ResponsiveContainer
+              width="100%"
+              height="100%"
+              minHeight={200}
+              minWidth={200}
+            >
+              <PieChart>
+                <Pie
+                  data={statusData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="60%"
+                  outerRadius="85%"
+                  dataKey="value"
+                  startAngle={90}
+                  endAngle={-270}
+                  strokeWidth={0}
+                >
+                  {statusData.map((entry) => (
+                    <Cell
+                      key={entry.name}
+                      fill={STATUS_COLORS[entry.name]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null
+                    const { name, value } = payload[0].payload
+                    return (
+                      <div className="rounded-lg border bg-white px-3 py-2 shadow-md">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="h-3 w-3 rounded-full"
+                            style={{
+                              backgroundColor: STATUS_COLORS[name],
+                            }}
+                          />
+                          <span className="text-sm font-semibold text-slate-700">
+                            {name}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-sm text-slate-600">
+                          {value}건 ({Math.round((value / total) * 100)}
+                          %)
+                        </p>
+                      </div>
+                    )
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <span className="text-slate-900 text-3xl sm:text-4xl font-bold">
+                {total}건
+              </span>
+              <span className="text-slate-400 text-xs sm:text-sm">
+                전체 PR
+              </span>
+            </div>
+          </div>
+          <div className="space-y-3 sm:space-y-4 w-full">
+            {statusData.map((item) => (
+              <div
+                key={item.name}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center gap-2 sm:gap-3">
+                  <div
+                    className="w-3 h-3 sm:w-4 sm:h-4 rounded-full shadow-sm"
+                    style={{ backgroundColor: STATUS_COLORS[item.name] }}
+                  />
+                  <span className="text-xs sm:text-sm font-semibold text-slate-700">
+                    {item.name}
+                  </span>
+                </div>
+                <span className="text-xs sm:text-sm font-bold text-slate-900">
+                  {item.value}건
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/stats/charts/PRTrendChart.tsx
+++ b/components/stats/charts/PRTrendChart.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { textStyles } from "@/lib/styles"
+import { Skeleton } from "@/components/ui/skeleton"
+import { BarChart3 } from "lucide-react"
+import type { PRTrendItem } from "@/lib/stats"
+
+interface PRTrendChartProps {
+  data: PRTrendItem[]
+  loading: boolean
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean
+  payload?: { name: string; value: number; color: string }[]
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3">
+      <div className="text-slate-900 font-bold text-sm mb-2">{label}</div>
+      {payload.map((entry) => (
+        <div key={entry.name} className="flex items-center gap-2 text-xs">
+          <div
+            className="w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="text-slate-600">{entry.name}:</span>
+          <span className="font-semibold text-slate-900">
+            {entry.value}건
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function PRTrendChart({ data, loading }: PRTrendChartProps) {
+  return (
+    <div className="lg:col-span-3 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
+        PR 활동 추이
+      </h3>
+      {loading ? (
+        <div className="w-full h-70 sm:h-85">
+          <Skeleton className="w-full h-full rounded-lg" />
+        </div>
+      ) : data.length === 0 ? (
+        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
+          <BarChart3 className="w-10 h-10 mb-3 text-slate-300" />
+          <p className="text-sm font-medium">데이터가 없습니다</p>
+        </div>
+      ) : (
+        <div className="w-full h-70 sm:h-85">
+          <ResponsiveContainer width="100%" height="100%" minHeight={200}>
+            <AreaChart
+              data={data}
+              margin={{ top: 5, right: 5, left: -20, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient
+                  id="openGradient"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                  <stop
+                    offset="100%"
+                    stopColor="#3b82f6"
+                    stopOpacity={0.05}
+                  />
+                </linearGradient>
+                <linearGradient
+                  id="mergedGradient"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="0%" stopColor="#22c55e" stopOpacity={0.3} />
+                  <stop
+                    offset="100%"
+                    stopColor="#22c55e"
+                    stopOpacity={0.05}
+                  />
+                </linearGradient>
+                <linearGradient
+                  id="closedGradient"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="0%" stopColor="#94a3b8" stopOpacity={0.3} />
+                  <stop
+                    offset="100%"
+                    stopColor="#94a3b8"
+                    stopOpacity={0.05}
+                  />
+                </linearGradient>
+              </defs>
+              <XAxis
+                dataKey="week"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                dy={10}
+              />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                allowDecimals={false}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={false} />
+              <Area
+                type="monotone"
+                dataKey="open"
+                name="Open"
+                stroke="#3b82f6"
+                strokeWidth={2}
+                fill="url(#openGradient)"
+                stackId="1"
+              />
+              <Area
+                type="monotone"
+                dataKey="merged"
+                name="Merged"
+                stroke="#22c55e"
+                strokeWidth={2}
+                fill="url(#mergedGradient)"
+                stackId="1"
+              />
+              <Area
+                type="monotone"
+                dataKey="closed"
+                name="Closed"
+                stroke="#94a3b8"
+                strokeWidth={2}
+                fill="url(#closedGradient)"
+                stackId="1"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/stats/charts/QualityTrendChart.tsx
+++ b/components/stats/charts/QualityTrendChart.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { textStyles } from "@/lib/styles"
+import { Skeleton } from "@/components/ui/skeleton"
+import { TrendingUp } from "lucide-react"
+import type { QualityTrendItem } from "@/lib/stats"
+
+interface QualityTrendChartProps {
+  data: QualityTrendItem[]
+  loading: boolean
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean
+  payload?: { value: number }[]
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3 text-center">
+      <div className="text-slate-900 font-bold text-sm">
+        점수: {payload[0].value}점
+      </div>
+      <div className="text-blue-500 text-xs mt-1">{label}</div>
+    </div>
+  )
+}
+
+export default function QualityTrendChart({
+  data,
+  loading,
+}: QualityTrendChartProps) {
+  return (
+    <div className="lg:col-span-3 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
+        코드 품질 추이
+      </h3>
+      {loading ? (
+        <div className="w-full h-70 sm:h-85">
+          <Skeleton className="w-full h-full rounded-lg" />
+        </div>
+      ) : data.length === 0 ? (
+        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
+          <TrendingUp className="w-10 h-10 mb-3 text-slate-300" />
+          <p className="text-sm font-medium">데이터가 없습니다</p>
+        </div>
+      ) : (
+        <div className="w-full h-70 sm:h-85">
+          <ResponsiveContainer width="100%" height="100%" minHeight={200}>
+            <AreaChart
+              data={data}
+              margin={{ top: 5, right: 5, left: -20, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient
+                  id="qualityGradient"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="0%" stopColor="#60a5fa" stopOpacity={0.3} />
+                  <stop
+                    offset="100%"
+                    stopColor="#60a5fa"
+                    stopOpacity={0.05}
+                  />
+                </linearGradient>
+              </defs>
+              <XAxis
+                dataKey="date"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                dy={10}
+              />
+              <YAxis
+                domain={[0, 100]}
+                ticks={[0, 25, 50, 75, 100]}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={false} />
+              <Area
+                type="monotone"
+                dataKey="avgScore"
+                stroke="#4d9be8"
+                strokeWidth={2.5}
+                fill="url(#qualityGradient)"
+                dot={{
+                  r: 3,
+                  fill: "#4d9be8",
+                  stroke: "#fff",
+                  strokeWidth: 2,
+                }}
+                activeDot={{
+                  r: 6,
+                  fill: "#fff",
+                  stroke: "#4d9be8",
+                  strokeWidth: 2.5,
+                }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/hooks/useSyncRepository.ts
+++ b/hooks/useSyncRepository.ts
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query"
+
+interface SyncResult {
+  updated: number
+  total: number
+}
+
+async function syncRepository(repositoryId: string): Promise<SyncResult> {
+  const res = await fetch(`/api/repositories/${repositoryId}/sync`, {
+    method: "POST",
+  })
+  if (!res.ok) {
+    const data = await res.json()
+    throw new Error(data.error ?? "동기화에 실패했습니다.")
+  }
+  return res.json()
+}
+
+export function useSyncRepository() {
+  return useMutation({
+    mutationFn: syncRepository,
+  })
+}


### PR DESCRIPTION
## 📊 통계 페이지 UI 구현

**요약:**
- `/stats` 페이지: 요약 카드(PR수/품질점수/이슈수/머지율), 6개 차트(PR 추이, 품질 추이, 이슈 심각도/카테고리, 코드 변경량)
- 기간 필터(7일/30일/90일/전체), 레포지토리 필터
- 서버사이드 초기 데이터 프리페치로 기본 요약 카드 표시
- Recharts 기반 상호작용 차트

## 🔄 레포지토리 동기화 API

**문제상황:**
- 저장소 연동 시 GitHub List API가 과거 PR들의 additions/deletions/changedFiles을 제공하지 않음
- 과거 데이터가 0으로 저장되어 통계 부정확

**해결방안:**
- `POST /api/repositories/[id]/sync` 엔드포인트: 변경량이 0인 PR을 찾아 GitHub Pull Detail API로 실제 값 조회 및 보정
- `useSyncRepository` 훅: React Query 기반 뮤테이션
- RepoCard에 동기화 버튼: 회전 애니메이션, 결과 메시지 3초 표시

## ✅ 테스트 사항

- [ ] `/stats` 페이지 접근 가능 및 차트 렌더링
- [ ] 기간/레포 필터 동작
- [ ] 동기화 버튼 클릭 시 로딩 상태 및 결과 메시지 표시
- [ ] 실제 PR 데이터 보정 확인

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>