### PR TITLE
feat: Socket.io 인증을 토큰 방식으로 변경

### DIFF
--- a/app/api/socket/token/route.ts
+++ b/app/api/socket/token/route.ts
@@ -1,0 +1,29 @@
+import { createHmac } from "crypto"
+import { auth } from "@/lib/auth"
+import { NextResponse } from "next/server"
+
+const TOKEN_TTL_SEC = 60
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json(null, { status: 401 })
+  }
+
+  const secret = process.env.SOCKET_INTERNAL_SECRET
+  if (!secret) {
+    return NextResponse.json(null, { status: 500 })
+  }
+
+  const payload = Buffer.from(
+    JSON.stringify({
+      userId: session.user.id,
+      userName: session.user.name ?? "Unknown",
+      exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SEC,
+    })
+  ).toString("base64url")
+
+  const signature = createHmac("sha256", secret).update(payload).digest("hex")
+
+  return NextResponse.json({ token: `${payload}.${signature}` })
+}

--- a/hooks/useSocket.ts
+++ b/hooks/useSocket.ts
@@ -7,6 +7,7 @@ import type { TypedClientSocket } from "@/lib/socket/types"
 // ── 외부 스토어 (모든 컴포넌트가 동일한 스냅샷을 구독) ────────────
 let socket: TypedClientSocket | null = null
 let connected = false
+let connecting = false
 const listeners = new Set<() => void>()
 
 function notify() {
@@ -36,34 +37,51 @@ function getServerConnectedSnapshot(): false {
   return false as const
 }
 
-function connect() {
-  if (socket) return
+async function connect() {
+  if (socket || connecting) return
   if (process.env.NEXT_PUBLIC_REALTIME_MODE !== "socket") return
 
-  socket = io(process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:4000", {
-    path: "/socket.io",
-    reconnection: true,
-    reconnectionDelay: 1000,
-    reconnectionDelayMax: 5000,
-    reconnectionAttempts: 10,
-  })
+  connecting = true
 
-  socket.on("connect", () => {
-    connected = true
+  try {
+    const res = await fetch("/api/socket/token")
+    if (!res.ok) {
+      connecting = false
+      return
+    }
+    const { token } = await res.json()
+
+    socket = io(process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:4000", {
+      path: "/socket.io",
+      transports: ["websocket"],
+      auth: { token },
+      reconnection: true,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
+      reconnectionAttempts: 10,
+    })
+
+    socket.on("connect", () => {
+      connected = true
+      notify()
+    })
+
+    socket.on("disconnect", () => {
+      connected = false
+      notify()
+    })
+
     notify()
-  })
-
-  socket.on("disconnect", () => {
-    connected = false
-    notify()
-  })
-
-  notify()
+  } catch {
+    connecting = false
+  }
 }
 
 // ── Hook ────────────────────────────────────────────────
 export function useSocket() {
-  useEffect(connect, [])
+  useEffect(() => {
+    connect()
+  }, [])
 
   const s = useSyncExternalStore(
     subscribe,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:socket": "cd socket-server && npm install && tsx index.ts",
+    "dev:socket": "cd socket-server && npm install && tsx --env-file=../.env index.ts",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",

--- a/socket-server/auth.ts
+++ b/socket-server/auth.ts
@@ -1,29 +1,44 @@
+import { createHmac } from "crypto"
 import type { TypedServerSocket, SocketData } from "./types"
 
-export async function authenticateSocket(
+export function authenticateSocket(
   socket: TypedServerSocket
-): Promise<Pick<SocketData, "userId" | "userName"> | null> {
-  const cookieHeader = socket.handshake.headers.cookie
-  if (!cookieHeader) return null
+): Pick<SocketData, "userId" | "userName"> | null {
+  const token = socket.handshake.auth?.token as string | undefined
+  if (!token) {
+    console.error("[Socket Auth] No token provided")
+    return null
+  }
 
-  const nextjsUrl = process.env.NEXTJS_URL
-  if (!nextjsUrl) {
-    console.error("[Socket Auth] NEXTJS_URL is not set")
+  const secret = process.env.SOCKET_INTERNAL_SECRET
+  if (!secret) {
+    console.error("[Socket Auth] SOCKET_INTERNAL_SECRET is not set")
+    return null
+  }
+
+  const [payload, signature] = token.split(".")
+  if (!payload || !signature) {
+    console.error("[Socket Auth] Malformed token")
+    return null
+  }
+
+  const expected = createHmac("sha256", secret).update(payload).digest("hex")
+  if (expected !== signature) {
+    console.error("[Socket Auth] Invalid signature")
     return null
   }
 
   try {
-    const res = await fetch(`${nextjsUrl}/api/socket/auth`, {
-      headers: {
-        cookie: cookieHeader,
-        "x-socket-secret": process.env.SOCKET_INTERNAL_SECRET ?? "",
-      },
-    })
+    const data = JSON.parse(Buffer.from(payload, "base64url").toString())
 
-    if (!res.ok) return null
-    return res.json() as Promise<Pick<SocketData, "userId" | "userName">>
-  } catch (err) {
-    console.error("[Socket Auth] Failed to verify session:", err)
+    if (data.exp < Math.floor(Date.now() / 1000)) {
+      console.error("[Socket Auth] Token expired")
+      return null
+    }
+
+    return { userId: data.userId, userName: data.userName }
+  } catch {
+    console.error("[Socket Auth] Failed to parse token payload")
     return null
   }
 }

--- a/socket-server/handlers.ts
+++ b/socket-server/handlers.ts
@@ -32,8 +32,8 @@ function registerTypingHandlers(socket: TypedServerSocket) {
 }
 
 export function setupSocketHandlers(io: TypedServer) {
-  io.on("connection", async (socket) => {
-    const userData = await authenticateSocket(socket)
+  io.on("connection", (socket) => {
+    const userData = authenticateSocket(socket)
 
     if (!userData) {
       socket.disconnect(true)


### PR DESCRIPTION
## Summary
크로스 도메인 쿠키 문제를 해결하기 위해 Socket.io 인증 방식을 쿠키 기반에서 토큰 기반으로 변경했습니다.

## Changes
- **신규**: `/api/socket/token` 엔드포인트 (세션 기반 HMAC 토큰 발급)
- **수정**: `socket-server/auth.ts` (쿠키 검증 → 토큰 HMAC 검증)
- **수정**: `hooks/useSocket.ts` (연결 전 토큰 요청 후 전달)
- **삭제**: `/api/socket/auth` 라우트 (더 이상 불필요)

## Technical Details
- 토큰 형식: `base64url(payload).hex(HMAC-SHA256)`
- 토큰 TTL: 60초 (Socket.io 연결 시간만 필요)
- 로컬/Railway 모두 동일한 `SOCKET_INTERNAL_SECRET`으로 검증

## Test Plan
- [x] 로컬 환경 (localhost:3000 + localhost:4000) 테스트
- [ ] Vercel + Railway 배포 후 테스트 필요
  - Railway 환경변수 확인: `SOCKET_INTERNAL_SECRET` (Vercel과 동일값)
  - `NEXTJS_URL` 끝 슬래시 제거

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)