### PR TITLE
feat: 설정 페이지 구현 (#80)

### DIFF
--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,0 +1,35 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+import { redirect } from "next/navigation"
+import SettingsClient from "@/components/settings/SettingsClient"
+
+export default async function SettingsPage() {
+  const session = await auth()
+  if (!session?.user?.id) redirect("/login")
+
+  const [user, account] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { name: true, email: true, image: true, githubId: true },
+    }),
+    prisma.account.findFirst({
+      where: { userId: session.user.id, provider: "github" },
+      select: { scope: true, providerAccountId: true },
+    }),
+  ])
+
+  if (!user) redirect("/login")
+
+  return (
+    <SettingsClient
+      user={{
+        name: user.name,
+        email: user.email,
+        image: user.image,
+        githubId: user.githubId !== null ? Number(user.githubId) : null,
+      }}
+      githubConnected={account !== null}
+      githubScope={account?.scope ?? null}
+    />
+  )
+}

--- a/app/api/settings/account/route.ts
+++ b/app/api/settings/account/route.ts
@@ -1,0 +1,16 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function DELETE() {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  await prisma.user.delete({
+    where: { id: session.user.id },
+  })
+
+  return Response.json({ ok: true })
+}

--- a/app/api/settings/ai-review/route.ts
+++ b/app/api/settings/ai-review/route.ts
@@ -1,0 +1,51 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+const DEFAULT_SETTINGS = {
+  autoReview: true,
+  language: "ko",
+  severityLevel: "normal",
+}
+
+export async function GET() {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const setting = await prisma.reviewSetting.findUnique({
+    where: { userId: session.user.id },
+  })
+
+  return Response.json({ settings: setting ?? DEFAULT_SETTINGS })
+}
+
+export async function PUT(request: Request) {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { autoReview, language, severityLevel } = body as {
+    autoReview?: boolean
+    language?: string
+    severityLevel?: string
+  }
+
+  const data = {
+    autoReview: autoReview ?? true,
+    language: language ?? "ko",
+    severityLevel: severityLevel ?? "normal",
+  }
+
+  const setting = await prisma.reviewSetting.upsert({
+    where: { userId: session.user.id },
+    create: { userId: session.user.id, ...data },
+    update: data,
+  })
+
+  return Response.json({ settings: setting })
+}

--- a/app/api/settings/disconnect-github/route.ts
+++ b/app/api/settings/disconnect-github/route.ts
@@ -1,0 +1,24 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function DELETE() {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const userId = session.user.id
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: userId },
+      data: { githubToken: null, githubId: null },
+    }),
+    prisma.account.deleteMany({
+      where: { userId, provider: "github" },
+    }),
+  ])
+
+  return Response.json({ ok: true })
+}

