### PR TITLE
feat: 대시보드 페이지 실제 데이터 연동 (#70)

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,13 +1,30 @@
+import { auth } from "@/lib/auth"
+import {
+  fetchDashboardStats,
+  fetchDashboardQualityTrend,
+  fetchDashboardIssueSeverity,
+  fetchDashboardRecentPRs,
+} from "@/lib/dashboard"
 import StatCards from "@/components/dashboard/stat-cards/StatCards"
 import ChartsSection from "@/components/dashboard/charts/ChartsSection"
 import RecentPRSection from "@/components/dashboard/recent-prs/RecentPRSection"
 
-export default function Page() {
+export default async function Page() {
+  const session = await auth()
+  if (!session?.user?.id) return null
+
+  const [stats, qualityTrend, issueSeverity, recentPRs] = await Promise.all([
+    fetchDashboardStats(session.user.id),
+    fetchDashboardQualityTrend(session.user.id),
+    fetchDashboardIssueSeverity(session.user.id),
+    fetchDashboardRecentPRs(session.user.id),
+  ])
+
   return (
     <div className="max-w-350 mx-auto space-y-4 sm:space-y-6">
-      <StatCards />
-      <ChartsSection />
-      <RecentPRSection />
+      <StatCards stats={stats} />
+      <ChartsSection qualityTrend={qualityTrend} issueSeverity={issueSeverity} />
+      <RecentPRSection prs={recentPRs} />
     </div>
   )
 }

--- a/components/dashboard/charts/ChartsSection.tsx
+++ b/components/dashboard/charts/ChartsSection.tsx
@@ -1,11 +1,17 @@
+import { type QualityTrendItem, type IssueSeverityItem } from "@/lib/dashboard"
 import CodeQualityChartCard from "./CodeQualityChartCard"
 import IssueDistributionCard from "./IssueDistributionCard"
 
-export default function ChartsSection() {
+interface ChartsSectionProps {
+  qualityTrend: QualityTrendItem[]
+  issueSeverity: IssueSeverityItem[]
+}
+
+export default function ChartsSection({ qualityTrend, issueSeverity }: ChartsSectionProps) {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 sm:gap-6">
-      <CodeQualityChartCard />
-      <IssueDistributionCard />
+      <CodeQualityChartCard qualityTrend={qualityTrend} />
+      <IssueDistributionCard issueSeverity={issueSeverity} />
     </div>
   )
 }

--- a/components/dashboard/charts/CodeQualityChart.tsx
+++ b/components/dashboard/charts/CodeQualityChart.tsx
@@ -8,22 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts"
-
-const data = [
-  { day: "1일", score: 72 },
-  { day: "3일", score: 75 },
-  { day: "5일", score: 78 },
-  { day: "7일", score: 76 },
-  { day: "9일", score: 80 },
-  { day: "11일", score: 78 },
-  { day: "13일", score: 83 },
-  { day: "15일", score: 82 },
-  { day: "17일", score: 85 },
-  { day: "19일", score: 87 },
-  { day: "23일", score: 89 },
-  { day: "27일", score: 91 },
-  { day: "30일", score: 88 },
-]
+import { type QualityTrendItem } from "@/lib/dashboard"
 
 function CustomTooltip({
   active,
@@ -44,7 +29,7 @@ function CustomTooltip({
   )
 }
 
-export default function CodeQualityChart() {
+export default function CodeQualityChart({ data }: { data: QualityTrendItem[] }) {
   return (
     <ResponsiveContainer width="100%" height="100%" minHeight={200} minWidth={200}>
       <AreaChart data={data} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
@@ -55,7 +40,7 @@ export default function CodeQualityChart() {
           </linearGradient>
         </defs>
         <XAxis
-          dataKey="day"
+          dataKey="date"
           axisLine={false}
           tickLine={false}
           tick={{ fontSize: 12, fill: "#94a3b8" }}
@@ -71,7 +56,7 @@ export default function CodeQualityChart() {
         <Tooltip content={<CustomTooltip />} cursor={false} />
         <Area
           type="monotone"
-          dataKey="score"
+          dataKey="avgScore"
           stroke="#4d9be8"
           strokeWidth={2.5}
           fill="url(#scoreGradient)"

--- a/components/dashboard/charts/CodeQualityChartCard.tsx
+++ b/components/dashboard/charts/CodeQualityChartCard.tsx
@@ -1,14 +1,19 @@
+import { type QualityTrendItem } from "@/lib/dashboard"
 import CodeQualityChart from "./CodeQualityChart"
 import { textStyles } from "@/lib/styles"
 
-export default function CodeQualityChartCard() {
+export default function CodeQualityChartCard({
+  qualityTrend,
+}: {
+  qualityTrend: QualityTrendItem[]
+}) {
   return (
     <div className="lg:col-span-3 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         코드 품질 추이 (최근 30일)
       </h3>
       <div className="w-full h-70 sm:h-85">
-        <CodeQualityChart />
+        <CodeQualityChart data={qualityTrend} />
       </div>
     </div>
   )

--- a/components/dashboard/charts/IssueDistributionCard.tsx
+++ b/components/dashboard/charts/IssueDistributionCard.tsx
@@ -1,11 +1,16 @@
+import { type IssueSeverityItem } from "@/lib/dashboard"
 import IssueDistributionChart from "./IssueDistributionChart"
 import { textStyles } from "@/lib/styles"
 
-export default function IssueDistributionCard() {
+export default function IssueDistributionCard({
+  issueSeverity,
+}: {
+  issueSeverity: IssueSeverityItem[]
+}) {
   return (
     <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>이슈 분포</h3>
-      <IssueDistributionChart />
+      <IssueDistributionChart data={issueSeverity} />
     </div>
   )
 }

--- a/components/dashboard/charts/IssueDistributionChart.tsx
+++ b/components/dashboard/charts/IssueDistributionChart.tsx
@@ -1,16 +1,15 @@
 "use client"
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts"
+import { type IssueSeverityItem } from "@/lib/dashboard"
 
-const data = [
-  { name: "HIGH", value: 15, color: "#ef4444" },
-  { name: "MEDIUM", value: 35, color: "#f59e0b" },
-  { name: "LOW", value: 50, color: "#3b82f6" },
-]
+export default function IssueDistributionChart({
+  data,
+}: {
+  data: IssueSeverityItem[]
+}) {
+  const total = data.reduce((sum, d) => sum + d.value, 0)
 
-const total = data.reduce((sum, d) => sum + d.value, 0)
-
-export default function IssueDistributionChart() {
   return (
     <div className="flex flex-col items-center gap-6">
       <div className="relative w-55 h-55 sm:w-65 sm:h-65">
@@ -35,13 +34,14 @@ export default function IssueDistributionChart() {
               content={({ active, payload }) => {
                 if (!active || !payload?.length) return null
                 const { name, value, color } = payload[0].payload
+                const pct = total > 0 ? Math.round((value / total) * 100) : 0
                 return (
                   <div className="rounded-lg border bg-white px-3 py-2 shadow-md">
                     <div className="flex items-center gap-2">
                       <div className="h-3 w-3 rounded-full" style={{ backgroundColor: color }} />
                       <span className="text-sm font-semibold text-slate-700">{name}</span>
                     </div>
-                    <p className="mt-1 text-sm text-slate-600">{value}% ({Math.round(total * value / 100)}건)</p>
+                    <p className="mt-1 text-sm text-slate-600">{pct}% ({value}건)</p>
                   </div>
                 )
               }}
@@ -54,15 +54,23 @@ export default function IssueDistributionChart() {
         </div>
       </div>
       <div className="mt-6 sm:mt-8 space-y-3 sm:space-y-4 w-full">
-        {data.map((item) => (
-          <div key={item.name} className="flex items-center justify-between">
-            <div className="flex items-center gap-2 sm:gap-3">
-              <div className="w-3 h-3 sm:w-4 sm:h-4 rounded-full shadow-sm" style={{ backgroundColor: item.color }} />
-              <span className="text-xs sm:text-sm font-semibold text-slate-700">{item.name}</span>
+        {data.map((item) => {
+          const pct = total > 0 ? Math.round((item.value / total) * 100) : 0
+          return (
+            <div key={item.name} className="flex items-center justify-between">
+              <div className="flex items-center gap-2 sm:gap-3">
+                <div
+                  className="w-3 h-3 sm:w-4 sm:h-4 rounded-full shadow-sm"
+                  style={{ backgroundColor: item.color }}
+                />
+                <span className="text-xs sm:text-sm font-semibold text-slate-700">
+                  {item.name}
+                </span>
+              </div>
+              <span className="text-xs sm:text-sm font-bold text-slate-900">{pct}%</span>
             </div>
-            <span className="text-xs sm:text-sm font-bold text-slate-900">{item.value}%</span>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/components/dashboard/recent-prs/RecentPRSection.tsx
+++ b/components/dashboard/recent-prs/RecentPRSection.tsx
@@ -1,15 +1,14 @@
+import { type DashboardRecentPR } from "@/lib/dashboard"
 import RecentPRTable from "./RecentPRTable"
 import { textStyles } from "@/lib/styles"
 
-export default function RecentPRSection() {
+export default function RecentPRSection({ prs }: { prs: DashboardRecentPR[] }) {
   return (
     <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
       <div className="p-4 sm:p-6 md:p-8 border-b border-slate-200">
-        <h3 className={textStyles.sectionTitle}>
-          최근 Pull Requests
-        </h3>
+        <h3 className={textStyles.sectionTitle}>최근 Pull Requests</h3>
       </div>
-      <RecentPRTable />
+      <RecentPRTable prs={prs} />
     </div>
   )
 }

--- a/components/dashboard/recent-prs/RecentPRTable.tsx
+++ b/components/dashboard/recent-prs/RecentPRTable.tsx
@@ -1,6 +1,6 @@
-import { ArrowUp, ArrowDown, Minus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { textStyles } from "@/lib/styles"
+import { type DashboardRecentPR } from "@/lib/dashboard"
 import {
   Table,
   TableBody,
@@ -10,39 +10,29 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
-type PRStatus = "오픈" | "병합됨" | "닫힘"
-type ScoreTrend = "up" | "down" | "neutral"
-
-interface PRItem {
-  number: number
-  title: string
-  author: string
-  score: number
-  trend: ScoreTrend
-  status: PRStatus
+const STATUS_LABEL: Record<DashboardRecentPR["status"], string> = {
+  OPEN: "오픈",
+  MERGED: "병합됨",
+  CLOSED: "닫힘",
+  DRAFT: "드래프트",
 }
 
-const prData: PRItem[] = [
-  { number: 42, title: "feat: Add AI review", author: "김개발", score: 87, trend: "up", status: "오픈" },
-  { number: 41, title: "fix: 메모리 누수 해결", author: "이코드", score: 92, trend: "up", status: "병합됨" },
-  { number: 40, title: "refactor: API 리팩토링", author: "박리뷰", score: 78, trend: "down", status: "오픈" },
-  { number: 39, title: "docs: README 업데이트", author: "최문서", score: 85, trend: "neutral", status: "병합됨" },
-  { number: 38, title: "test: 단위 테스트 추가", author: "정테스트", score: 90, trend: "up", status: "닫힘" },
-]
-
-const statusStyles: Record<PRStatus, string> = {
-  "오픈": "bg-blue-100 text-blue-700",
-  "병합됨": "bg-green-100 text-green-700",
-  "닫힘": "bg-slate-100 text-slate-600",
+const STATUS_STYLE: Record<DashboardRecentPR["status"], string> = {
+  OPEN: "bg-blue-100 text-blue-700",
+  MERGED: "bg-green-100 text-green-700",
+  CLOSED: "bg-slate-100 text-slate-600",
+  DRAFT: "bg-slate-100 text-slate-500",
 }
 
-function TrendIcon({ trend }: { trend: ScoreTrend }) {
-  if (trend === "up") return <ArrowUp className="w-3 h-3 sm:w-4 sm:h-4 text-green-600" />
-  if (trend === "down") return <ArrowDown className="w-3 h-3 sm:w-4 sm:h-4 text-red-600" />
-  return <Minus className="w-3 h-3 sm:w-4 sm:h-4 text-slate-400" />
-}
+export default function RecentPRTable({ prs }: { prs: DashboardRecentPR[] }) {
+  if (prs.length === 0) {
+    return (
+      <div className="px-4 sm:px-8 py-12 text-center text-slate-400 text-sm">
+        연결된 레포지토리에 Pull Request가 없습니다.
+      </div>
+    )
+  }
 
-export default function RecentPRTable() {
   return (
     <Table>
       <TableHeader>
@@ -54,7 +44,7 @@ export default function RecentPRTable() {
             제목
           </TableHead>
           <TableHead className={cn(textStyles.tableHeader, "px-4 sm:px-6 md:px-8 py-3 sm:py-4 hidden md:table-cell")}>
-            작성자
+            레포지토리
           </TableHead>
           <TableHead className={cn(textStyles.tableHeader, "px-4 sm:px-6 md:px-8 py-3 sm:py-4")}>
             점수
@@ -65,9 +55,9 @@ export default function RecentPRTable() {
         </TableRow>
       </TableHeader>
       <TableBody className="divide-y divide-slate-100">
-        {prData.map((pr, index) => (
+        {prs.map((pr, index) => (
           <TableRow
-            key={pr.number}
+            key={pr.id}
             className={`hover:bg-slate-50 transition-colors cursor-pointer ${
               index % 2 === 1 ? "bg-slate-50/30" : "bg-white"
             }`}
@@ -79,22 +69,29 @@ export default function RecentPRTable() {
             </TableCell>
             <TableCell className="px-4 sm:px-6 md:px-8 py-4 sm:py-5 whitespace-normal">
               <div className="flex flex-col gap-1">
-                <span className="text-xs sm:text-sm text-slate-900 font-semibold">{pr.title}</span>
-                <span className="text-xs text-slate-500 md:hidden">{pr.author}</span>
+                <span className="text-xs sm:text-sm text-slate-900 font-semibold">
+                  {pr.title}
+                </span>
+                <span className="text-xs text-slate-500 md:hidden">{pr.repoName}</span>
               </div>
             </TableCell>
             <TableCell className="px-4 sm:px-6 md:px-8 py-4 sm:py-5 hidden md:table-cell">
-              <span className="text-sm text-slate-600 font-medium">{pr.author}</span>
+              <span className="text-sm text-slate-600 font-medium">{pr.repoName}</span>
             </TableCell>
             <TableCell className="px-4 sm:px-6 md:px-8 py-4 sm:py-5">
-              <div className="flex items-center gap-1 sm:gap-2">
-                <span className="text-xs sm:text-sm font-bold text-slate-900">{pr.score}점</span>
-                <TrendIcon trend={pr.trend} />
-              </div>
+              {pr.score !== null ? (
+                <span className="text-xs sm:text-sm font-bold text-slate-900">
+                  {pr.score}점
+                </span>
+              ) : (
+                <span className="text-xs sm:text-sm text-slate-400">-</span>
+              )}
             </TableCell>
             <TableCell className="px-4 sm:px-6 md:px-8 py-4 sm:py-5 hidden sm:table-cell">
-              <span className={`inline-flex items-center px-2 sm:px-3 py-1 sm:py-1.5 rounded-full text-xs font-semibold ${statusStyles[pr.status]}`}>
-                {pr.status}
+              <span
+                className={`inline-flex items-center px-2 sm:px-3 py-1 sm:py-1.5 rounded-full text-xs font-semibold ${STATUS_STYLE[pr.status]}`}
+              >
+                {STATUS_LABEL[pr.status]}
               </span>
             </TableCell>
           </TableRow>

--- a/components/dashboard/stat-cards/CodeQualityCard.tsx
+++ b/components/dashboard/stat-cards/CodeQualityCard.tsx
@@ -1,14 +1,32 @@
 import { Star } from "lucide-react"
 import StatCard from "./StatCard"
 
-export default function CodeQualityCard() {
+interface CodeQualityCardProps {
+  score: number
+  trend: number
+}
+
+export default function CodeQualityCard({ score, trend }: CodeQualityCardProps) {
+  const trendText =
+    trend > 0 ? `+${trend}% ↗` : trend < 0 ? `${trend}% ↘` : "변동 없음"
+  const trendColor =
+    trend > 0
+      ? "text-green-600"
+      : trend < 0
+        ? "text-red-600"
+        : "text-slate-500"
+
   return (
     <StatCard
       icon={Star}
-      value="87점"
+      value={`${score}점`}
       label="평균 코드 품질"
       badge={
-        <span className="text-green-600 text-xs font-semibold flex items-center gap-1">+5% ↗</span>
+        <span
+          className={`text-xs font-semibold flex items-center gap-1 ${trendColor}`}
+        >
+          {trendText}
+        </span>
       }
     />
   )

--- a/components/dashboard/stat-cards/OpenPRCard.tsx
+++ b/components/dashboard/stat-cards/OpenPRCard.tsx
@@ -1,14 +1,21 @@
 import { GitPullRequest } from "lucide-react"
 import StatCard from "./StatCard"
 
-export default function OpenPRCard() {
+interface OpenPRCardProps {
+  openPRs: number
+  pendingReviewPRs: number
+}
+
+export default function OpenPRCard({ openPRs, pendingReviewPRs }: OpenPRCardProps) {
   return (
     <StatCard
       icon={GitPullRequest}
-      value="12개"
+      value={`${openPRs}개`}
       label="오픈 PR"
       badge={
-        <span className="text-orange-600 text-xs font-semibold">5개 리뷰 대기중</span>
+        <span className="text-orange-600 text-xs font-semibold">
+          {pendingReviewPRs}개 리뷰 대기중
+        </span>
       }
     />
   )

--- a/components/dashboard/stat-cards/StatCards.tsx
+++ b/components/dashboard/stat-cards/StatCards.tsx
@@ -1,13 +1,23 @@
+import { type DashboardStats } from "@/lib/dashboard"
 import CodeQualityCard from "./CodeQualityCard"
 import OpenPRCard from "./OpenPRCard"
 import WeeklyReviewCard from "./WeeklyReviewCard"
 
-export default function StatCards() {
+export default function StatCards({ stats }: { stats: DashboardStats }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      <CodeQualityCard />
-      <OpenPRCard />
-      <WeeklyReviewCard />
+      <CodeQualityCard
+        score={stats.avgQualityScore}
+        trend={stats.qualityScoreTrend}
+      />
+      <OpenPRCard
+        openPRs={stats.openPRs}
+        pendingReviewPRs={stats.pendingReviewPRs}
+      />
+      <WeeklyReviewCard
+        weeklyReviews={stats.weeklyReviews}
+        diff={stats.weeklyReviewsDiff}
+      />
     </div>
   )
 }

--- a/components/dashboard/stat-cards/WeeklyReviewCard.tsx
+++ b/components/dashboard/stat-cards/WeeklyReviewCard.tsx
@@ -1,14 +1,26 @@
 import { Bot } from "lucide-react"
 import StatCard from "./StatCard"
 
-export default function WeeklyReviewCard() {
+interface WeeklyReviewCardProps {
+  weeklyReviews: number
+  diff: number
+}
+
+export default function WeeklyReviewCard({ weeklyReviews, diff }: WeeklyReviewCardProps) {
+  const diffText =
+    diff > 0 ? `+${diff} vs 지난주` : diff < 0 ? `${diff} vs 지난주` : "지난주와 동일"
+  const diffColor =
+    diff > 0 ? "text-green-600" : diff < 0 ? "text-red-600" : "text-slate-500"
+
   return (
     <StatCard
       icon={Bot}
-      value="23건"
+      value={`${weeklyReviews}건`}
       label="이번주 리뷰"
       badge={
-        <span className="text-green-600 text-xs font-semibold flex items-center gap-1">+8 vs 지난주</span>
+        <span className={`text-xs font-semibold flex items-center gap-1 ${diffColor}`}>
+          {diffText}
+        </span>
       }
     />
   )

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,172 @@
+import { prisma } from "@/lib/prisma"
+import {
+  fetchQualityTrend,
+  fetchIssueDistribution,
+  type QualityTrendItem,
+  type IssueSeverityItem,
+} from "@/lib/stats"
+
+export type { QualityTrendItem, IssueSeverityItem }
+
+export interface DashboardStats {
+  avgQualityScore: number
+  qualityScoreTrend: number // 이전 30일 대비 변화율 (%)
+  openPRs: number
+  pendingReviewPRs: number // 리뷰 없는 OPEN PR 수
+  weeklyReviews: number
+  weeklyReviewsDiff: number // 지난주 대비 차이
+}
+
+export interface DashboardRecentPR {
+  id: string
+  number: number
+  title: string
+  repoName: string
+  score: number | null
+  status: "OPEN" | "MERGED" | "CLOSED" | "DRAFT"
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  d.setDate(diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+export async function fetchDashboardStats(
+  userId: string
+): Promise<DashboardStats> {
+  const now = new Date()
+
+  const thirtyDaysAgo = new Date(now)
+  thirtyDaysAgo.setDate(now.getDate() - 30)
+  thirtyDaysAgo.setHours(0, 0, 0, 0)
+
+  const sixtyDaysAgo = new Date(now)
+  sixtyDaysAgo.setDate(now.getDate() - 60)
+  sixtyDaysAgo.setHours(0, 0, 0, 0)
+
+  const thisWeekStart = getWeekStart(now)
+  const lastWeekStart = new Date(thisWeekStart)
+  lastWeekStart.setDate(thisWeekStart.getDate() - 7)
+
+  const repoFilter = { repo: { userId } }
+
+  const [
+    currentQuality,
+    prevQuality,
+    openPRs,
+    pendingReviewPRs,
+    weeklyReviews,
+    prevWeekReviews,
+  ] = await Promise.all([
+    prisma.review.aggregate({
+      where: {
+        pullRequest: repoFilter,
+        status: "COMPLETED",
+        reviewedAt: { gte: thirtyDaysAgo },
+      },
+      _avg: { qualityScore: true },
+    }),
+    prisma.review.aggregate({
+      where: {
+        pullRequest: repoFilter,
+        status: "COMPLETED",
+        reviewedAt: { gte: sixtyDaysAgo, lt: thirtyDaysAgo },
+      },
+      _avg: { qualityScore: true },
+    }),
+    prisma.pullRequest.count({
+      where: { ...repoFilter, status: "OPEN" },
+    }),
+    prisma.pullRequest.count({
+      where: {
+        ...repoFilter,
+        status: "OPEN",
+        reviews: { none: { status: "COMPLETED" } },
+      },
+    }),
+    prisma.review.count({
+      where: {
+        pullRequest: repoFilter,
+        status: "COMPLETED",
+        reviewedAt: { gte: thisWeekStart },
+      },
+    }),
+    prisma.review.count({
+      where: {
+        pullRequest: repoFilter,
+        status: "COMPLETED",
+        reviewedAt: { gte: lastWeekStart, lt: thisWeekStart },
+      },
+    }),
+  ])
+
+  const currentScore =
+    Math.round((currentQuality._avg.qualityScore ?? 0) * 10) / 10
+  const prevScore = prevQuality._avg.qualityScore
+
+  const qualityScoreTrend =
+    prevScore && prevScore > 0
+      ? Math.round(((currentScore - prevScore) / prevScore) * 1000) / 10
+      : 0
+
+  return {
+    avgQualityScore: currentScore,
+    qualityScoreTrend,
+    openPRs,
+    pendingReviewPRs,
+    weeklyReviews,
+    weeklyReviewsDiff: weeklyReviews - prevWeekReviews,
+  }
+}
+
+export async function fetchDashboardQualityTrend(
+  userId: string
+): Promise<QualityTrendItem[]> {
+  return fetchQualityTrend(userId, "30d")
+}
+
+export async function fetchDashboardIssueSeverity(
+  userId: string
+): Promise<IssueSeverityItem[]> {
+  const dist = await fetchIssueDistribution(userId, "30d")
+  return dist.bySeverity
+}
+
+export async function fetchDashboardRecentPRs(
+  userId: string
+): Promise<DashboardRecentPR[]> {
+  const prs = await prisma.pullRequest.findMany({
+    where: { repo: { userId } },
+    select: {
+      id: true,
+      number: true,
+      title: true,
+      status: true,
+      repo: { select: { name: true } },
+      reviews: {
+        where: { status: "COMPLETED" },
+        select: { qualityScore: true },
+        orderBy: { reviewedAt: "desc" },
+        take: 1,
+      },
+    },
+    orderBy: [
+      { githubCreatedAt: { sort: "desc", nulls: "last" } },
+      { createdAt: "desc" },
+    ],
+    take: 5,
+  })
+
+  return prs.map((pr) => ({
+    id: pr.id,
+    number: pr.number,
+    title: pr.title,
+    repoName: pr.repo.name,
+    score: pr.reviews[0]?.qualityScore ?? null,
+    status: pr.status as DashboardRecentPR["status"],
+  }))
+}


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)

## 관련 마일스톤

- [x] Week 9-10: 대시보드 & 배포

## 개요

대시보드 페이지의 하드코딩된 샘플 데이터를 실제 DB 데이터로 교체합니다. `page.tsx`를 async 서버 컴포넌트로 변환하여 Prisma 쿼리를 서버사이드에서 병렬 프리페칭합니다.

## 변경 사항

- `lib/dashboard.ts` 신규 생성: 대시보드용 데이터 페칭 함수 4개 및 타입 정의
  - `fetchDashboardStats`: 평균 품질 점수(전월 대비 변화율), 오픈 PR 수, 리뷰 대기 PR 수, 이번주 리뷰 수
  - `fetchDashboardQualityTrend`: 최근 30일 품질 추이 (`fetchQualityTrend` 재사용)
  - `fetchDashboardIssueSeverity`: 최근 30일 이슈 분포 (`fetchIssueDistribution` 재사용)
  - `fetchDashboardRecentPRs`: 최근 PR 5건 (레포명, 품질 점수 포함)
- `app/(protected)/dashboard/page.tsx`: async 서버 컴포넌트로 변환, `Promise.all`로 4개 쿼리 병렬 실행
- StatCards 하위 컴포넌트 (`CodeQualityCard`, `OpenPRCard`, `WeeklyReviewCard`): 실제 데이터 props 수신
- ChartsSection 하위 컴포넌트 (`CodeQualityChart`, `IssueDistributionChart`): 실제 데이터 props 수신, IssueDistributionChart는 count → % 내부 계산으로 변경
- `RecentPRTable`: 하드코딩 제거, 실제 PR 데이터 렌더링 및 빈 상태 처리 추가, 작성자 → 레포지토리명으로 변경 (스키마에 PR author 필드 없음)

## 테스트

- [x] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인

## 참고 사항

- 서버사이드 프리페칭으로 클라이언트 로딩 상태 없이 데이터 즉시 렌더링
- 내부 Prisma 직접 쿼리(HTTP API 없음)이므로 네트워크 왕복 없이 빠른 응답
- 총 ~10개 DB 쿼리가 `Promise.all`로 최대한 병렬 실행됨