### PR TITLE
fix: AI 리뷰 응답 파싱 실패 수정 (#89)

### DIFF
--- a/lib/ai/analyze.ts
+++ b/lib/ai/analyze.ts
@@ -64,15 +64,21 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
       per_page: 100,
     })
 
-    const diff = files
-      .filter((f) => f.patch)
-      .map((f) => `--- ${f.filename}\n${f.patch}`)
-      .join("\n\n")
+    const MAX_DIFF_CHARS = 20000
+    let diff = ""
+    for (const f of files.filter((f) => f.patch)) {
+      const chunk = `--- ${f.filename}\n${f.patch}\n\n`
+      if (diff.length + chunk.length > MAX_DIFF_CHARS) {
+        diff += "... (diff truncated)"
+        break
+      }
+      diff += chunk
+    }
 
     // Call Claude
     const response = await getAnthropicClient().messages.create({
       model: CLAUDE_MODEL,
-      max_tokens: 4096,
+      max_tokens: 8192,
       system: SYSTEM_PROMPT,
       messages: [
         {

--- a/lib/ai/parsers.ts
+++ b/lib/ai/parsers.ts
@@ -27,13 +27,25 @@ const FALLBACK: AIReviewResponse = {
 }
 
 function extractJson(text: string): string {
-  // 마크다운 코드 블록 안의 JSON 추출 (```json ... ``` 또는 ``` ... ```)
-  const codeBlockMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/)
-  if (codeBlockMatch) return codeBlockMatch[1].trim()
+  const jsonBlockMatch = text.match(/```json\s*([\s\S]*?)```/)
+  if (jsonBlockMatch) return jsonBlockMatch[1].trim()
 
-  // 중괄호로 감싸진 첫 번째 JSON 객체 추출
-  const jsonMatch = text.match(/\{[\s\S]*\}/)
-  if (jsonMatch) return jsonMatch[0]
+  const start = text.indexOf("{")
+  if (start !== -1) {
+    let depth = 0
+    let inString = false
+    let escape = false
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i]
+      if (escape) { escape = false; continue }
+      if (ch === "\\" && inString) { escape = true; continue }
+      if (ch === '"') { inString = !inString; continue }
+      if (inString) continue
+      if (ch === "{") depth++
+      else if (ch === "}") { depth--; if (depth === 0) return text.slice(start, i + 1) }
+    }
+    return text.slice(start)
+  }
 
   return text.trim()
 }


### PR DESCRIPTION
## 작업 유형
- [x] fix

## 개요
AI 코드 리뷰 응답 파싱 시 `Unterminated string in JSON` 에러가 발생하여 리뷰 결과를 가져올 수 없는 문제를 수정합니다.

Closes #89

## 변경 사항

### `lib/ai/analyze.ts`
- `max_tokens` 4096 → **8192** 로 증가 (주원인 해결)
  - 한국어 텍스트 + 다수 이슈의 description/suggestion/exampleCode 필드 조합 시 4096 토큰을 초과해 JSON이 중간에 잘리던 문제
- diff 빌드 방식을 **early-exit 루프**로 변경
  - 기존: 전체 diff 문자열을 먼저 연결한 후 잘라냄 (대용량 PR에서 불필요한 메모리 낭비)
  - 변경: 20,000자 초과 시 즉시 중단

### `lib/ai/parsers.ts`
- `extractJson`을 **중괄호 깊이 추적 방식**으로 교체
  - 기존 regex `` /```(?:json)?\s*([\s\S]*?)```/ `` 는 `exampleCode` 필드 내 백틱이 포함된 코드 예시와 충돌 시 잘못된 위치에서 JSON을 끊는 문제 존재
  - 문자열/이스케이프 상태를 직접 트래킹하여 완전한 JSON 객체 범위를 정확하게 추출
  - 잘린 응답의 경우에도 부분 텍스트를 반환해 기존 FALLBACK 처리 흐름 유지

## 테스트
- [ ] AI 리뷰 요청 후 파싱 성공 확인
- [ ] 대용량 diff (20,000자 초과) PR에서 정상 동작 확인
- [ ] `exampleCode`에 백틱 포함된 응답 파싱 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)