### PR TITLE
feat: PR 상세 페이지 댓글 실시간 반영 UX 개선

### DIFF
--- a/app/(protected)/pulls/[id]/page.tsx
+++ b/app/(protected)/pulls/[id]/page.tsx
@@ -21,12 +21,16 @@ export default async function PRDetailPage({ params }: PRDetailPageProps) {
   const { id } = await params;
   const session = await auth();
   const currentUserId = session?.user?.id ?? "";
+  const currentUserName = session?.user?.name ?? null;
+  const currentUserImage = session?.user?.image ?? null;
 
   return (
     <PRDetailContainer
       id={id}
       commentSlot={<CommentSection prId={id} />}
       currentUserId={currentUserId}
+      currentUserName={currentUserName}
+      currentUserImage={currentUserImage}
     />
   );
 }

--- a/components/comment/CommentList.tsx
+++ b/components/comment/CommentList.tsx
@@ -26,6 +26,8 @@ import type { CommentWithAuthor, MentionUser } from "@/types/comment"
 interface CommentListProps {
   prId: string
   currentUserId: string
+  currentUserName?: string | null
+  currentUserImage?: string | null
 }
 
 const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
@@ -125,6 +127,8 @@ function ChatBubble({
 }) {
   const deleteComment = useDeleteComment(prId)
   const isPendingComment = isOptimisticComment(comment.id)
+  const isDeletingComment =
+    deleteComment.isPending && deleteComment.variables === comment.id
 
   return (
     <div className={cn("group flex items-end gap-2", isOwn ? "flex-row-reverse" : "flex-row")}>
@@ -168,7 +172,7 @@ function ChatBubble({
               isOwn
                 ? "rounded-[18px] rounded-br-[4px] bg-blue-500 text-white"
                 : "rounded-[18px] rounded-bl-[4px] border border-slate-100 bg-white text-slate-800 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100",
-              isPendingComment && "opacity-80"
+              (isPendingComment || isDeletingComment) && "opacity-80"
             )}
           >
             {renderContent(comment.content, isOwn)}
@@ -186,6 +190,18 @@ function ChatBubble({
             )}
           </div>
 
+          {isDeletingComment && (
+            <span
+              className={cn(
+                "mb-1 inline-flex shrink-0 items-center gap-1 text-[10px] font-medium",
+                isOwn ? "text-blue-200" : "text-slate-500 dark:text-slate-300"
+              )}
+            >
+              <Loader2 size={10} className="animate-spin" />
+              삭제 중입니다...
+            </span>
+          )}
+
           {isOwn && !isPendingComment && (
             <button
               className="mb-1 shrink-0 text-slate-300 opacity-0 transition-opacity hover:text-rose-400 group-hover:opacity-100"
@@ -202,14 +218,14 @@ function ChatBubble({
           {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
         </span>
 
-        {comment.replies.length > 0 && (
+        {(comment.replies?.length ?? 0) > 0 && (
           <div
             className={cn(
               "mt-0.5 flex w-full flex-col gap-1",
               isOwn ? "items-end" : "items-start"
             )}
           >
-            {comment.replies.map((reply) => {
+            {(comment.replies ?? []).map((reply) => {
               const isOwnReply = reply.authorId === currentUserId
               const isPendingReply = isOptimisticComment(reply.id)
 
@@ -251,9 +267,18 @@ function ChatBubble({
   )
 }
 
-export default function CommentList({ prId, currentUserId }: CommentListProps) {
+export default function CommentList({
+  prId,
+  currentUserId,
+  currentUserName,
+  currentUserImage,
+}: CommentListProps) {
   const { data: allComments = [], isLoading } = useRealtimeComments(prId)
-  const createComment = useCreateComment(prId, { id: currentUserId })
+  const createComment = useCreateComment(prId, {
+    id: currentUserId,
+    name: currentUserName,
+    image: currentUserImage,
+  })
   const { names: typingNames, onTyping, onTypingStop } = useTypingIndicator(prId)
   const { connectionStatus, connectionError } = useSocket()
   const { data: pr } = usePRDetail(prId)
@@ -273,7 +298,10 @@ export default function CommentList({ prId, currentUserId }: CommentListProps) {
     const users: MentionUser[] = []
     const candidates = [
       pr?.repo.owner,
-      ...allComments.flatMap((comment) => [comment.author, ...comment.replies.map((reply) => reply.author)]),
+      ...allComments.flatMap((comment) => [
+        comment.author,
+        ...(Array.isArray(comment.replies) ? comment.replies : []).map((reply) => reply.author),
+      ]),
     ]
 
     for (const user of candidates) {

--- a/components/comment/CommentSection.tsx
+++ b/components/comment/CommentSection.tsx
@@ -8,6 +8,15 @@ interface CommentSectionProps {
 export default async function CommentSection({ prId }: CommentSectionProps) {
   const session = await auth()
   const currentUserId = session?.user?.id ?? ""
+  const currentUserName = session?.user?.name ?? null
+  const currentUserImage = session?.user?.image ?? null
 
-  return <CommentList prId={prId} currentUserId={currentUserId} />
+  return (
+    <CommentList
+      prId={prId}
+      currentUserId={currentUserId}
+      currentUserName={currentUserName}
+      currentUserImage={currentUserImage}
+    />
+  )
 }

--- a/components/comment/InlineCommentForm.tsx
+++ b/components/comment/InlineCommentForm.tsx
@@ -11,6 +11,8 @@ interface InlineCommentFormProps {
   filePath: string
   lineNumber: number
   currentUserId?: string
+  currentUserName?: string | null
+  currentUserImage?: string | null
   onClose: () => void
 }
 
@@ -19,10 +21,16 @@ export default function InlineCommentForm({
   filePath,
   lineNumber,
   currentUserId = "",
+  currentUserName = null,
+  currentUserImage = null,
   onClose,
 }: InlineCommentFormProps) {
   const [content, setContent] = useState("")
-  const createComment = useCreateComment(prId, { id: currentUserId })
+  const createComment = useCreateComment(prId, {
+    id: currentUserId,
+    name: currentUserName,
+    image: currentUserImage,
+  })
   const { onInlineTyping, onInlineTypingStop } = useInlineTypingIndicator(prId)
 
   const handleClose = () => {

--- a/components/comment/InlineCommentThread.tsx
+++ b/components/comment/InlineCommentThread.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image"
 import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
-import { Trash2 } from "lucide-react"
+import { Loader2, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useDeleteComment } from "@/hooks/useComments"
 import type { CommentWithAuthor } from "@/types/comment"
@@ -23,7 +23,11 @@ export default function InlineCommentThread({
 
   return (
     <div className="bg-slate-50 dark:bg-slate-800/50 border-y border-slate-200 dark:border-slate-700 divide-y divide-slate-200 dark:divide-slate-700">
-      {comments.map((comment) => (
+      {comments.map((comment) => {
+        const isDeletingComment =
+          deleteComment.isPending && deleteComment.variables === comment.id
+
+        return (
         <div key={comment.id} id={`comment-${comment.id}`} className="px-4 py-3 flex gap-3">
           <div className="shrink-0">
             {comment.author.image ? (
@@ -65,9 +69,15 @@ export default function InlineCommentThread({
             <p className="mt-0.5 text-xs text-slate-700 dark:text-slate-300 whitespace-pre-wrap">
               {comment.content}
             </p>
+            {isDeletingComment && (
+              <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 dark:text-slate-300">
+                <Loader2 size={11} className="animate-spin" />
+                삭제 중입니다...
+              </div>
+            )}
           </div>
         </div>
-      ))}
+      )})}
     </div>
   )
 }

--- a/components/pulls/detail/PRDetailContainer.tsx
+++ b/components/pulls/detail/PRDetailContainer.tsx
@@ -6,14 +6,23 @@ import { usePRFiles } from "@/hooks/usePRFiles";
 import { useReview } from "@/hooks/useReview";
 import { useQueryClient } from "@tanstack/react-query";
 import PRDetailLayout from "@/components/pulls/detail/PRDetailLayout";
+import { layoutStyles } from "@/lib/styles";
 
 interface PRDetailContainerProps {
   id: string;
   commentSlot: React.ReactNode;
   currentUserId: string;
+  currentUserName?: string | null;
+  currentUserImage?: string | null;
 }
 
-export default function PRDetailContainer({ id, commentSlot, currentUserId }: PRDetailContainerProps) {
+export default function PRDetailContainer({
+  id,
+  commentSlot,
+  currentUserId,
+  currentUserName,
+  currentUserImage,
+}: PRDetailContainerProps) {
   const { data: pr, isPending: prPending, isError: prError } = usePRDetail(id);
   const { data: files, isPending: filesPending, isError: filesError } = usePRFiles(id);
   const { data: review, isPending: reviewPending } = useReview(id);
@@ -39,7 +48,7 @@ export default function PRDetailContainer({ id, commentSlot, currentUserId }: PR
 
   if (prPending || filesPending) {
     return (
-      <div className="flex h-[calc(100svh-6.5rem)] md:h-[calc(100svh-8.5rem)] lg:h-[calc(100svh-9.5rem)] bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-[24px] shadow-sm mt-2 animate-pulse">
+      <div className={`${layoutStyles.detailFrame} animate-pulse`}>
         <div className="w-72 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900" />
         <div className="flex-1 p-6 space-y-4">
           <div className="h-8 bg-slate-200 dark:bg-slate-800 rounded-xl w-2/3" />
@@ -53,7 +62,7 @@ export default function PRDetailContainer({ id, commentSlot, currentUserId }: PR
 
   if (prError || filesError || !pr || !files) {
     return (
-      <div className="flex items-center justify-center h-[calc(100svh-6.5rem)] md:h-[calc(100svh-8.5rem)] lg:h-[calc(100svh-9.5rem)] bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-[24px] shadow-sm mt-2">
+      <div className={`${layoutStyles.detailFrame} items-center justify-center`}>
         <div className="text-center space-y-2">
           <p className="text-slate-500 dark:text-slate-400 text-sm">PR 정보를 불러오는 데 실패했습니다.</p>
           <p className="text-slate-400 dark:text-slate-500 text-xs">잠시 후 다시 시도해주세요.</p>
@@ -72,6 +81,8 @@ export default function PRDetailContainer({ id, commentSlot, currentUserId }: PR
       isRequesting={isRequesting}
       commentSlot={commentSlot}
       currentUserId={currentUserId}
+      currentUserName={currentUserName}
+      currentUserImage={currentUserImage}
     />
   );
 }

--- a/components/pulls/detail/PRDetailLayout.tsx
+++ b/components/pulls/detail/PRDetailLayout.tsx
@@ -12,6 +12,7 @@ import { usePRDetailStore } from "@/stores/prDetailStore";
 import { useComments } from "@/hooks/useComments";
 import { useSocketRoom } from "@/hooks/useSocketRoom";
 import { useInlineTypingIndicator } from "@/hooks/useInlineTypingIndicator";
+import { layoutStyles } from "@/lib/styles";
 import type { PRFile, PullRequest } from "@/types/pulls";
 import type { Review, ReviewIssue } from "@/types/review";
 import ReviewPanel from "@/components/review/ReviewPanel";
@@ -34,6 +35,8 @@ interface PRDetailLayoutProps {
   isRequesting?: boolean;
   commentSlot: React.ReactNode;
   currentUserId: string;
+  currentUserName?: string | null;
+  currentUserImage?: string | null;
 }
 
 export default function PRDetailLayout({
@@ -45,6 +48,8 @@ export default function PRDetailLayout({
   isRequesting = false,
   commentSlot,
   currentUserId,
+  currentUserName,
+  currentUserImage,
 }: PRDetailLayoutProps) {
   const selectedFile = usePRDetailStore((s) => s.selectedFile);
   const sidebarCollapsed = usePRDetailStore((s) => s.sidebarCollapsed);
@@ -178,7 +183,7 @@ export default function PRDetailLayout({
 
   return (
     <>
-      <div className="flex h-[calc(100svh-6.5rem)] md:h-[calc(100svh-8.5rem)] lg:h-[calc(100svh-9.5rem)] bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-[24px] shadow-sm relative min-w-0 overflow-hidden mt-2">
+      <div className={`${layoutStyles.detailFrame} relative`}>
         <PRFileList
           files={files}
           selectedFile={selectedFile}
@@ -357,6 +362,8 @@ export default function PRDetailLayout({
                 onIssueClick={setSelectedIssue}
                 prId={pr.id}
                 currentUserId={currentUserId}
+                currentUserName={currentUserName}
+                currentUserImage={currentUserImage}
                 inlineComments={inlineCommentsByFile[file.filename] ?? []}
               />
             ))}

--- a/components/pulls/detail/PRDiffViewer/DiffTable.tsx
+++ b/components/pulls/detail/PRDiffViewer/DiffTable.tsx
@@ -20,6 +20,8 @@ interface DiffTableProps {
   prId?: string
   filePath?: string
   currentUserId?: string
+  currentUserName?: string | null
+  currentUserImage?: string | null
 }
 
 export default function DiffTable({
@@ -30,6 +32,8 @@ export default function DiffTable({
   prId,
   filePath,
   currentUserId = "",
+  currentUserName = null,
+  currentUserImage = null,
 }: DiffTableProps) {
   const [hoveredLine, setHoveredLine] = useState<number | null>(null)
   const [openFormLine, setOpenFormLine] = useState<number | null>(null)
@@ -135,6 +139,9 @@ export default function DiffTable({
                       prId={prId!}
                       filePath={filePath!}
                       lineNumber={line.newNum!}
+                      currentUserId={currentUserId}
+                      currentUserName={currentUserName}
+                      currentUserImage={currentUserImage}
                       onClose={() => setOpenFormLine(null)}
                     />
                   </td>

--- a/components/pulls/detail/PRDiffViewer/index.tsx
+++ b/components/pulls/detail/PRDiffViewer/index.tsx
@@ -15,6 +15,8 @@ interface PRDiffViewerProps {
   onIssueClick?: (issue: ReviewIssue) => void;
   prId: string;
   currentUserId: string;
+  currentUserName?: string | null;
+  currentUserImage?: string | null;
   inlineComments: CommentWithAuthor[];
 }
 
@@ -25,6 +27,8 @@ export default function PRDiffViewer({
   onIssueClick,
   prId,
   currentUserId,
+  currentUserName,
+  currentUserImage,
   inlineComments,
 }: PRDiffViewerProps) {
   const collapsed = usePRDetailStore((s) => s.collapsedDiffs[file.filename] ?? false);
@@ -62,6 +66,8 @@ export default function PRDiffViewer({
               prId={prId}
               filePath={file.filename}
               currentUserId={currentUserId}
+              currentUserName={currentUserName}
+              currentUserImage={currentUserImage}
             />
           )}
         </div>

--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -20,6 +20,18 @@ type OptimisticUser = {
   image?: string | null
 }
 
+function normalizeComment(comment: CommentWithAuthor): CommentWithAuthor {
+  return {
+    ...comment,
+    author: {
+      id: comment.author?.id ?? comment.authorId,
+      name: comment.author?.name ?? null,
+      image: comment.author?.image ?? null,
+    },
+    replies: Array.isArray(comment.replies) ? comment.replies.map(normalizeComment) : [],
+  }
+}
+
 async function fetchAllCommentsPage(
   filter: CommentsFilter,
   page: number
@@ -32,7 +44,7 @@ async function fetchAllCommentsPage(
   params.set("limit", "20")
 
   const res = await fetch(`/api/comments?${params}`)
-  if (!res.ok) throw new Error("댓글을 불러오지 못했습니다.")
+  if (!res.ok) throw new Error("Failed to load comments.")
   return res.json()
 }
 
@@ -50,28 +62,32 @@ export function useAllComments(filter: CommentsFilter) {
 
 async function fetchComments(prId: string): Promise<CommentWithAuthor[]> {
   const res = await fetch(`/api/pulls/${prId}/comments`)
-  if (!res.ok) throw new Error("댓글을 불러오지 못했습니다.")
+  if (!res.ok) throw new Error("Failed to load comments.")
   const data = await res.json()
-  return data.comments
+  return (data.comments as CommentWithAuthor[]).map(normalizeComment)
 }
 
 function appendComment(
   comments: CommentWithAuthor[],
   comment: CommentWithAuthor
 ): CommentWithAuthor[] {
-  if (comment.parentId == null) {
-    if (comments.some((item) => item.id === comment.id)) return comments
-    return [...comments, comment]
+  const normalizedComment = normalizeComment(comment)
+
+  if (normalizedComment.parentId == null) {
+    if (comments.some((item) => item.id === normalizedComment.id)) return comments
+    return [...comments, normalizedComment]
   }
 
   return comments.map((item) => {
-    if (item.id === comment.parentId) {
-      if (item.replies.some((reply) => reply.id === comment.id)) return item
-      return { ...item, replies: [...item.replies, comment] }
+    const replies = Array.isArray(item.replies) ? item.replies : []
+
+    if (item.id === normalizedComment.parentId) {
+      if (replies.some((reply) => reply.id === normalizedComment.id)) return item
+      return { ...item, replies: [...replies, normalizedComment] }
     }
 
-    if (item.replies.length === 0) return item
-    return { ...item, replies: appendComment(item.replies, comment) }
+    if (replies.length === 0) return item
+    return { ...item, replies: appendComment(replies, normalizedComment) }
   })
 }
 
@@ -81,22 +97,24 @@ function replaceComment(
   nextComment: CommentWithAuthor
 ): CommentWithAuthor[] {
   let replaced = false
+  const normalizedNextComment = normalizeComment(nextComment)
 
   const walk = (items: CommentWithAuthor[]): CommentWithAuthor[] =>
     items.map((item) => {
       if (item.id === targetId) {
         replaced = true
-        return nextComment
+        return normalizedNextComment
       }
 
-      if (item.replies.length === 0) return item
+      const replies = Array.isArray(item.replies) ? item.replies : []
+      if (replies.length === 0) return item
 
-      const nextReplies = walk(item.replies)
-      return nextReplies === item.replies ? item : { ...item, replies: nextReplies }
+      const nextReplies = walk(replies)
+      return nextReplies === replies ? item : { ...item, replies: nextReplies }
     })
 
   const updated = walk(comments)
-  return replaced ? updated : appendComment(updated, nextComment)
+  return replaced ? updated : appendComment(updated, normalizedNextComment)
 }
 
 export function useComments(prId: string) {
@@ -116,9 +134,9 @@ export function useCreateComment(prId: string, optimisticUser?: OptimisticUser) 
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(input),
       })
-      if (!res.ok) throw new Error("댓글 작성에 실패했습니다.")
+      if (!res.ok) throw new Error("Failed to create comment.")
       const data = await res.json()
-      return data.comment as CommentWithAuthor
+      return normalizeComment(data.comment as CommentWithAuthor)
     },
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: ["comments", prId] })
@@ -130,7 +148,7 @@ export function useCreateComment(prId: string, optimisticUser?: OptimisticUser) 
       const now = new Date().toISOString()
       const author: CommentAuthor = {
         id: optimisticUser?.id ?? "optimistic-user",
-        name: optimisticUser?.name ?? "나",
+        name: optimisticUser?.name ?? null,
         image: optimisticUser?.image ?? null,
       }
 
@@ -182,7 +200,7 @@ export function useUpdateComment(prId: string) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(input),
       })
-      if (!res.ok) throw new Error("댓글 수정에 실패했습니다.")
+      if (!res.ok) throw new Error("Failed to update comment.")
       const data = await res.json()
       return data.comment as CommentWithAuthor
     },
@@ -197,7 +215,7 @@ export function useDeleteComment(prId: string) {
   return useMutation({
     mutationFn: async (commentId: string) => {
       const res = await fetch(`/api/comments/${commentId}`, { method: "DELETE" })
-      if (!res.ok) throw new Error("댓글 삭제에 실패했습니다.")
+      if (!res.ok) throw new Error("Failed to delete comment.")
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", prId] })
@@ -214,7 +232,7 @@ export function useToggleReaction(prId: string) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ emoji }),
       })
-      if (!res.ok) throw new Error("반응 추가에 실패했습니다.")
+      if (!res.ok) throw new Error("Failed to toggle reaction.")
       const data = await res.json()
       return data.comment as CommentWithAuthor
     },
@@ -229,7 +247,7 @@ export function useToggleResolve(prId: string) {
   return useMutation({
     mutationFn: async (commentId: string) => {
       const res = await fetch(`/api/comments/${commentId}/resolve`, { method: "PATCH" })
-      if (!res.ok) throw new Error("resolve 토글에 실패했습니다.")
+      if (!res.ok) throw new Error("Failed to resolve comment.")
       const data = await res.json()
       return data.comment as CommentWithAuthor
     },

--- a/hooks/useRealtimeComments.ts
+++ b/hooks/useRealtimeComments.ts
@@ -1,18 +1,59 @@
 "use client"
 
-import { useEffect, useCallback } from "react"
+import { useCallback, useEffect } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { CommentWithAuthor } from "@/types/comment"
+import {
+  recordHandlerInvocation,
+  recordHandlerRegistered,
+  recordHandlerRemoved,
+} from "@/lib/measurements/socketMetrics"
 import { useSocketRoom } from "./useSocketRoom"
+
+function normalizeComment(comment: CommentWithAuthor): CommentWithAuthor {
+  return {
+    ...comment,
+    author: {
+      id: comment.author?.id ?? comment.authorId,
+      name: comment.author?.name ?? null,
+      image: comment.author?.image ?? null,
+    },
+    replies: Array.isArray(comment.replies) ? comment.replies.map(normalizeComment) : [],
+  }
+}
 
 async function fetchComments(prId: string): Promise<CommentWithAuthor[]> {
   const res = await fetch(`/api/pulls/${prId}/comments`)
-  if (!res.ok) throw new Error("댓글을 불러오지 못했습니다.")
+  if (!res.ok) throw new Error("Failed to load comments.")
   const data = await res.json()
-  return data.comments
+  return (data.comments as CommentWithAuthor[]).map(normalizeComment)
 }
 
 const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
+
+function appendComment(
+  comments: CommentWithAuthor[],
+  comment: CommentWithAuthor
+): CommentWithAuthor[] {
+  const normalizedComment = normalizeComment(comment)
+
+  if (normalizedComment.parentId == null) {
+    if (comments.some((item) => item.id === normalizedComment.id)) return comments
+    return [...comments, normalizedComment]
+  }
+
+  return comments.map((item) => {
+    const replies = Array.isArray(item.replies) ? item.replies : []
+
+    if (item.id === normalizedComment.parentId) {
+      if (replies.some((reply) => reply.id === normalizedComment.id)) return item
+      return { ...item, replies: [...replies, normalizedComment] }
+    }
+
+    if (replies.length === 0) return item
+    return { ...item, replies: appendComment(replies, normalizedComment) }
+  })
+}
 
 export function useRealtimeComments(prId: string) {
   const socket = useSocketRoom(prId)
@@ -26,9 +67,9 @@ export function useRealtimeComments(prId: string) {
 
   const handleNew = useCallback(
     (comment: CommentWithAuthor) => {
-      queryClient.setQueryData<CommentWithAuthor[]>(
-        ["comments", prId],
-        (old) => (old ? [...old, comment] : [comment])
+      recordHandlerInvocation("comment:new")
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old ? appendComment(old, comment) : [normalizeComment(comment)]
       )
     },
     [queryClient, prId]
@@ -36,22 +77,41 @@ export function useRealtimeComments(prId: string) {
 
   const handleUpdated = useCallback(
     (comment: CommentWithAuthor) => {
-      queryClient.setQueryData<CommentWithAuthor[]>(
-        ["comments", prId],
-        (old) => {
-          if (!old) return [comment]
-          return old.map((c) => (c.id === comment.id ? comment : c))
-        }
-      )
+      recordHandlerInvocation("comment:updated")
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) => {
+        const normalizedComment = normalizeComment(comment)
+        if (!old) return [normalizedComment]
+
+        return old.map((item) => {
+          if (item.id === normalizedComment.id) return normalizedComment
+
+          const replies = Array.isArray(item.replies) ? item.replies : []
+          if (replies.length === 0) return item
+
+          return {
+            ...item,
+            replies: replies.map((reply) =>
+              reply.id === normalizedComment.id ? normalizedComment : reply
+            ),
+          }
+        })
+      })
     },
     [queryClient, prId]
   )
 
   const handleDeleted = useCallback(
     ({ commentId }: { commentId: string; prId: string }) => {
-      queryClient.setQueryData<CommentWithAuthor[]>(
-        ["comments", prId],
-        (old) => (old ? old.filter((c) => c.id !== commentId) : [])
+      recordHandlerInvocation("comment:deleted")
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old
+          ? old
+              .filter((item) => item.id !== commentId)
+              .map((item) => ({
+                ...item,
+                replies: (item.replies ?? []).filter((reply) => reply.id !== commentId),
+              }))
+          : []
       )
     },
     [queryClient, prId]
@@ -60,6 +120,9 @@ export function useRealtimeComments(prId: string) {
   useEffect(() => {
     if (!socket) return
 
+    recordHandlerRegistered("comment:new")
+    recordHandlerRegistered("comment:updated")
+    recordHandlerRegistered("comment:deleted")
     socket.on("comment:new", handleNew)
     socket.on("comment:updated", handleUpdated)
     socket.on("comment:deleted", handleDeleted)
@@ -68,8 +131,11 @@ export function useRealtimeComments(prId: string) {
       socket.off("comment:new", handleNew)
       socket.off("comment:updated", handleUpdated)
       socket.off("comment:deleted", handleDeleted)
+      recordHandlerRemoved("comment:new")
+      recordHandlerRemoved("comment:updated")
+      recordHandlerRemoved("comment:deleted")
     }
-  }, [socket, handleNew, handleUpdated, handleDeleted])
+  }, [socket, handleDeleted, handleNew, handleUpdated])
 
   return query
 }

--- a/hooks/useSocketRoom.ts
+++ b/hooks/useSocketRoom.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 import { useSocket } from "./useSocket"
+import { recordRoomJoin, recordRoomLeave } from "@/lib/measurements/socketMetrics"
 
 export function useSocketRoom(prId: string) {
   const { socket } = useSocket()
@@ -9,9 +10,11 @@ export function useSocketRoom(prId: string) {
   useEffect(() => {
     if (!socket || !prId) return
 
+    recordRoomJoin(prId)
     socket.emit("room:join", prId)
 
     return () => {
+      recordRoomLeave(prId)
       socket.emit("room:leave", prId)
     }
   }, [socket, prId])

--- a/lib/measurements/socketMetrics.ts
+++ b/lib/measurements/socketMetrics.ts
@@ -1,0 +1,239 @@
+"use client"
+
+export const SOCKET_METRIC_EVENTS = [
+  "comment:new",
+  "comment:updated",
+  "comment:deleted",
+  "notification:new",
+  "typing:start",
+  "typing:stop",
+  "inline:typing:start",
+  "inline:typing:stop",
+] as const
+
+export type SocketMetricEvent = (typeof SOCKET_METRIC_EVENTS)[number]
+
+type CounterMap = Record<string, number>
+
+type SocketMetricsStore = {
+  startedAt: string
+  updatedAt: string
+  socketCreates: number
+  connectCalls: number
+  connects: number
+  disconnects: number
+  connectErrors: number
+  activeConnections: number
+  peakConnections: number
+  roomJoins: number
+  roomLeaves: number
+  currentRoomSubscriptions: number
+  peakRoomSubscriptions: number
+  activeRooms: CounterMap
+  peakRooms: CounterMap
+  activeHandlers: CounterMap
+  peakHandlers: CounterMap
+  handlerInvocations: CounterMap
+  reconnectSamplesMs: number[]
+  lastDisconnectAt: number | null
+  lastErrorMessage: string | null
+}
+
+export type SocketMetricsSnapshot = SocketMetricsStore & {
+  roomBalance: number
+  reconnectCount: number
+  reconnectAvgMs: number | null
+  reconnectP95Ms: number | null
+  reconnectMaxMs: number | null
+}
+
+const SOCKET_METRICS_KEY = "__codeMateSocketMetrics"
+
+function createCounterMap(): CounterMap {
+  return Object.fromEntries(SOCKET_METRIC_EVENTS.map((event) => [event, 0]))
+}
+
+function createStore(): SocketMetricsStore {
+  const now = new Date().toISOString()
+
+  return {
+    startedAt: now,
+    updatedAt: now,
+    socketCreates: 0,
+    connectCalls: 0,
+    connects: 0,
+    disconnects: 0,
+    connectErrors: 0,
+    activeConnections: 0,
+    peakConnections: 0,
+    roomJoins: 0,
+    roomLeaves: 0,
+    currentRoomSubscriptions: 0,
+    peakRoomSubscriptions: 0,
+    activeRooms: {},
+    peakRooms: {},
+    activeHandlers: createCounterMap(),
+    peakHandlers: createCounterMap(),
+    handlerInvocations: createCounterMap(),
+    reconnectSamplesMs: [],
+    lastDisconnectAt: null,
+    lastErrorMessage: null,
+  }
+}
+
+function getMetricsWindow():
+  | (Window & { [SOCKET_METRICS_KEY]?: SocketMetricsStore })
+  | null {
+  if (typeof window === "undefined") return null
+
+  return window as Window & { [SOCKET_METRICS_KEY]?: SocketMetricsStore }
+}
+
+function getStore(): SocketMetricsStore {
+  const metricsWindow = getMetricsWindow()
+  if (!metricsWindow) {
+    return createStore()
+  }
+
+  if (!metricsWindow[SOCKET_METRICS_KEY]) {
+    metricsWindow[SOCKET_METRICS_KEY] = createStore()
+  }
+
+  return metricsWindow[SOCKET_METRICS_KEY]
+}
+
+function touch(store: SocketMetricsStore) {
+  store.updatedAt = new Date().toISOString()
+}
+
+function incrementCounter(map: CounterMap, key: string, delta = 1) {
+  map[key] = (map[key] ?? 0) + delta
+}
+
+function updatePeak(map: CounterMap, key: string, value: number) {
+  map[key] = Math.max(map[key] ?? 0, value)
+}
+
+function percentile(samples: number[], ratio: number): number | null {
+  if (samples.length === 0) return null
+
+  const sorted = [...samples].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)
+
+  return sorted[index]
+}
+
+function average(samples: number[]): number | null {
+  if (samples.length === 0) return null
+  return samples.reduce((sum, sample) => sum + sample, 0) / samples.length
+}
+
+export function resetSocketMetrics(): SocketMetricsSnapshot {
+  const metricsWindow = getMetricsWindow()
+  if (metricsWindow) {
+    metricsWindow[SOCKET_METRICS_KEY] = createStore()
+  }
+
+  return getSocketMetricsSnapshot()
+}
+
+export function getSocketMetricsSnapshot(): SocketMetricsSnapshot {
+  const store = getStore()
+
+  return {
+    ...store,
+    activeRooms: { ...store.activeRooms },
+    peakRooms: { ...store.peakRooms },
+    activeHandlers: { ...store.activeHandlers },
+    peakHandlers: { ...store.peakHandlers },
+    handlerInvocations: { ...store.handlerInvocations },
+    reconnectSamplesMs: [...store.reconnectSamplesMs],
+    roomBalance: store.roomJoins - store.roomLeaves,
+    reconnectCount: store.reconnectSamplesMs.length,
+    reconnectAvgMs: average(store.reconnectSamplesMs),
+    reconnectP95Ms: percentile(store.reconnectSamplesMs, 0.95),
+    reconnectMaxMs:
+      store.reconnectSamplesMs.length > 0 ? Math.max(...store.reconnectSamplesMs) : null,
+  }
+}
+
+export function recordSocketConnectCall() {
+  const store = getStore()
+  store.connectCalls += 1
+  touch(store)
+}
+
+export function recordSocketCreate() {
+  const store = getStore()
+  store.socketCreates += 1
+  touch(store)
+}
+
+export function recordSocketConnected() {
+  const store = getStore()
+  store.connects += 1
+  store.activeConnections = 1
+  store.peakConnections = Math.max(store.peakConnections, store.activeConnections)
+
+  if (store.lastDisconnectAt != null) {
+    store.reconnectSamplesMs.push(performance.now() - store.lastDisconnectAt)
+    store.lastDisconnectAt = null
+  }
+
+  touch(store)
+}
+
+export function recordSocketDisconnected() {
+  const store = getStore()
+  store.disconnects += 1
+  store.activeConnections = 0
+  store.lastDisconnectAt = performance.now()
+  touch(store)
+}
+
+export function recordSocketConnectError(message: string) {
+  const store = getStore()
+  store.connectErrors += 1
+  store.lastErrorMessage = message
+  touch(store)
+}
+
+export function recordRoomJoin(prId: string) {
+  const store = getStore()
+  store.roomJoins += 1
+  store.currentRoomSubscriptions += 1
+  store.peakRoomSubscriptions = Math.max(
+    store.peakRoomSubscriptions,
+    store.currentRoomSubscriptions
+  )
+  incrementCounter(store.activeRooms, prId)
+  updatePeak(store.peakRooms, prId, store.activeRooms[prId])
+  touch(store)
+}
+
+export function recordRoomLeave(prId: string) {
+  const store = getStore()
+  store.roomLeaves += 1
+  store.currentRoomSubscriptions = Math.max(0, store.currentRoomSubscriptions - 1)
+  store.activeRooms[prId] = Math.max(0, (store.activeRooms[prId] ?? 0) - 1)
+  touch(store)
+}
+
+export function recordHandlerRegistered(event: SocketMetricEvent) {
+  const store = getStore()
+  incrementCounter(store.activeHandlers, event)
+  updatePeak(store.peakHandlers, event, store.activeHandlers[event])
+  touch(store)
+}
+
+export function recordHandlerRemoved(event: SocketMetricEvent) {
+  const store = getStore()
+  store.activeHandlers[event] = Math.max(0, (store.activeHandlers[event] ?? 0) - 1)
+  touch(store)
+}
+
+export function recordHandlerInvocation(event: SocketMetricEvent) {
+  const store = getStore()
+  incrementCounter(store.handlerInvocations, event)
+  touch(store)
+}

--- a/lib/styles.ts
+++ b/lib/styles.ts
@@ -1,17 +1,65 @@
 /**
- * 공통 텍스트 스타일 상수
- * Tailwind 클래스를 문자열로 관리하여 일관성 유지
+ * Shared text style tokens.
+ * Keeping repeated Tailwind class groups here makes page-level UI consistent.
  */
 export const textStyles = {
-  /** 페이지 최상단 제목 (h1) */
-  pageTitle: "text-3xl font-bold text-slate-900 tracking-tight",
+  /** Top-level page title. */
+  pageTitle: "text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-50",
 
-  /** 페이지 제목 아래 설명 문구 */
-  pageSubtitle: "text-sm text-slate-500 font-medium mt-1",
+  /** Short descriptive text under a page title. */
+  pageSubtitle: "mt-1 text-sm font-medium text-slate-500 dark:text-slate-400",
 
-  /** 카드/섹션 제목 (h2 수준, 반응형) */
-  sectionTitle: "text-base sm:text-lg font-bold text-slate-900",
+  /** Card and section title text. */
+  sectionTitle: "text-base font-bold text-slate-900 dark:text-slate-50 sm:text-lg",
 
-  /** 테이블 헤더 셀 */
-  tableHeader: "text-xs font-bold text-slate-700 uppercase tracking-wider",
+  /** Table header text. */
+  tableHeader:
+    "text-xs font-bold uppercase tracking-wider text-slate-700 dark:text-slate-300",
+} as const;
+
+/**
+ * Protected page layout tokens.
+ * - page: default list/workflow pages
+ * - narrowPage: settings and notification pages
+ * - widePage: dashboard and analytics pages
+ */
+export const layoutStyles = {
+  page:
+    "mx-auto flex w-full max-w-6xl flex-col gap-6 animate-in fade-in slide-in-from-bottom-2 duration-500",
+  narrowPage:
+    "mx-auto flex w-full max-w-3xl flex-col gap-6 animate-in fade-in slide-in-from-bottom-2 duration-500",
+  widePage:
+    "mx-auto flex w-full max-w-7xl flex-col gap-6 animate-in fade-in slide-in-from-bottom-2 duration-500",
+  sectionStack: "flex flex-col gap-4 sm:gap-6",
+  listStack: "flex flex-col gap-4",
+  gridGap: "gap-4 sm:gap-6",
+  detailFrame:
+    "mt-2 flex h-[calc(100svh-6.5rem)] min-w-0 overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950 md:h-[calc(100svh-8.5rem)] lg:h-[calc(100svh-9.5rem)]",
+} as const;
+
+/** Reusable surface and card styles. */
+export const surfaceStyles = {
+  panel:
+    "rounded-md border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950",
+  panelPadding: "p-4 sm:p-6 md:p-8",
+  card:
+    "rounded-md border border-slate-200 bg-white p-4 shadow-sm transition-all duration-200 dark:border-slate-800 dark:bg-slate-950 sm:p-5",
+  interactiveCard:
+    "rounded-md border border-slate-200 bg-white p-4 shadow-sm transition-all duration-200 hover:border-blue-200 hover:shadow-lg hover:shadow-blue-500/5 dark:border-slate-800 dark:bg-slate-950 dark:hover:border-blue-900 sm:p-5",
+  toolbar:
+    "rounded-md border border-slate-200 bg-white p-2 shadow-sm dark:border-slate-800 dark:bg-slate-950",
+  emptyState:
+    "py-16 text-center text-sm font-medium text-slate-400 dark:text-slate-500 sm:py-20",
+} as const;
+
+/** Shared controls and action styles. */
+export const controlStyles = {
+  filterButton:
+    "inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium transition-colors",
+  iconButton:
+    "inline-flex size-9 items-center justify-center rounded-md border border-transparent transition-colors",
+  primaryAction:
+    "rounded-md bg-blue-700 font-bold text-white shadow-lg shadow-blue-700/20 hover:bg-blue-800",
+  secondaryAction:
+    "rounded-md border border-slate-200 bg-white font-bold text-slate-700 shadow-sm hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-900",
 } as const;


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 상호작용
- [ ] Week 9-10: 대시보드 & 배포

## 개요

PR 상세 페이지 댓글 경험을 개선했습니다. 댓글 작성 직후 실시간 반영 흐름을 안정화하고, optimistic UI에서 실제 사용자 닉네임/프로필 이미지가 보이도록 맞췄으며, 댓글 삭제 시 진행 상태 피드백도 추가했습니다.

Closes #113

## 변경 사항

- 댓글/실시간 댓글 캐시 데이터를 정규화해 eplies 누락으로 인한 런타임 에러를 방어했습니다.
- 일반 댓글 작성 시 optimistic UI에 실제 사용자 닉네임과 프로필 이미지를 반영하도록 수정했습니다.
- 인라인 댓글 작성 시에도 동일하게 사용자 프로필 정보가 즉시 반영되도록 연결했습니다.
- 댓글 삭제와 인라인 댓글 삭제 시 삭제 중입니다... 피드백을 표시하도록 개선했습니다.
- PR 상세 페이지에서 현재 사용자 정보를 댓글/인라인 댓글 흐름으로 전달하도록 정리했습니다.

## 스크린샷 (선택)

- 추후 측정 페이지 및 PR 상세 댓글 GIF/스크린샷 추가 예정

## 테스트

- [x] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (	sc --noEmit)
- [ ] ESLint 경고/에러 없음

## 참고 사항

- 현재 워크트리에 다른 변경사항이 있어, 이 PR에는 #113 관련 파일만 별도 커밋으로 분리했습니다.
- 포트폴리오용 측정 자료와 설명 문서는 후속 작업에서 정리할 예정입니다.