--- a/components/settings/AIReviewSection.tsx
+++ b/components/settings/AIReviewSection.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+
+interface ReviewSettings {
+  autoReview: boolean
+  language: string
+  severityLevel: string
+}
+
+const DEFAULT: ReviewSettings = {
+  autoReview: true,
+  language: "ko",
+  severityLevel: "normal",
+}
+
+async function fetchSettings(): Promise<ReviewSettings> {
+  const res = await fetch("/api/settings/ai-review")
+  if (!res.ok) return DEFAULT
+  const data = await res.json()
+  return data.settings ?? DEFAULT
+}
+
+async function updateSettings(settings: ReviewSettings): Promise<ReviewSettings> {
+  const res = await fetch("/api/settings/ai-review", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+  })
+  const data = await res.json()
+  return data.settings
+}
+
+export default function AIReviewSection() {
+  const queryClient = useQueryClient()
+
+  const { data: settings = DEFAULT, isLoading } = useQuery({
+    queryKey: ["review-settings"],
+    queryFn: fetchSettings,
+  })
+
+  const { mutate: save } = useMutation({
+    mutationFn: updateSettings,
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({ queryKey: ["review-settings"] })
+      queryClient.setQueryData(["review-settings"], next)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["review-settings"] })
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <section className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-base font-semibold text-slate-800 mb-4">AI 리뷰 설정</h2>
+        <p className="text-sm text-slate-400">설정을 불러오는 중...</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 p-6">
+      <h2 className="text-base font-semibold text-slate-800 mb-4">AI 리뷰 설정</h2>
+      <div className="space-y-5">
+        {/* 자동 리뷰 토글 */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-slate-700">자동 리뷰</p>
+            <p className="text-xs text-slate-400 mt-0.5">PR 생성 시 AI 리뷰를 자동으로 실행합니다.</p>
+          </div>
+          <button
+            onClick={() => save({ ...settings, autoReview: !settings.autoReview })}
+            className={`relative w-10 h-5 rounded-full transition-colors ${
+              settings.autoReview ? "bg-blue-500" : "bg-slate-300"
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                settings.autoReview ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+
+        {/* 리뷰 언어 */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-slate-700">리뷰 언어</p>
+            <p className="text-xs text-slate-400 mt-0.5">AI 리뷰 코멘트를 작성할 언어를 선택합니다.</p>
+          </div>
+          <div className="flex gap-1.5">
+            {(["ko", "en"] as const).map((lang) => (
+              <button
+                key={lang}
+                onClick={() => save({ ...settings, language: lang })}
+                className={`px-3 py-1 text-xs font-medium rounded-lg border transition-colors ${
+                  settings.language === lang
+                    ? "bg-blue-500 text-white border-blue-500"
+                    : "text-slate-600 border-slate-300 hover:bg-slate-50"
+                }`}
+              >
+                {lang === "ko" ? "한국어" : "English"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 심각도 기준 */}
+        <div>
+          <div className="mb-2">
+            <p className="text-sm font-medium text-slate-700">심각도 기준</p>
+            <p className="text-xs text-slate-400 mt-0.5">리뷰에서 강조할 이슈의 민감도를 설정합니다.</p>
+          </div>
+          <div className="flex gap-1.5">
+            {(
+              [
+                { value: "strict", label: "엄격", desc: "LOW 이상 모두 표시" },
+                { value: "normal", label: "보통", desc: "MEDIUM 이상 표시" },
+                { value: "lenient", label: "관대", desc: "HIGH 이상만 표시" },
+              ] as const
+            ).map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => save({ ...settings, severityLevel: opt.value })}
+                className={`flex-1 px-3 py-2 text-xs font-medium rounded-lg border transition-colors text-center ${
+                  settings.severityLevel === opt.value
+                    ? "bg-blue-500 text-white border-blue-500"
+                    : "text-slate-600 border-slate-300 hover:bg-slate-50"
+                }`}
+              >
+                <span className="block">{opt.label}</span>
+                <span className={`block mt-0.5 font-normal ${settings.severityLevel === opt.value ? "text-blue-100" : "text-slate-400"}`}>
+                  {opt.desc}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/settings/DangerZoneSection.tsx
+++ b/components/settings/DangerZoneSection.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { signOut } from "next-auth/react"
+import { AlertTriangle } from "lucide-react"
+
+export default function DangerZoneSection() {
+  const router = useRouter()
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isDisconnecting, setIsDisconnecting] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDisconnectGitHub = async () => {
+    if (!confirm("GitHub 연결을 해제하면 서비스 이용이 불가합니다. 계속하시겠습니까?")) return
+    setIsDisconnecting(true)
+    try {
+      const res = await fetch("/api/settings/disconnect-github", { method: "DELETE" })
+      if (res.ok) {
+        await signOut({ callbackUrl: "/login" })
+      }
+    } finally {
+      setIsDisconnecting(false)
+    }
+  }
+
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true)
+    try {
+      const res = await fetch("/api/settings/account", { method: "DELETE" })
+      if (res.ok) {
+        await signOut({ callbackUrl: "/login" })
+      }
+    } finally {
+      setIsDeleting(false)
+      setShowDeleteConfirm(false)
+    }
+  }
+
+  return (
+    <section className="bg-white rounded-xl border border-red-200 p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <AlertTriangle className="w-4 h-4 text-red-500" />
+        <h2 className="text-base font-semibold text-red-600">위험 구역</h2>
+      </div>
+
+      <div className="space-y-4">
+        {/* GitHub 연결 해제 */}
+        <div className="flex items-center justify-between py-3 border-b border-slate-100">
+          <div>
+            <p className="text-sm font-medium text-slate-800">GitHub 연결 해제</p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              GitHub 연결을 해제하면 즉시 로그아웃됩니다.
+            </p>
+          </div>
+          <button
+            onClick={handleDisconnectGitHub}
+            disabled={isDisconnecting}
+            className="px-3 py-1.5 text-sm font-medium text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+          >
+            {isDisconnecting ? "처리 중..." : "연결 해제"}
+          </button>
+        </div>
+
+        {/* 계정 삭제 */}
+        <div className="flex items-center justify-between py-3">
+          <div>
+            <p className="text-sm font-medium text-slate-800">계정 삭제</p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              계정과 모든 데이터가 영구적으로 삭제됩니다.
+            </p>
+          </div>
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="px-3 py-1.5 text-sm font-medium text-white bg-red-500 rounded-lg hover:bg-red-600 transition-colors flex-shrink-0"
+          >
+            계정 삭제
+          </button>
+        </div>
+      </div>
+
+      {/* 삭제 확인 다이얼로그 */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl shadow-xl max-w-sm w-full p-6">
+            <div className="flex items-center gap-2 mb-3">
+              <AlertTriangle className="w-5 h-5 text-red-500" />
+              <h3 className="text-base font-semibold text-slate-900">계정 삭제</h3>
+            </div>
+            <p className="text-sm text-slate-600 mb-6">
+              계정을 삭제하면 모든 저장소 연결, PR, 댓글, 리뷰 데이터가 영구적으로 삭제됩니다.
+              이 작업은 되돌릴 수 없습니다.
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isDeleting}
+                className="px-4 py-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleDeleteAccount}
+                disabled={isDeleting}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-500 rounded-lg hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isDeleting ? "삭제 중..." : "영구 삭제"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/settings/GitHubConnectionSection.tsx
+++ b/components/settings/GitHubConnectionSection.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Github, RefreshCw } from "lucide-react"
+import { signIn } from "next-auth/react"
+
+interface GitHubConnectionSectionProps {
+  isConnected: boolean
+  githubId: number | null
+  scope: string | null
+}
+
+const SCOPE_LABELS: Record<string, string> = {
+  repo: "저장소 읽기/쓰기",
+  "admin:repo_hook": "웹훅 관리",
+  "read:user": "프로필 읽기",
+  "user:email": "이메일 읽기",
+}
+
+export default function GitHubConnectionSection({ isConnected, githubId, scope }: GitHubConnectionSectionProps) {
+  const scopes = scope ? scope.split(/[,\s]+/).filter(Boolean) : []
+
+  const handleReconnect = () => {
+    signIn("github", { callbackUrl: "/settings" })
+  }
+
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 p-6">
+      <h2 className="text-base font-semibold text-slate-800 mb-4">GitHub 연결</h2>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-slate-900 flex items-center justify-center flex-shrink-0">
+            <Github className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            {isConnected ? (
+              <>
+                <p className="text-sm font-medium text-slate-800">연결됨</p>
+                {githubId && <p className="text-xs text-slate-500">GitHub ID: {githubId}</p>}
+              </>
+            ) : (
+              <p className="text-sm text-slate-500">GitHub 계정이 연결되어 있지 않습니다.</p>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={handleReconnect}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors flex-shrink-0"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          재연결
+        </button>
+      </div>
+
+      {scopes.length > 0 && (
+        <div className="mt-4">
+          <p className="text-xs font-medium text-slate-500 mb-2">부여된 권한</p>
+          <div className="flex flex-wrap gap-1.5">
+            {scopes.map((s) => (
+              <span
+                key={s}
+                className="px-2 py-0.5 bg-slate-100 text-slate-600 text-xs rounded-full"
+              >
+                {SCOPE_LABELS[s] ?? s}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/settings/NotificationSection.tsx
+++ b/components/settings/NotificationSection.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useNotificationSettings } from "@/hooks/useNotificationSettings"
+import type { NotificationSetting } from "@/types/notification"
+
+const settingItems: { key: keyof NotificationSetting; label: string; description: string }[] = [
+  {
+    key: "mentionEnabled",
+    label: "멘션 알림",
+    description: "댓글에서 멘션되었을 때 알림을 받습니다.",
+  },
+  {
+    key: "newReviewEnabled",
+    label: "리뷰 완료 알림",
+    description: "AI 코드 리뷰가 완료되었을 때 알림을 받습니다.",
+  },
+  {
+    key: "prMergedEnabled",
+    label: "PR 병합/닫힘 알림",
+    description: "PR이 병합되거나 닫혔을 때 알림을 받습니다.",
+  },
+  {
+    key: "commentReplyEnabled",
+    label: "댓글 알림",
+    description: "PR에 새 댓글이 달렸을 때 알림을 받습니다.",
+  },
+]
+
+export default function NotificationSection() {
+  const { settings, isLoading, saveSettings } = useNotificationSettings()
+
+  if (isLoading) {
+    return (
+      <section className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-base font-semibold text-slate-800 mb-4">알림 설정</h2>
+        <p className="text-sm text-slate-400">설정을 불러오는 중...</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 p-6">
+      <h2 className="text-base font-semibold text-slate-800 mb-4">알림 설정</h2>
+      <div className="space-y-1">
+        {settingItems.map((item) => (
+          <div
+            key={item.key}
+            className="flex items-center justify-between px-2 py-3 hover:bg-slate-50 rounded-lg transition-colors"
+          >
+            <div>
+              <p className="text-sm font-medium text-slate-700">{item.label}</p>
+              <p className="text-xs text-slate-400 mt-0.5">{item.description}</p>
+            </div>
+            <button
+              onClick={() => saveSettings({ ...settings, [item.key]: !settings[item.key] })}
+              className={`relative w-10 h-5 rounded-full transition-colors flex-shrink-0 ${
+                settings[item.key] ? "bg-blue-500" : "bg-slate-300"
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                  settings[item.key] ? "translate-x-5" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/settings/ProfileSection.tsx
+++ b/components/settings/ProfileSection.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image"
+import { User } from "lucide-react"
+
+interface ProfileSectionProps {
+  name: string | null
+  email: string | null
+  image: string | null
+}
+
+export default function ProfileSection({ name, email, image }: ProfileSectionProps) {
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 p-6">
+      <h2 className="text-base font-semibold text-slate-800 mb-4">프로필</h2>
+      <div className="flex items-center gap-4">
+        {image ? (
+          <Image
+            src={image}
+            alt={name ?? "사용자"}
+            width={64}
+            height={64}
+            className="rounded-full ring-2 ring-slate-100"
+          />
+        ) : (
+          <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center">
+            <User className="w-8 h-8 text-slate-400" />
+          </div>
+        )}
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-slate-800">{name ?? "이름 없음"}</p>
+          <p className="text-sm text-slate-500">{email ?? "이메일 없음"}</p>
+          <p className="text-xs text-slate-400">GitHub에서 가져온 정보입니다. 직접 수정이 불가합니다.</p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/settings/SettingsClient.tsx
+++ b/components/settings/SettingsClient.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { Settings } from "lucide-react"
+import ProfileSection from "@/components/settings/ProfileSection"
+import GitHubConnectionSection from "@/components/settings/GitHubConnectionSection"
+import AIReviewSection from "@/components/settings/AIReviewSection"
+import NotificationSection from "@/components/settings/NotificationSection"
+import DangerZoneSection from "@/components/settings/DangerZoneSection"
+
+interface SettingsClientProps {
+  user: {
+    name: string | null
+    email: string | null
+    image: string | null
+    githubId: number | null
+  }
+  githubConnected: boolean
+  githubScope: string | null
+}
+
+export default function SettingsClient({ user, githubConnected, githubScope }: SettingsClientProps) {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-3 mb-6">
+        <Settings className="w-6 h-6 text-slate-700" />
+        <h1 className="text-xl font-bold text-slate-900">설정</h1>
+      </div>
+
+      <div className="space-y-4">
+        <ProfileSection name={user.name} email={user.email} image={user.image} />
+        <GitHubConnectionSection isConnected={githubConnected} githubId={user.githubId} scope={githubScope} />
+        <AIReviewSection />
+        <NotificationSection />
+        <DangerZoneSection />
+      </div>
+    </div>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   comments      Comment[]
   notifications       Notification[]
   notificationSetting NotificationSetting?
+  reviewSetting       ReviewSetting?
 
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
@@ -246,6 +247,18 @@ model NotificationSetting {
   commentReplyEnabled Boolean @default(true)
 
   updatedAt DateTime @updatedAt
+}
+
+model ReviewSetting {
+  id            String  @id @default(cuid())
+  user          User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId        String  @unique
+
+  autoReview    Boolean @default(true)
+  language      String  @default("ko")      // "ko" | "en"
+  severityLevel String  @default("normal")  // "strict" | "normal" | "lenient"
+
+  updatedAt     DateTime @updatedAt
 }
 
 enum NotificationType {


### PR DESCRIPTION
## 요약
설정 페이지(Settings) 기능 완전 구현. 프로필, GitHub 연결, AI 리뷰 설정, 알림 설정, 계정 관리 섹션 추가.

## 변경 사항
- **DB**: ReviewSetting 모델 추가 (자동 리뷰, 언어, 심각도 기준)
- **API**:
  - `GET/PUT /api/settings/ai-review` - AI 리뷰 설정 조회/저장
  - `DELETE /api/settings/disconnect-github` - GitHub 연결 해제
  - `DELETE /api/settings/account` - 계정 영구 삭제
- **UI**: 6개 섹션 컴포넌트 구현
  - ProfileSection: GitHub에서 가져온 프로필 정보 (읽기전용)
  - GitHubConnectionSection: 연결 상태, 권한 범위, 재연결 버튼
  - AIReviewSection: 자동 리뷰 토글, 언어 선택(한/영), 심각도 선택
  - NotificationSection: 알림 유형별 ON/OFF 토글
  - DangerZoneSection: GitHub 연결 해제, 계정 삭제 (확인 다이얼로그)
  - SettingsClient: 클라이언트 래퍼
- **Page**: 서버 컴포넌트 구현, user + account scope 조회 후 props 전달

## 테스트
- 각 섹션 UI 렌더링 확인
- 토글/버튼 클릭 이벤트 작동 확인
- GitHub 연결 여부 정확한 표시 확인 (Account 레코드 존재 여부 기준)

🤖 Generated with Claude Code