### PR TITLE
perf: PR 상세 API over-fetch 제거 & 레포 동기화 N+1 배치 처리

### DIFF
--- a/app/api/pulls/[id]/route.ts
+++ b/app/api/pulls/[id]/route.ts
@@ -71,7 +71,19 @@ export async function GET(
             owner: { select: { id: true, name: true, image: true } },
           },
         },
-        reviews: true,
+        reviews: {
+          select: {
+            id: true,
+            status: true,
+            qualityScore: true,
+            issueCount: true,
+            severity: true,
+            reviewedAt: true,
+            // aiSuggestions 제외 — /api/pulls/[id]/review 전용 API에서 제공
+          },
+          take: 1,
+          orderBy: { reviewedAt: "desc" },
+        },
       },
     })
 

--- a/app/api/repositories/[id]/sync/route.ts
+++ b/app/api/repositories/[id]/sync/route.ts
@@ -52,7 +52,13 @@ export async function POST(
     const [owner, repo] = repository.fullName.split("/")
     const octokit = await getOctokit(session.user.id)
 
-    let updated = 0
+    // 1단계: GitHub API 결과를 메모리에 수집 (개별 실패는 건너뜀)
+    const results: {
+      id: string
+      additions: number
+      deletions: number
+      changedFiles: number
+    }[] = []
 
     for (const pr of unsynced) {
       try {
@@ -67,21 +73,34 @@ export async function POST(
           continue
         }
 
-        await prisma.pullRequest.update({
-          where: { id: pr.id },
-          data: {
-            additions: data.additions,
-            deletions: data.deletions,
-            changedFiles: data.changed_files,
-          },
+        results.push({
+          id: pr.id,
+          additions: data.additions,
+          deletions: data.deletions,
+          changedFiles: data.changed_files,
         })
-        updated++
       } catch {
         // 개별 PR 보정 실패는 건너뛰고 계속 진행
       }
     }
 
-    return NextResponse.json({ updated, total: unsynced.length })
+    // 2단계: 단일 트랜잭션으로 DB 업데이트 (N회 왕복 → 1회)
+    if (results.length > 0) {
+      await prisma.$transaction(
+        results.map((r) =>
+          prisma.pullRequest.update({
+            where: { id: r.id },
+            data: {
+              additions: r.additions,
+              deletions: r.deletions,
+              changedFiles: r.changedFiles,
+            },
+          })
+        )
+      )
+    }
+
+    return NextResponse.json({ updated: results.length, total: unsynced.length })
   } catch {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [x] Week 9-10: 대시보드 & 배포

## 개요

API 레이어의 DB 쿼리 비효율 2건을 수정한다. 두 문제 모두 동일 레이어(API route + Prisma) 쿼리 최적화이며 UI 변경 없음. closes #105

## 변경 사항

### `app/api/pulls/[id]/route.ts` — `reviews: true` over-fetch 제거

- `reviews: true` → `select` 6개 필드(`id`, `status`, `qualityScore`, `issueCount`, `severity`, `reviewedAt`) + `take: 1` + `orderBy: { reviewedAt: "desc" }`
- `aiSuggestions` 제외 — 수 KB~수십 KB 크기이며 `/api/pulls/[id]/review` 전용 API에서 제공
- 리뷰가 누적될수록 응답 크기가 선형으로 커지는 문제 방지

### `app/api/repositories/[id]/sync/route.ts` — N+1 → `prisma.$transaction()` 배치 처리

- GitHub API 결과를 메모리 배열(`results[]`)에 수집
- 루프 종료 후 `prisma.$transaction()`으로 단일 DB 왕복 처리
- DB 업데이트 레이턴시 O(N) → O(1)
- 개별 GitHub API 실패 건너뛰기 로직 그대로 유지

## 테스트

- [x] 기존 테스트 20개 통과 (`__tests__/api/pulls/`)
- [ ] 로컬 개발 서버에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

## 참고 사항

- 출처: `docs/architecture-review/04-bundle-optimization.md` 문제 2, 3
- `reviews` 응답 shape는 배열 유지 — 기존 타입(`types/pulls.ts`)에 `reviews` 필드 없으므로 프론트엔드 영향 없음