### PR TITLE
Feat/115 shared repository membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ npx shadcn@latest add dropdown-menu avatar badge
 ```env
 # Database
 DATABASE_URL="postgresql://username:password@localhost:5432/codemate"
+DIRECT_DATABASE_URL="postgresql://username:password@localhost:5432/codemate"
 
 # NextAuth
 NEXTAUTH_URL="http://localhost:3000"
@@ -418,6 +419,10 @@ npx prisma generate
 # (Optional) Prisma Studio로 DB 확인
 npx prisma studio
 ```
+
+Supabase pooler URL을 `DATABASE_URL`로 쓰는 경우:
+`DIRECT_DATABASE_URL`에는 direct connection URL을 따로 넣어두는 것을 권장합니다.
+런타임 쿼리는 pooler로 처리해도 되지만, Prisma migration은 direct URL이 더 안정적입니다.
 
 ### 5. 개발 서버 실행
 

--- a/__tests__/api/comments/route.test.ts
+++ b/__tests__/api/comments/route.test.ts
@@ -1,6 +1,7 @@
 import { GET } from "@/app/api/comments/route"
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -16,12 +17,18 @@ jest.mock("@/lib/prisma", () => ({
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  buildAccessibleRepositoryWhere: jest.fn(),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedTransaction = prisma.$transaction as jest.Mock
+const mockedBuildAccessibleRepositoryWhere =
+  buildAccessibleRepositoryWhere as jest.Mock
 
 const sampleComment = {
   id: "comment-1",
-  content: "좋은 코드입니다.",
+  content: "Nice code",
   lineNumber: null,
   filePath: null,
   isResolved: false,
@@ -32,10 +39,10 @@ const sampleComment = {
   reactions: {},
   createdAt: new Date("2024-01-01T00:00:00.000Z"),
   updatedAt: new Date("2024-01-01T00:00:00.000Z"),
-  author: { id: "user-1", name: "홍길동", image: null },
+  author: { id: "user-1", name: "Tester", image: null },
   pullRequest: {
     id: "pr-1",
-    title: "feat: 대시보드 추가",
+    title: "feat: Add dashboard",
     number: 42,
     repoId: "repo-1",
     repo: { name: "awesome-app" },
@@ -55,7 +62,7 @@ describe("GET /api/comments", () => {
     jest.clearAllMocks()
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const response = await GET(createRequest())
@@ -65,8 +72,9 @@ describe("GET /api/comments", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("전체 댓글 목록을 최신순으로 반환한다", async () => {
+  it("returns paginated comments", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
     mockedTransaction.mockResolvedValue([[sampleComment], 1])
 
     const response = await GET(createRequest())
@@ -83,21 +91,25 @@ describe("GET /api/comments", () => {
     })
   })
 
-  it("repoId 필터를 적용하면 해당 저장소 댓글만 조회한다", async () => {
+  it("supports repoId filters", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
     mockedTransaction.mockResolvedValue([[sampleComment], 1])
 
     const response = await GET(createRequest({ repoId: "repo-1" }))
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(mockedTransaction).toHaveBeenCalledTimes(1)
-    // $transaction은 [findMany promise, count promise]를 인자로 받음
+    expect(mockedBuildAccessibleRepositoryWhere).toHaveBeenCalledWith(
+      "user-1",
+      "repo-1"
+    )
     expect(body.pagination.total).toBe(1)
   })
 
-  it("authorId 필터를 적용하면 해당 작성자의 댓글만 조회한다", async () => {
+  it("supports authorId filters", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
     mockedTransaction.mockResolvedValue([[sampleComment], 1])
 
     const response = await GET(createRequest({ authorId: "user-1" }))
@@ -107,8 +119,9 @@ describe("GET /api/comments", () => {
     expect(body.comments[0].authorId).toBe("user-1")
   })
 
-  it("댓글이 없으면 빈 배열과 pagination을 반환한다", async () => {
+  it("returns empty pagination when there are no comments", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
     mockedTransaction.mockResolvedValue([[], 0])
 
     const response = await GET(createRequest())
@@ -120,8 +133,9 @@ describe("GET /api/comments", () => {
     expect(body.pagination.totalPages).toBe(0)
   })
 
-  it("page/limit 쿼리 파라미터를 처리한다", async () => {
+  it("supports page and limit parameters", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
     mockedTransaction.mockResolvedValue([[sampleComment], 25])
 
     const response = await GET(createRequest({ page: "2", limit: "10" }))
@@ -133,8 +147,9 @@ describe("GET /api/comments", () => {
     expect(body.pagination.totalPages).toBe(3)
   })
 
-  it("서버 오류 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
     mockedTransaction.mockRejectedValue(new Error("DB error"))
 
     const response = await GET(createRequest())

--- a/__tests__/api/github/repos.test.ts
+++ b/__tests__/api/github/repos.test.ts
@@ -3,6 +3,10 @@ import { GET } from "@/app/api/github/repos/route"
 import { auth } from "@/lib/auth"
 import { getAuthenticatedOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  buildAccessibleRepositoryWhere,
+  isRepositoryMembershipMigrationError,
+} from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -20,19 +24,31 @@ jest.mock("@/lib/prisma", () => ({
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  buildAccessibleRepositoryWhere: jest.fn(),
+  isRepositoryMembershipMigrationError: jest.fn(() => false),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedGetAuthenticatedOctokit = getAuthenticatedOctokit as jest.Mock
 const mockedFindMany = prisma.repository.findMany as jest.Mock
+const mockedBuildAccessibleRepositoryWhere =
+  buildAccessibleRepositoryWhere as jest.Mock
+const mockedIsRepositoryMembershipMigrationError =
+  isRepositoryMembershipMigrationError as jest.Mock
 
-const makeRequest = () => new NextRequest("http://localhost/api/github/repos")
+const makeRequest = () =>
+  new NextRequest("http://localhost/api/github/repos?page=1")
 
 describe("GET /api/github/repos", () => {
   afterEach(() => {
     jest.clearAllMocks()
+    mockedIsRepositoryMembershipMigrationError.mockReturnValue(false)
   })
 
-  it("인증된 사용자의 Repository 목록을 반환한다", async () => {
+  it("returns repository list for authenticated users", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["db-repo-1"] } })
     mockedGetAuthenticatedOctokit.mockResolvedValue({
       rest: {
         repos: {
@@ -53,16 +69,31 @@ describe("GET /api/github/repos", () => {
 
     expect(response.status).toBe(200)
     expect(body.repos).toEqual([
-      { id: 1, name: "repo-a", fullName: "user/repo-a", language: "TypeScript", isConnected: true, repositoryId: "db-repo-1" },
-      { id: 2, name: "repo-b", fullName: "user/repo-b", language: "Python", isConnected: false, repositoryId: undefined },
+      {
+        id: 1,
+        name: "repo-a",
+        fullName: "user/repo-a",
+        language: "TypeScript",
+        isConnected: true,
+        repositoryId: "db-repo-1",
+      },
+      {
+        id: 2,
+        name: "repo-b",
+        fullName: "user/repo-b",
+        language: "Python",
+        isConnected: false,
+        repositoryId: undefined,
+      },
     ])
+    expect(body.pagination).toEqual({ page: 1, perPage: 20, hasNextPage: false })
     expect(mockedFindMany).toHaveBeenCalledWith({
-      where: { userId: "user-1" },
+      where: { id: { in: ["db-repo-1"] } },
       select: { githubId: true, id: true },
     })
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const response = await GET(makeRequest())
@@ -72,7 +103,7 @@ describe("GET /api/github/repos", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("GitHub API 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
     mockedGetAuthenticatedOctokit.mockRejectedValue(new Error("GitHub API error"))
 

--- a/__tests__/api/pulls/[id]/files/route.test.ts
+++ b/__tests__/api/pulls/[id]/files/route.test.ts
@@ -2,6 +2,7 @@ import { GET } from "@/app/api/pulls/[id]/files/route"
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import { buildAccessiblePullRequestWhere } from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -19,9 +20,15 @@ jest.mock("@/lib/prisma", () => ({
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  buildAccessiblePullRequestWhere: jest.fn(),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedGetOctokit = getOctokit as jest.Mock
 const mockedFindFirst = prisma.pullRequest.findFirst as jest.Mock
+const mockedBuildAccessiblePullRequestWhere =
+  buildAccessiblePullRequestWhere as jest.Mock
 
 const createRequest = () => new Request("http://localhost/api/pulls/pr-1/files")
 const createParams = (id = "pr-1") =>
@@ -55,7 +62,7 @@ const sampleFiles = [
     additions: 0,
     deletions: 5,
     changes: 5,
-    patch: undefined, // patch가 없는 경우
+    patch: undefined,
   },
 ]
 
@@ -64,7 +71,7 @@ describe("GET /api/pulls/[id]/files", () => {
     jest.clearAllMocks()
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const response = await GET(createRequest(), createParams())
@@ -74,19 +81,25 @@ describe("GET /api/pulls/[id]/files", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("존재하지 않는 PR은 404를 반환한다", async () => {
+  it("returns 404 when the PR does not exist", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedFindFirst.mockResolvedValue(null)
 
     const response = await GET(createRequest(), createParams())
     const body = await response.json()
 
     expect(response.status).toBe(404)
-    expect(body.error).toBe("PR을 찾을 수 없습니다.")
+    expect(body.error).toBe("Pull request not found")
   })
 
-  it("정상 조회 시 파일 목록(filename, status, additions, deletions, changes, patch)을 반환한다", async () => {
+  it("returns transformed file data", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedFindFirst.mockResolvedValue(samplePR)
 
     const mockOctokit = {
@@ -111,8 +124,11 @@ describe("GET /api/pulls/[id]/files", () => {
     })
   })
 
-  it("patch가 없는 파일은 null로 반환한다", async () => {
+  it("normalizes missing patch values to null", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedFindFirst.mockResolvedValue(samplePR)
 
     const mockOctokit = {
@@ -128,8 +144,11 @@ describe("GET /api/pulls/[id]/files", () => {
     expect(body.files[2].patch).toBeNull()
   })
 
-  it("owner/repo를 fullName에서 올바르게 파싱해 GitHub API를 호출한다", async () => {
+  it("parses owner/repo from fullName", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedFindFirst.mockResolvedValue(samplePR)
 
     const mockListFiles = jest.fn().mockResolvedValue({ data: [] })
@@ -145,9 +164,9 @@ describe("GET /api/pulls/[id]/files", () => {
     })
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
-    mockedFindFirst.mockRejectedValue(new Error("DB error"))
+    mockedBuildAccessiblePullRequestWhere.mockRejectedValue(new Error("DB error"))
 
     const response = await GET(createRequest(), createParams())
     const body = await response.json()

--- a/__tests__/api/pulls/[id]/route.test.ts
+++ b/__tests__/api/pulls/[id]/route.test.ts
@@ -2,6 +2,10 @@ import { GET } from "@/app/api/pulls/[id]/route"
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  buildAccessiblePullRequestWhere,
+  getRepositoryPrimaryUser,
+} from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -20,10 +24,18 @@ jest.mock("@/lib/prisma", () => ({
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  buildAccessiblePullRequestWhere: jest.fn(),
+  getRepositoryPrimaryUser: jest.fn(),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedGetOctokit = getOctokit as jest.Mock
 const mockedFindFirst = prisma.pullRequest.findFirst as jest.Mock
 const mockedUpdate = prisma.pullRequest.update as jest.Mock
+const mockedBuildAccessiblePullRequestWhere =
+  buildAccessiblePullRequestWhere as jest.Mock
+const mockedGetRepositoryPrimaryUser = getRepositoryPrimaryUser as jest.Mock
 
 const createRequest = () => new Request("http://localhost/api/pulls/pr-1")
 const createParams = (id = "pr-1") =>
@@ -55,7 +67,7 @@ describe("GET /api/pulls/[id]", () => {
     jest.clearAllMocks()
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const response = await GET(createRequest(), createParams())
@@ -65,19 +77,31 @@ describe("GET /api/pulls/[id]", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("존재하지 않는 PR은 404를 반환한다", async () => {
+  it("returns 404 when the PR does not exist", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedFindFirst.mockResolvedValue(null)
 
     const response = await GET(createRequest(), createParams())
     const body = await response.json()
 
     expect(response.status).toBe(404)
-    expect(body.error).toBe("PR을 찾을 수 없습니다.")
+    expect(body.error).toBe("Pull request not found")
   })
 
-  it("정상 조회 시 PR 상세를 반환하고 githubId를 Number로 직렬화한다", async () => {
+  it("serializes githubId and returns repository owner info", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
+    mockedGetRepositoryPrimaryUser.mockResolvedValue({
+      id: "user-1",
+      name: "Owner",
+      image: null,
+      githubToken: "token",
+    })
     mockedFindFirst.mockResolvedValue(samplePR)
 
     const response = await GET(createRequest(), createParams())
@@ -90,10 +114,17 @@ describe("GET /api/pulls/[id]", () => {
     expect(body.deletions).toBe(20)
     expect(body.changedFiles).toBe(5)
     expect(body.reviews).toEqual([])
+    expect(body.repo.owner).toEqual(
+      expect.objectContaining({ id: "user-1", name: "Owner" })
+    )
   })
 
-  it("additions/deletions/changedFiles가 모두 0이면 GitHub API로 보정한다", async () => {
+  it("hydrates code change counts from GitHub when stored values are zero", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
+    mockedGetRepositoryPrimaryUser.mockResolvedValue(null)
     mockedFindFirst.mockResolvedValue({
       ...samplePR,
       additions: 0,
@@ -125,8 +156,12 @@ describe("GET /api/pulls/[id]", () => {
     })
   })
 
-  it("GitHub API 보정 실패 시 0값 그대로 반환한다", async () => {
+  it("keeps zero values when GitHub hydration fails", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
+    mockedGetRepositoryPrimaryUser.mockResolvedValue(null)
     mockedFindFirst.mockResolvedValue({
       ...samplePR,
       additions: 0,
@@ -144,9 +179,9 @@ describe("GET /api/pulls/[id]", () => {
     expect(body.changedFiles).toBe(0)
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
-    mockedFindFirst.mockRejectedValue(new Error("DB error"))
+    mockedBuildAccessiblePullRequestWhere.mockRejectedValue(new Error("DB error"))
 
     const response = await GET(createRequest(), createParams())
     const body = await response.json()

--- a/__tests__/api/pulls/route.test.ts
+++ b/__tests__/api/pulls/route.test.ts
@@ -1,6 +1,7 @@
 import { GET } from "@/app/api/pulls/route"
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { buildAccessiblePullRequestWhere } from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -15,9 +16,15 @@ jest.mock("@/lib/prisma", () => ({
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  buildAccessiblePullRequestWhere: jest.fn(),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedCount = prisma.pullRequest.count as jest.Mock
 const mockedFindMany = prisma.pullRequest.findMany as jest.Mock
+const mockedBuildAccessiblePullRequestWhere =
+  buildAccessiblePullRequestWhere as jest.Mock
 
 function createRequest(params?: Record<string, string>) {
   const url = new URL("http://localhost/api/pulls")
@@ -29,7 +36,7 @@ function createRequest(params?: Record<string, string>) {
 
 const samplePR = {
   id: "pr-1",
-  githubId: 1001,
+  githubId: BigInt(1001),
   number: 45,
   title: "feat: Implement real-time monitoring",
   description: null,
@@ -54,7 +61,7 @@ describe("GET /api/pulls", () => {
     jest.clearAllMocks()
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const response = await GET(createRequest())
@@ -64,8 +71,11 @@ describe("GET /api/pulls", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("기본 조회 시 pagination과 함께 PR 목록을 반환한다", async () => {
+  it("returns paginated pull requests", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedCount.mockResolvedValue(1)
     mockedFindMany.mockResolvedValue([samplePR])
 
@@ -75,36 +85,38 @@ describe("GET /api/pulls", () => {
     expect(response.status).toBe(200)
     expect(body.pullRequests).toHaveLength(1)
     expect(body.pullRequests[0].title).toBe("feat: Implement real-time monitoring")
+    expect(body.pullRequests[0].githubId).toBe(1001)
     expect(body.pagination).toEqual({ total: 1, page: 1, limit: 20, totalPages: 1 })
     expect(mockedFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { repo: { userId: "user-1" } },
-        orderBy: [
-          { githubCreatedAt: { sort: "desc", nulls: "last" } },
-          { number: "desc" },
-        ],
+        where: { repoId: { in: ["repo-1"] } },
         skip: 0,
         take: 20,
       })
     )
   })
 
-  it("repoId 파라미터로 저장소 필터링이 동작한다", async () => {
+  it("passes repoId into the accessibility filter", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedCount.mockResolvedValue(1)
     mockedFindMany.mockResolvedValue([samplePR])
 
     await GET(createRequest({ repoId: "repo-1" }))
 
-    expect(mockedFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { repo: { userId: "user-1" }, repoId: "repo-1" },
-      })
+    expect(mockedBuildAccessiblePullRequestWhere).toHaveBeenCalledWith(
+      "user-1",
+      "repo-1"
     )
   })
 
-  it("status 파라미터로 상태 필터링이 동작한다", async () => {
+  it("applies status filters on top of accessible PR filters", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedCount.mockResolvedValue(1)
     mockedFindMany.mockResolvedValue([samplePR])
 
@@ -112,23 +124,26 @@ describe("GET /api/pulls", () => {
 
     expect(mockedFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { repo: { userId: "user-1" }, status: "OPEN" },
+        where: { repoId: { in: ["repo-1"] }, status: "OPEN" },
       })
     )
   })
 
-  it("유효하지 않은 status 값은 400을 반환한다", async () => {
+  it("returns 400 for invalid statuses", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
 
     const response = await GET(createRequest({ status: "INVALID" }))
     const body = await response.json()
 
     expect(response.status).toBe(400)
-    expect(body.error).toContain("유효하지 않은")
+    expect(body.error).toContain("Invalid status")
   })
 
-  it("page/limit 파라미터로 페이지네이션이 동작한다", async () => {
+  it("supports page and limit parameters", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedCount.mockResolvedValue(50)
     mockedFindMany.mockResolvedValue([])
 
@@ -142,8 +157,11 @@ describe("GET /api/pulls", () => {
     )
   })
 
-  it("limit은 최대 50을 초과할 수 없다", async () => {
+  it("caps limit at 50", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessiblePullRequestWhere.mockResolvedValue({
+      repoId: { in: ["repo-1"] },
+    })
     mockedCount.mockResolvedValue(0)
     mockedFindMany.mockResolvedValue([])
 
@@ -154,9 +172,9 @@ describe("GET /api/pulls", () => {
     )
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
-    mockedCount.mockRejectedValue(new Error("DB error"))
+    mockedBuildAccessiblePullRequestWhere.mockRejectedValue(new Error("DB error"))
 
     const response = await GET(createRequest())
     const body = await response.json()

--- a/__tests__/api/repositories/[id]/route.test.ts
+++ b/__tests__/api/repositories/[id]/route.test.ts
@@ -1,6 +1,12 @@
 import { DELETE } from "@/app/api/repositories/[id]/route"
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import {
+  detachRepositoryFromUser,
+  getRepositoryMemberCount,
+  isRepositoryAccessibleToUser,
+  isRepositoryMembershipMigrationError,
+} from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -19,9 +25,22 @@ jest.mock("@/lib/prisma", () => ({
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  detachRepositoryFromUser: jest.fn(),
+  getRepositoryMemberCount: jest.fn(),
+  isRepositoryAccessibleToUser: jest.fn(),
+  isRepositoryMembershipMigrationError: jest.fn(() => false),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedFindUnique = prisma.repository.findUnique as jest.Mock
 const mockedDelete = prisma.repository.delete as jest.Mock
+const mockedDetachRepositoryFromUser = detachRepositoryFromUser as jest.Mock
+const mockedGetRepositoryMemberCount = getRepositoryMemberCount as jest.Mock
+const mockedIsRepositoryAccessibleToUser =
+  isRepositoryAccessibleToUser as jest.Mock
+const mockedIsRepositoryMembershipMigrationError =
+  isRepositoryMembershipMigrationError as jest.Mock
 
 function createRequest(id: string) {
   return {
@@ -35,15 +54,18 @@ function createRequest(id: string) {
 describe("DELETE /api/repositories/[id]", () => {
   afterEach(() => {
     jest.clearAllMocks()
+    mockedIsRepositoryMembershipMigrationError.mockReturnValue(false)
   })
 
-  it("Repository 해제에 성공하면 200을 반환한다", async () => {
+  it("removes the repository record when this user is the last member", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
     mockedFindUnique.mockResolvedValue({
       id: "repo-1",
-      githubId: 12345,
-      userId: "user-1",
+      fullName: "user/repo-1",
+      webhookId: null,
     })
+    mockedIsRepositoryAccessibleToUser.mockResolvedValue(true)
+    mockedGetRepositoryMemberCount.mockResolvedValue(1)
     mockedDelete.mockResolvedValue({})
 
     const { request, params } = createRequest("repo-1")
@@ -51,11 +73,11 @@ describe("DELETE /api/repositories/[id]", () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body.message).toContain("해제")
+    expect(body.message).toContain("removed")
     expect(mockedDelete).toHaveBeenCalledWith({ where: { id: "repo-1" } })
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const { request, params } = createRequest("repo-1")
@@ -66,35 +88,60 @@ describe("DELETE /api/repositories/[id]", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("존재하지 않는 Repository는 404를 반환한다", async () => {
+  it("returns 404 when the repository does not exist", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
     mockedFindUnique.mockResolvedValue(null)
 
-    const { request, params } = createRequest("nonexistent")
+    const { request, params } = createRequest("missing")
     const response = await DELETE(request, { params })
     const body = await response.json()
 
     expect(response.status).toBe(404)
-    expect(body.error).toContain("찾을 수 없습니다")
+    expect(body.error).toContain("not found")
   })
 
-  it("다른 사용자의 Repository는 403을 반환한다", async () => {
+  it("returns 403 when the user is not connected to the repository", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
     mockedFindUnique.mockResolvedValue({
       id: "repo-1",
-      githubId: 12345,
-      userId: "user-2",
+      fullName: "user/repo-1",
+      webhookId: null,
     })
+    mockedIsRepositoryAccessibleToUser.mockResolvedValue(false)
 
     const { request, params } = createRequest("repo-1")
     const response = await DELETE(request, { params })
     const body = await response.json()
 
     expect(response.status).toBe(403)
-    expect(body.error).toContain("권한")
+    expect(body.error).toBe("Forbidden")
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("removes only the membership when other members remain", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue({
+      id: "repo-1",
+      fullName: "user/repo-1",
+      webhookId: null,
+    })
+    mockedIsRepositoryAccessibleToUser.mockResolvedValue(true)
+    mockedGetRepositoryMemberCount.mockResolvedValue(2)
+    mockedDetachRepositoryFromUser.mockResolvedValue(undefined)
+
+    const { request, params } = createRequest("repo-1")
+    const response = await DELETE(request, { params })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.message).toContain("connection removed")
+    expect(mockedDetachRepositoryFromUser).toHaveBeenCalledWith(
+      "user-1",
+      "repo-1"
+    )
+    expect(mockedDelete).not.toHaveBeenCalled()
+  })
+
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
     mockedFindUnique.mockRejectedValue(new Error("DB error"))
 

--- a/__tests__/api/repositories/route.test.ts
+++ b/__tests__/api/repositories/route.test.ts
@@ -2,6 +2,10 @@ import { POST } from "@/app/api/repositories/route"
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  connectRepositoryToUser,
+  isRepositoryMembershipMigrationError,
+} from "@/lib/repository-access"
 
 jest.mock("@/lib/auth", () => ({
   auth: jest.fn(),
@@ -14,17 +18,32 @@ jest.mock("@/lib/github", () => ({
 jest.mock("@/lib/prisma", () => ({
   prisma: {
     repository: {
-      findFirst: jest.fn(),
+      findUnique: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+    },
+    pullRequest: {
+      count: jest.fn(),
+      createMany: jest.fn(),
     },
   },
 }))
 
+jest.mock("@/lib/repository-access", () => ({
+  connectRepositoryToUser: jest.fn(),
+  isRepositoryMembershipMigrationError: jest.fn(() => false),
+}))
+
 const mockedAuth = auth as jest.Mock
 const mockedGetOctokit = getOctokit as jest.Mock
-const mockedFindFirst = prisma.repository.findFirst as jest.Mock
+const mockedFindUnique = prisma.repository.findUnique as jest.Mock
 const mockedCreate = prisma.repository.create as jest.Mock
+const mockedUpdate = prisma.repository.update as jest.Mock
+const mockedCount = prisma.pullRequest.count as jest.Mock
+const mockedCreateMany = prisma.pullRequest.createMany as jest.Mock
+const mockedConnectRepositoryToUser = connectRepositoryToUser as jest.Mock
+const mockedIsRepositoryMembershipMigrationError =
+  isRepositoryMembershipMigrationError as jest.Mock
 
 function createRequest(body: object) {
   return new Request("http://localhost/api/repositories", {
@@ -37,11 +56,14 @@ function createRequest(body: object) {
 describe("POST /api/repositories", () => {
   afterEach(() => {
     jest.clearAllMocks()
+    mockedIsRepositoryMembershipMigrationError.mockReturnValue(false)
   })
 
-  it("Repository 연동에 성공하면 201을 반환한다", async () => {
+  it("creates a repository connection", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
-    mockedFindFirst.mockResolvedValue(null)
+    mockedFindUnique.mockResolvedValue(null)
+    mockedCount.mockResolvedValue(0)
+    mockedCreateMany.mockResolvedValue({ count: 0 })
     mockedGetOctokit.mockResolvedValue({
       rest: {
         repos: {
@@ -52,21 +74,24 @@ describe("POST /api/repositories", () => {
         },
       },
     })
-
-    const created = {
+    mockedCreate.mockResolvedValue({
       id: "repo-1",
       githubId: BigInt(12345),
       name: "my-repo",
       fullName: "user/my-repo",
       description: null,
       language: "TypeScript",
-      isActive: true,
       webhookId: null,
-      userId: "user-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }
-    mockedCreate.mockResolvedValue(created)
+    })
+    mockedUpdate.mockResolvedValue({
+      id: "repo-1",
+      githubId: BigInt(12345),
+      name: "my-repo",
+      fullName: "user/my-repo",
+      description: null,
+      language: "TypeScript",
+      webhookId: 9999,
+    })
 
     const response = await POST(
       createRequest({
@@ -79,12 +104,14 @@ describe("POST /api/repositories", () => {
     const body = await response.json()
 
     expect(response.status).toBe(201)
-    expect(body.repository).toEqual(expect.objectContaining({
-      id: "repo-1",
-      githubId: 12345,
-      name: "my-repo",
-      fullName: "user/my-repo",
-    }))
+    expect(body.repository).toEqual(
+      expect.objectContaining({
+        id: "repo-1",
+        githubId: 12345,
+        name: "my-repo",
+        fullName: "user/my-repo",
+      })
+    )
     expect(mockedCreate).toHaveBeenCalledWith({
       data: {
         githubId: BigInt(12345),
@@ -92,12 +119,17 @@ describe("POST /api/repositories", () => {
         fullName: "user/my-repo",
         description: null,
         language: "TypeScript",
-        userId: "user-1",
+        userRepositories: {
+          create: {
+            userId: "user-1",
+          },
+        },
       },
+      select: expect.any(Object),
     })
   })
 
-  it("미인증 사용자는 401을 반환한다", async () => {
+  it("returns 401 for anonymous users", async () => {
     mockedAuth.mockResolvedValue(null)
 
     const response = await POST(
@@ -109,19 +141,28 @@ describe("POST /api/repositories", () => {
     expect(body.error).toBe("Unauthorized")
   })
 
-  it("필수 필드가 누락되면 400을 반환한다", async () => {
+  it("returns 400 when required fields are missing", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
 
     const response = await POST(createRequest({ githubId: 12345 }))
     const body = await response.json()
 
     expect(response.status).toBe(400)
-    expect(body.error).toContain("필수")
+    expect(body.error).toContain("required")
   })
 
-  it("이미 연동된 Repository는 409를 반환한다", async () => {
+  it("returns 409 when the repository is already connected", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
-    mockedFindFirst.mockResolvedValue({ id: "existing-repo", githubId: BigInt(12345) })
+    mockedFindUnique.mockResolvedValue({
+      id: "existing-repo",
+      githubId: BigInt(12345),
+      name: "repo",
+      fullName: "user/repo",
+      description: null,
+      language: null,
+      webhookId: null,
+    })
+    mockedConnectRepositoryToUser.mockResolvedValue("existing")
 
     const response = await POST(
       createRequest({ githubId: 12345, name: "repo", fullName: "user/repo" })
@@ -129,12 +170,12 @@ describe("POST /api/repositories", () => {
     const body = await response.json()
 
     expect(response.status).toBe(409)
-    expect(body.error).toContain("이미 연동")
+    expect(body.error).toContain("already connected")
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
-    mockedFindFirst.mockRejectedValue(new Error("DB error"))
+    mockedFindUnique.mockRejectedValue(new Error("DB error"))
 
     const response = await POST(
       createRequest({ githubId: 12345, name: "repo", fullName: "user/repo" })

--- a/__tests__/api/review/analyze/route.test.ts
+++ b/__tests__/api/review/analyze/route.test.ts
@@ -1,11 +1,11 @@
 import { POST } from "@/app/api/review/analyze/route"
 import { prisma } from "@/lib/prisma"
 import * as analyzeModule from "@/lib/ai/analyze"
+import { getRepositoryMemberIds } from "@/lib/repository-access"
 
 jest.mock("@/lib/prisma", () => ({
   prisma: {
     pullRequest: { findUnique: jest.fn() },
-    review: { create: jest.fn(), findUnique: jest.fn() },
     notification: { create: jest.fn() },
   },
 }))
@@ -19,12 +19,17 @@ jest.mock("@/lib/socket/emitter", () => ({
 }))
 
 jest.mock("@/lib/notification-settings", () => ({
-  isNotificationEnabled: jest.fn().mockResolvedValue(true),
+  getEnabledUserIds: jest.fn().mockResolvedValue(["user-1"]),
+}))
+
+jest.mock("@/lib/repository-access", () => ({
+  getRepositoryMemberIds: jest.fn().mockResolvedValue(["user-1"]),
 }))
 
 const mockedFindUnique = prisma.pullRequest.findUnique as jest.Mock
-const mockedReviewCreate = prisma.review.create as jest.Mock
+const mockedNotificationCreate = prisma.notification.create as jest.Mock
 const mockedAnalyze = analyzeModule.analyzeReview as jest.Mock
+const mockedGetRepositoryMemberIds = getRepositoryMemberIds as jest.Mock
 
 function makeRequest(body: object) {
   return new Request("http://localhost/api/review/analyze", {
@@ -37,27 +42,37 @@ function makeRequest(body: object) {
 const mockPR = {
   id: "pr-1",
   title: "Fix bug",
-  repo: { userId: "user-1" },
+  repoId: "repo-1",
 }
 
 describe("POST /api/review/analyze", () => {
   afterEach(() => jest.clearAllMocks())
 
-  it("유효한 pullRequestId로 리뷰 분석을 백그라운드에서 실행하고 PENDING을 반환한다", async () => {
+  it("starts review analysis and returns PENDING", async () => {
     mockedFindUnique.mockResolvedValue(mockPR)
-    mockedReviewCreate.mockResolvedValue({ id: "review-1" })
     mockedAnalyze.mockResolvedValue(undefined)
+    mockedNotificationCreate.mockResolvedValue({
+      id: "notif-1",
+      type: "NEW_REVIEW",
+      title: "AI review is ready",
+      message: "done",
+      isRead: false,
+      userId: "user-1",
+      prId: "pr-1",
+      commentId: null,
+      createdAt: new Date(),
+    })
 
     const res = await POST(makeRequest({ pullRequestId: "pr-1" }))
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body.reviewId).toBe("review-1")
     expect(body.status).toBe("PENDING")
     expect(mockedAnalyze).toHaveBeenCalledWith("pr-1")
+    expect(mockedGetRepositoryMemberIds).toHaveBeenCalledWith("repo-1")
   })
 
-  it("pullRequestId 없으면 400을 반환한다", async () => {
+  it("returns 400 when pullRequestId is missing", async () => {
     const res = await POST(makeRequest({}))
     const body = await res.json()
 
@@ -66,17 +81,17 @@ describe("POST /api/review/analyze", () => {
     expect(mockedAnalyze).not.toHaveBeenCalled()
   })
 
-  it("존재하지 않는 pullRequestId면 404를 반환한다", async () => {
+  it("returns 404 when the pull request does not exist", async () => {
     mockedFindUnique.mockResolvedValue(null)
 
     const res = await POST(makeRequest({ pullRequestId: "not-exist" }))
     const body = await res.json()
 
     expect(res.status).toBe(404)
-    expect(body.error).toBe("PullRequest not found")
+    expect(body.error).toBe("Pull request not found")
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedFindUnique.mockRejectedValue(new Error("DB error"))
 
     const res = await POST(makeRequest({ pullRequestId: "pr-1" }))

--- a/__tests__/api/webhook/github/route.test.ts
+++ b/__tests__/api/webhook/github/route.test.ts
@@ -3,11 +3,11 @@ import { prisma } from "@/lib/prisma"
 import * as webhookValidator from "@/lib/webhook-validator"
 import * as analyzeModule from "@/lib/ai/analyze"
 import * as emitterModule from "@/lib/socket/emitter"
+import { getRepositoryMemberIds } from "@/lib/repository-access"
 import crypto from "crypto"
 
-// after()는 콜백을 큐에 저장 → flushAfter()로 수동 실행
-// POST가 after() 완료를 기다리지 않으므로 직접 flush해야 비동기 결과 검증 가능
 const afterQueue: Array<() => Promise<void>> = []
+
 async function flushAfter() {
   for (const fn of afterQueue) await fn()
   afterQueue.length = 0
@@ -17,7 +17,9 @@ jest.mock("next/server", () => {
   const actual = jest.requireActual("next/server")
   return {
     ...actual,
-    after: jest.fn((fn: () => Promise<void>) => { afterQueue.push(fn) }),
+    after: jest.fn((fn: () => Promise<void>) => {
+      afterQueue.push(fn)
+    }),
   }
 })
 
@@ -42,7 +44,11 @@ jest.mock("@/lib/socket/emitter", () => ({
 }))
 
 jest.mock("@/lib/notification-settings", () => ({
-  isNotificationEnabled: jest.fn().mockResolvedValue(true),
+  getEnabledUserIds: jest.fn(async (userIds: string[]) => userIds),
+}))
+
+jest.mock("@/lib/repository-access", () => ({
+  getRepositoryMemberIds: jest.fn(),
 }))
 
 const mockedVerify = webhookValidator.verifyWebhookSignature as jest.Mock
@@ -50,6 +56,7 @@ const mockedFindFirst = prisma.repository.findFirst as jest.Mock
 const mockedUpsert = prisma.pullRequest.upsert as jest.Mock
 const mockedAnalyzeReview = analyzeModule.analyzeReview as jest.Mock
 const mockedEmitNotification = emitterModule.emitNotification as jest.Mock
+const mockedGetRepositoryMemberIds = getRepositoryMemberIds as jest.Mock
 
 function makeSignature(payload: string): string {
   const hmac = crypto.createHmac("sha256", "test-secret")
@@ -94,12 +101,13 @@ const prPayload = {
 describe("POST /api/webhook/github", () => {
   beforeEach(() => {
     mockedVerify.mockResolvedValue(true)
-    mockedFindFirst.mockResolvedValue({ id: "repo-1", userId: "user-1" })
+    mockedFindFirst.mockResolvedValue({ id: "repo-1" })
     mockedUpsert.mockResolvedValue({ id: "pr-1" })
+    mockedGetRepositoryMemberIds.mockResolvedValue(["user-1"])
     ;(prisma.notification.create as jest.Mock).mockResolvedValue({
       id: "notif-1",
       type: "NEW_REVIEW",
-      title: "AI 코드 리뷰가 완료되었습니다",
+      title: "AI review is ready",
       message: null,
       isRead: false,
       userId: "user-1",
@@ -114,7 +122,7 @@ describe("POST /api/webhook/github", () => {
     afterQueue.length = 0
   })
 
-  it("유효한 PR opened 이벤트에 200으로 즉시 응답한다", async () => {
+  it("returns 200 immediately for a valid opened event", async () => {
     const response = await POST(createRequest(prPayload))
     const body = await response.json()
 
@@ -122,22 +130,25 @@ describe("POST /api/webhook/github", () => {
     expect(body.message).toBe("PR processed")
   })
 
-  it("after() 안에서 analyzeReview를 호출한다 (PENDING 생성은 analyzeReview 내부 책임)", async () => {
+  it("calls analyzeReview inside after()", async () => {
     await POST(createRequest(prPayload))
     await flushAfter()
 
     expect(mockedAnalyzeReview).toHaveBeenCalledWith("pr-1")
-    // webhook이 직접 review.create를 호출하지 않음
-    expect(prisma.notification.create).toHaveBeenCalledTimes(1) // NEW_REVIEW 알림만
+    expect(prisma.notification.create).toHaveBeenCalledTimes(1)
   })
 
-  it("analyzeReview 성공 시 NEW_REVIEW 알림을 발송한다", async () => {
+  it("sends NEW_REVIEW notifications after successful analysis", async () => {
     await POST(createRequest(prPayload))
     await flushAfter()
 
     expect(prisma.notification.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ type: "NEW_REVIEW", userId: "user-1", prId: "pr-1" }),
+        data: expect.objectContaining({
+          type: "NEW_REVIEW",
+          userId: "user-1",
+          prId: "pr-1",
+        }),
       })
     )
     expect(mockedEmitNotification).toHaveBeenCalledWith(
@@ -146,12 +157,12 @@ describe("POST /api/webhook/github", () => {
     )
   })
 
-  it("analyzeReview 실패 시 REVIEW_FAILED 알림을 발송한다", async () => {
+  it("sends REVIEW_FAILED notifications when analysis fails", async () => {
     mockedAnalyzeReview.mockRejectedValueOnce(new Error("Claude timeout"))
     ;(prisma.notification.create as jest.Mock).mockResolvedValue({
       id: "notif-fail",
       type: "REVIEW_FAILED",
-      title: "AI 코드 리뷰에 실패했습니다",
+      title: "AI review failed",
       message: null,
       isRead: false,
       userId: "user-1",
@@ -163,7 +174,6 @@ describe("POST /api/webhook/github", () => {
     const response = await POST(createRequest(prPayload))
     await flushAfter()
 
-    // 분석 실패여도 webhook 응답은 200
     expect(response.status).toBe(200)
     expect(prisma.notification.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -176,7 +186,7 @@ describe("POST /api/webhook/github", () => {
     )
   })
 
-  it("잘못된 서명이면 401을 반환한다", async () => {
+  it("returns 401 for invalid signatures", async () => {
     mockedVerify.mockResolvedValue(false)
 
     const response = await POST(createRequest(prPayload, "pull_request", false))
@@ -186,7 +196,7 @@ describe("POST /api/webhook/github", () => {
     expect(body.error).toBe("Invalid webhook signature")
   })
 
-  it("pull_request 외 이벤트는 200으로 무시한다", async () => {
+  it("ignores non pull_request events", async () => {
     const response = await POST(createRequest({ zen: "Keep it simple" }, "ping"))
     const body = await response.json()
 
@@ -195,7 +205,7 @@ describe("POST /api/webhook/github", () => {
     expect(mockedUpsert).not.toHaveBeenCalled()
   })
 
-  it("opened/synchronize/closed 외 action은 무시한다", async () => {
+  it("ignores unsupported pull_request actions", async () => {
     const response = await POST(createRequest({ ...prPayload, action: "labeled" }))
     const body = await response.json()
 
@@ -204,11 +214,11 @@ describe("POST /api/webhook/github", () => {
     expect(mockedUpsert).not.toHaveBeenCalled()
   })
 
-  it("closed action은 PR 상태 변경을 처리하고 PR_MERGED 알림을 생성한다", async () => {
+  it("creates PR_MERGED notifications for closed actions", async () => {
     ;(prisma.notification.create as jest.Mock).mockResolvedValue({
       id: "notif-1",
       type: "PR_MERGED",
-      title: "PR이 닫혔습니다",
+      title: "PR merged",
       message: null,
       isRead: false,
       userId: "user-1",
@@ -230,12 +240,12 @@ describe("POST /api/webhook/github", () => {
     expect(body.message).toBe("PR status processed")
     expect(prisma.notification.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ type: "PR_MERGED" }),
+        data: expect.objectContaining({ type: "PR_MERGED", userId: "user-1" }),
       })
     )
   })
 
-  it("연동되지 않은 Repository의 이벤트는 404를 반환한다", async () => {
+  it("returns 404 when the repository is not connected", async () => {
     mockedFindFirst.mockResolvedValue(null)
 
     const response = await POST(createRequest(prPayload))
@@ -245,7 +255,7 @@ describe("POST /api/webhook/github", () => {
     expect(body.error).toBe("Repository not found")
   })
 
-  it("draft PR은 DRAFT 상태로 저장한다", async () => {
+  it("stores draft PRs with DRAFT status", async () => {
     const draftPayload = {
       ...prPayload,
       pull_request: { ...prPayload.pull_request, draft: true },
@@ -260,7 +270,7 @@ describe("POST /api/webhook/github", () => {
     )
   })
 
-  it("서버 에러 시 500을 반환한다", async () => {
+  it("returns 500 on unexpected errors", async () => {
     mockedVerify.mockRejectedValue(new Error("unexpected"))
 
     const response = await POST(createRequest(prPayload))

--- a/app/(protected)/stats/page.tsx
+++ b/app/(protected)/stats/page.tsx
@@ -2,21 +2,23 @@ import type { Metadata } from "next"
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
 import { fetchStatsOverview } from "@/lib/stats"
+import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
 import StatsClient from "@/components/stats/StatsClient"
 
 export const metadata: Metadata = {
   title: "코드 통계",
-  description: "코드 품질 지표 및 리뷰 통계를 분석하세요",
+  description: "코드 품질 지표와 리뷰 통계를 분석합니다.",
 }
 
 export default async function StatsPage() {
   const session = await auth()
   if (!session?.user?.id) return null
+  const repositoryWhere = await buildAccessibleRepositoryWhere(session.user.id)
 
   const [overview, repos] = await Promise.all([
     fetchStatsOverview(session.user.id, "30d"),
     prisma.repository.findMany({
-      where: { userId: session.user.id },
+      where: repositoryWhere,
       select: { id: true, name: true, fullName: true },
       orderBy: { name: "asc" },
     }),

--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,49 +1,8 @@
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/comments:
- *   get:
- *     summary: 전체 댓글 목록 조회
- *     description: 현재 사용자 소유 저장소의 댓글 목록을 필터/페이지네이션과 함께 반환합니다.
- *     tags:
- *       - Comment
- *     parameters:
- *       - in: query
- *         name: repoId
- *         schema:
- *           type: string
- *         description: 저장소 ID 필터
- *       - in: query
- *         name: prId
- *         schema:
- *           type: string
- *         description: PR ID 필터
- *       - in: query
- *         name: authorId
- *         schema:
- *           type: string
- *         description: 작성자 ID 필터
- *       - in: query
- *         name: page
- *         schema:
- *           type: integer
- *           default: 1
- *       - in: query
- *         name: limit
- *         schema:
- *           type: integer
- *           default: 20
- *     responses:
- *       200:
- *         description: 댓글 목록 조회 성공
- *       401:
- *         description: 인증되지 않은 사용자
- *       500:
- *         description: 서버 내부 오류
- */
 export async function GET(request: Request) {
   try {
     const session = await auth()
@@ -57,12 +16,15 @@ export async function GET(request: Request) {
     const authorId = searchParams.get("authorId") ?? undefined
     const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10))
     const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") ?? "20", 10)))
+    const repositoryWhere = await buildAccessibleRepositoryWhere(
+      session.user.id,
+      repoId
+    )
 
     const where = {
       parentId: null,
       pullRequest: {
-        repo: { userId: session.user.id },
-        ...(repoId && { repoId }),
+        repo: repositoryWhere,
       },
       ...(prId && { pullRequestId: prId }),
       ...(authorId && { authorId }),

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,54 +1,12 @@
 import { auth } from "@/lib/auth"
 import { getAuthenticatedOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  buildAccessibleRepositoryWhere,
+  isRepositoryMembershipMigrationError,
+} from "@/lib/repository-access"
 import { NextRequest, NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/github/repos:
- *   get:
- *     summary: GitHub Repository 목록 조회
- *     description: 인증된 사용자의 GitHub Repository 목록을 반환하며, CodeMate 연동 여부를 포함합니다.
- *     tags:
- *       - GitHub
- *     parameters:
- *       - in: query
- *         name: page
- *         schema:
- *           type: integer
- *           default: 1
- *       - in: query
- *         name: per_page
- *         schema:
- *           type: integer
- *           default: 20
- *     responses:
- *       200:
- *         description: Repository 목록 반환 성공
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 repos:
- *                   type: array
- *                   items:
- *                     $ref: '#/components/schemas/GitHubRepo'
- *                 pagination:
- *                   $ref: '#/components/schemas/RepoPagination'
- *       401:
- *         description: 인증되지 않은 사용자
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: 서버 내부 오류
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- */
 export async function GET(req: NextRequest) {
   try {
     const session = await auth()
@@ -71,11 +29,19 @@ export async function GET(req: NextRequest) {
 
     const hasNextPage = !!headers.link?.includes('rel="next"')
 
+    const repositoryWhere = await buildAccessibleRepositoryWhere(session.user.id)
+
     const connectedRepos = await prisma.repository.findMany({
-      where: { userId: session.user.id },
-      select: { githubId: true, id: true },
+      where: repositoryWhere,
+      select: {
+        githubId: true,
+        id: true,
+      },
     })
-    const connectedMap = new Map(connectedRepos.map((r) => [r.githubId, r.id]))
+
+    const connectedMap = new Map(
+      connectedRepos.map((repository) => [repository.githubId, repository.id])
+    )
 
     const repos = data.map((repo) => ({
       id: repo.id,
@@ -90,7 +56,29 @@ export async function GET(req: NextRequest) {
       repos,
       pagination: { page, perPage, hasNextPage },
     })
-  } catch {
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "status" in error &&
+      error.status === 401
+    ) {
+      return NextResponse.json(
+        { error: "GitHub authorization expired. Please reconnect GitHub." },
+        { status: 401 }
+      )
+    }
+
+    if (isRepositoryMembershipMigrationError(error)) {
+      return NextResponse.json(
+        {
+          error:
+            'Shared repository migration is not applied. Run the "split_repository_membership" migration first.',
+        },
+        { status: 503 }
+      )
+    }
+
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/app/api/pulls/[id]/comments/route.ts
+++ b/app/api/pulls/[id]/comments/route.ts
@@ -1,33 +1,42 @@
 import { auth } from "@/lib/auth"
+import { getEnabledUserIds } from "@/lib/notification-settings"
 import { prisma } from "@/lib/prisma"
-import { NextResponse } from "next/server"
+import {
+  buildAccessiblePullRequestWhere,
+  getRepositoryMemberIds,
+} from "@/lib/repository-access"
 import { emitCommentNew, emitNotification } from "@/lib/socket/emitter"
-import { isNotificationEnabled, getEnabledUserIds } from "@/lib/notification-settings"
+import { NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/pulls/{id}/comments:
- *   get:
- *     summary: 댓글 목록 조회
- *     description: PR의 루트 댓글 목록을 replies 중첩 포함하여 반환합니다.
- *     tags:
- *       - Comment
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: 댓글 목록 조회 성공
- *       401:
- *         description: 인증되지 않은 사용자
- *       404:
- *         description: PR을 찾을 수 없음
- *       500:
- *         description: 서버 내부 오류
- */
+async function createNotificationsForUsers(params: {
+  userIds: string[]
+  type: "MENTION" | "COMMENT_REPLY"
+  title: string
+  message: string
+  prId: string
+  commentId: string
+}) {
+  await Promise.all(
+    params.userIds.map(async (userId) => {
+      const notification = await prisma.notification.create({
+        data: {
+          type: params.type,
+          title: params.title,
+          message: params.message,
+          userId,
+          prId: params.prId,
+          commentId: params.commentId,
+        },
+      })
+
+      emitNotification(userId, {
+        ...notification,
+        createdAt: notification.createdAt.toISOString(),
+      })
+    })
+  )
+}
+
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -39,13 +48,19 @@ export async function GET(
     }
 
     const { id } = await params
+    const pullRequestWhere = await buildAccessiblePullRequestWhere(
+      session.user.id
+    )
 
     const pr = await prisma.pullRequest.findFirst({
-      where: { id, repo: { userId: session.user.id } },
+      where: {
+        id,
+        ...pullRequestWhere,
+      },
       select: { id: true },
     })
     if (!pr) {
-      return NextResponse.json({ error: "PR을 찾을 수 없습니다." }, { status: 404 })
+      return NextResponse.json({ error: "Pull request not found" }, { status: 404 })
     }
 
     const comments = await prisma.comment.findMany({
@@ -69,30 +84,6 @@ export async function GET(
   }
 }
 
-/**
- * @swagger
- * /api/pulls/{id}/comments:
- *   post:
- *     summary: 댓글 작성
- *     description: PR에 댓글을 작성합니다. 멘션 포함 시 Notification을 생성합니다.
- *     tags:
- *       - Comment
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       201:
- *         description: 댓글 작성 성공
- *       401:
- *         description: 인증되지 않은 사용자
- *       404:
- *         description: PR을 찾을 수 없음
- *       500:
- *         description: 서버 내부 오류
- */
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -104,13 +95,23 @@ export async function POST(
     }
 
     const { id } = await params
+    const pullRequestWhere = await buildAccessiblePullRequestWhere(
+      session.user.id
+    )
 
     const pr = await prisma.pullRequest.findFirst({
-      where: { id, repo: { userId: session.user.id } },
-      select: { id: true, title: true, repo: { select: { userId: true } } },
+      where: {
+        id,
+        ...pullRequestWhere,
+      },
+      select: {
+        id: true,
+        title: true,
+        repoId: true,
+      },
     })
     if (!pr) {
-      return NextResponse.json({ error: "PR을 찾을 수 없습니다." }, { status: 404 })
+      return NextResponse.json({ error: "Pull request not found" }, { status: 404 })
     }
 
     const body = await request.json()
@@ -123,7 +124,7 @@ export async function POST(
     }
 
     if (!content?.trim()) {
-      return NextResponse.json({ error: "댓글 내용을 입력해주세요." }, { status: 400 })
+      return NextResponse.json({ error: "Content is required." }, { status: 400 })
     }
 
     const comment = await prisma.comment.create({
@@ -143,64 +144,53 @@ export async function POST(
       },
     })
 
-    // 소켓 실시간 브로드캐스트
     emitCommentNew(id, { ...comment, replies: [] })
 
-    // 멘션 알림 생성
     if (mentions && mentions.length > 0) {
-      const uniqueMentions = [...new Set(mentions)].filter((uid) => uid !== session.user.id)
-      if (uniqueMentions.length > 0) {
-        const mentionMessage = `${session.user.name ?? "누군가"}님이 댓글에서 회원님을 멘션했습니다.`
+      const uniqueMentions = [...new Set(mentions)].filter(
+        (userId) => userId !== session.user.id
+      )
 
-        // 구독 설정 확인 후 알림 생성 — 배치 조회로 N+1 방지
-        const enabledMentions = await getEnabledUserIds(uniqueMentions, "MENTION")
+      const enabledMentionRecipients = await getEnabledUserIds(
+        uniqueMentions,
+        "MENTION"
+      )
 
-        if (enabledMentions.length > 0) {
-          await prisma.notification.createMany({
-            data: enabledMentions.map((userId) => ({
-              type: "MENTION" as const,
-              title: "댓글에서 멘션되었습니다",
-              message: mentionMessage,
-              userId,
-              prId: id,
-              commentId: comment.id,
-            })),
-            skipDuplicates: true,
-          })
+      if (enabledMentionRecipients.length > 0) {
+        const mentionMessage = `${
+          session.user.name ?? "A teammate"
+        } mentioned you in a comment.`
 
-          for (const userId of enabledMentions) {
-            emitNotification(userId, {
-              id: comment.id,
-              type: "MENTION",
-              title: "댓글에서 멘션되었습니다",
-              message: mentionMessage,
-              isRead: false,
-              userId,
-              prId: id,
-              commentId: comment.id,
-              createdAt: new Date().toISOString(),
-            })
-          }
-        }
+        await createNotificationsForUsers({
+          userIds: enabledMentionRecipients,
+          type: "MENTION",
+          title: "You were mentioned in a comment",
+          message: mentionMessage,
+          prId: id,
+          commentId: comment.id,
+        })
       }
     }
 
-    // COMMENT 알림 - 댓글 작성자가 PR 소유자가 아닐 때
-    const prOwnerId = pr.repo.userId
-    if (prOwnerId !== session.user.id && await isNotificationEnabled(prOwnerId, "COMMENT_REPLY")) {
-      const commentNotification = await prisma.notification.create({
-        data: {
-          type: "COMMENT_REPLY",
-          title: "새 댓글이 달렸습니다",
-          message: `${session.user.name ?? "누군가"}님이 "${pr.title}"에 댓글을 남겼습니다.`,
-          userId: prOwnerId,
-          prId: id,
-          commentId: comment.id,
-        },
-      })
-      emitNotification(prOwnerId, {
-        ...commentNotification,
-        createdAt: commentNotification.createdAt.toISOString(),
+    const connectedUserIds = (await getRepositoryMemberIds(pr.repoId)).filter(
+      (userId) => userId !== session.user.id
+    )
+
+    const enabledCommentRecipients = await getEnabledUserIds(
+      connectedUserIds,
+      "COMMENT_REPLY"
+    )
+
+    if (enabledCommentRecipients.length > 0) {
+      await createNotificationsForUsers({
+        userIds: enabledCommentRecipients,
+        type: "COMMENT_REPLY",
+        title: "A new comment was added",
+        message: `${
+          session.user.name ?? "A teammate"
+        } commented on "${pr.title}".`,
+        prId: id,
+        commentId: comment.id,
       })
     }
 

--- a/app/api/pulls/[id]/files/route.ts
+++ b/app/api/pulls/[id]/files/route.ts
@@ -1,57 +1,9 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import { buildAccessiblePullRequestWhere } from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/pulls/{id}/files:
- *   get:
- *     summary: PR 변경 파일 목록 조회
- *     description: PR에서 변경된 파일 목록과 Diff(patch)를 반환합니다.
- *     tags:
- *       - PullRequest
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *         description: PR ID (DB)
- *     responses:
- *       200:
- *         description: 파일 목록 조회 성공
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 files:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       filename:
- *                         type: string
- *                       status:
- *                         type: string
- *                         enum: [added, modified, removed, renamed, copied, changed, unchanged]
- *                       additions:
- *                         type: integer
- *                       deletions:
- *                         type: integer
- *                       changes:
- *                         type: integer
- *                       patch:
- *                         type: string
- *                         nullable: true
- *       401:
- *         description: 인증되지 않은 사용자
- *       404:
- *         description: PR을 찾을 수 없음
- *       500:
- *         description: 서버 내부 오류
- */
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -64,11 +16,14 @@ export async function GET(
     }
 
     const { id } = await params
+    const pullRequestWhere = await buildAccessiblePullRequestWhere(
+      session.user.id
+    )
 
     const pr = await prisma.pullRequest.findFirst({
       where: {
         id,
-        repo: { userId: session.user.id },
+        ...pullRequestWhere,
       },
       select: {
         number: true,
@@ -77,7 +32,7 @@ export async function GET(
     })
 
     if (!pr) {
-      return NextResponse.json({ error: "PR을 찾을 수 없습니다." }, { status: 404 })
+      return NextResponse.json({ error: "Pull request not found" }, { status: 404 })
     }
 
     const octokit = await getOctokit(session.user.id)
@@ -90,14 +45,16 @@ export async function GET(
       per_page: 100,
     })
 
-    const files = data.map(({ filename, status, additions, deletions, changes, patch }) => ({
-      filename,
-      status,
-      additions,
-      deletions,
-      changes,
-      patch: patch ?? null,
-    }))
+    const files = data.map(
+      ({ filename, status, additions, deletions, changes, patch }) => ({
+        filename,
+        status,
+        additions,
+        deletions,
+        changes,
+        patch: patch ?? null,
+      })
+    )
 
     return NextResponse.json({ files })
   } catch {

--- a/app/api/pulls/[id]/route.ts
+++ b/app/api/pulls/[id]/route.ts
@@ -1,49 +1,12 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  buildAccessiblePullRequestWhere,
+  getRepositoryPrimaryUser,
+} from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/pulls/{id}:
- *   get:
- *     summary: PR 상세 조회
- *     description: PR 상세 정보를 반환합니다. additions/deletions/changedFiles가 모두 0이면 GitHub API로 실시간 보정합니다.
- *     tags:
- *       - PullRequest
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *         description: PR ID (DB)
- *     responses:
- *       200:
- *         description: PR 상세 조회 성공
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/PullRequest'
- *       401:
- *         description: 인증되지 않은 사용자
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       404:
- *         description: PR을 찾을 수 없음
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: 서버 내부 오류
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- */
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -56,11 +19,14 @@ export async function GET(
     }
 
     const { id } = await params
+    const pullRequestWhere = await buildAccessiblePullRequestWhere(
+      session.user.id
+    )
 
     const pr = await prisma.pullRequest.findFirst({
       where: {
         id,
-        repo: { userId: session.user.id },
+        ...pullRequestWhere,
       },
       include: {
         repo: {
@@ -68,7 +34,6 @@ export async function GET(
             id: true,
             name: true,
             fullName: true,
-            owner: { select: { id: true, name: true, image: true } },
           },
         },
         reviews: {
@@ -79,7 +44,6 @@ export async function GET(
             issueCount: true,
             severity: true,
             reviewedAt: true,
-            // aiSuggestions 제외 — /api/pulls/[id]/review 전용 API에서 제공
           },
           take: 1,
           orderBy: { reviewedAt: "desc" },
@@ -88,19 +52,20 @@ export async function GET(
     })
 
     if (!pr) {
-      return NextResponse.json({ error: "PR을 찾을 수 없습니다." }, { status: 404 })
+      return NextResponse.json({ error: "Pull request not found" }, { status: 404 })
     }
+
+    const owner = await getRepositoryPrimaryUser(pr.repo.id)
 
     let { additions, deletions, changedFiles } = pr
 
-    // additions/deletions/changedFiles가 모두 0이면 GitHub API로 실시간 보정
     if (additions === 0 && deletions === 0 && changedFiles === 0) {
       try {
         const octokit = await getOctokit(session.user.id)
-        const [owner, repo] = pr.repo.fullName.split("/")
+        const [ownerName, repoName] = pr.repo.fullName.split("/")
         const { data } = await octokit.pulls.get({
-          owner,
-          repo,
+          owner: ownerName,
+          repo: repoName,
           pull_number: pr.number,
         })
 
@@ -108,16 +73,15 @@ export async function GET(
         deletions = data.deletions
         changedFiles = data.changed_files
 
-        // DB 보정값 저장 (fire-and-forget)
         prisma.pullRequest
           .update({ where: { id }, data: { additions, deletions, changedFiles } })
           .catch(() => {})
       } catch {
-        // GitHub API 실패 시 DB 값(0)을 그대로 반환
+        // Keep stored values when GitHub hydration fails.
       }
     }
 
-    const { githubId, ...rest } = pr
+    const { githubId, repo: repository, ...rest } = pr
 
     return NextResponse.json({
       ...rest,
@@ -125,6 +89,12 @@ export async function GET(
       additions,
       deletions,
       changedFiles,
+      repo: {
+        id: repository.id,
+        name: repository.name,
+        fullName: repository.fullName,
+        owner,
+      },
     })
   } catch {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })

--- a/app/api/pulls/route.ts
+++ b/app/api/pulls/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { buildAccessiblePullRequestWhere } from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
 const VALID_STATUSES = ["OPEN", "CLOSED", "MERGED", "DRAFT"] as const
@@ -7,81 +8,6 @@ type PRStatus = (typeof VALID_STATUSES)[number]
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 50
 
-/**
- * @swagger
- * /api/pulls:
- *   get:
- *     summary: PR 목록 조회
- *     description: 로그인한 유저의 연동된 저장소 PR 목록을 반환합니다. 저장소별/상태별 필터 및 페이지네이션을 지원합니다.
- *     tags:
- *       - PullRequest
- *     parameters:
- *       - in: query
- *         name: repoId
- *         schema:
- *           type: string
- *         description: 특정 저장소 ID로 필터링 (없으면 전체 저장소)
- *       - in: query
- *         name: status
- *         schema:
- *           type: string
- *           enum: [OPEN, CLOSED, MERGED, DRAFT]
- *         description: PR 상태로 필터링
- *       - in: query
- *         name: page
- *         schema:
- *           type: integer
- *           default: 1
- *         description: 페이지 번호
- *       - in: query
- *         name: limit
- *         schema:
- *           type: integer
- *           default: 20
- *           maximum: 50
- *         description: 페이지당 항목 수
- *     responses:
- *       200:
- *         description: PR 목록 조회 성공
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 pullRequests:
- *                   type: array
- *                   items:
- *                     $ref: '#/components/schemas/PullRequest'
- *                 pagination:
- *                   type: object
- *                   properties:
- *                     total:
- *                       type: integer
- *                     page:
- *                       type: integer
- *                     limit:
- *                       type: integer
- *                     totalPages:
- *                       type: integer
- *       400:
- *         description: 유효하지 않은 파라미터
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       401:
- *         description: 인증되지 않은 사용자
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: 서버 내부 오류
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- */
 export async function GET(request: Request) {
   try {
     const session = await auth()
@@ -95,21 +21,30 @@ export async function GET(request: Request) {
     const repoId = searchParams.get("repoId") ?? undefined
     const statusParam = searchParams.get("status") ?? undefined
     const pageParam = parseInt(searchParams.get("page") ?? "1", 10)
-    const limitParam = parseInt(searchParams.get("limit") ?? String(DEFAULT_LIMIT), 10)
+    const limitParam = parseInt(
+      searchParams.get("limit") ?? String(DEFAULT_LIMIT),
+      10
+    )
 
     if (statusParam && !VALID_STATUSES.includes(statusParam as PRStatus)) {
       return NextResponse.json(
-        { error: `유효하지 않은 status 값입니다. 허용값: ${VALID_STATUSES.join(", ")}` },
+        { error: `Invalid status. Allowed: ${VALID_STATUSES.join(", ")}` },
         { status: 400 }
       )
     }
 
     const page = isNaN(pageParam) || pageParam < 1 ? 1 : pageParam
-    const limit = isNaN(limitParam) || limitParam < 1 ? DEFAULT_LIMIT : Math.min(limitParam, MAX_LIMIT)
+    const limit =
+      isNaN(limitParam) || limitParam < 1
+        ? DEFAULT_LIMIT
+        : Math.min(limitParam, MAX_LIMIT)
+    const accessiblePullRequestWhere = await buildAccessiblePullRequestWhere(
+      session.user.id,
+      repoId
+    )
 
     const where = {
-      repo: { userId: session.user.id },
-      ...(repoId && { repoId }),
+      ...accessiblePullRequestWhere,
       ...(statusParam && { status: statusParam as PRStatus }),
     }
 

--- a/app/api/repositories/[id]/route.ts
+++ b/app/api/repositories/[id]/route.ts
@@ -1,57 +1,16 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  detachRepositoryFromUser,
+  getRepositoryMemberCount,
+  isRepositoryMembershipMigrationError,
+  isRepositoryAccessibleToUser,
+} from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/repositories/{id}:
- *   delete:
- *     summary: Repository 연동 해제
- *     description: CodeMate에 연동된 Repository를 해제합니다.
- *     tags:
- *       - Repository
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *         description: Repository DB ID
- *     responses:
- *       200:
- *         description: Repository 연동 해제 성공
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Message'
- *       401:
- *         description: 인증되지 않은 사용자
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       403:
- *         description: 권한 없음 (소유자가 아님)
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       404:
- *         description: Repository를 찾을 수 없음
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: 서버 내부 오류
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- */
 export async function DELETE(
-  request: Request,
+  _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -65,20 +24,31 @@ export async function DELETE(
 
     const repository = await prisma.repository.findUnique({
       where: { id },
+      select: {
+        id: true,
+        fullName: true,
+        webhookId: true,
+      },
     })
 
     if (!repository) {
-      return NextResponse.json(
-        { error: "Repository를 찾을 수 없습니다" },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: "Repository not found" }, { status: 404 })
     }
 
-    if (repository.userId !== session.user.id) {
-      return NextResponse.json(
-        { error: "해당 Repository에 대한 권한이 없습니다" },
-        { status: 403 }
-      )
+    const isConnected = await isRepositoryAccessibleToUser(session.user.id, id)
+
+    if (!isConnected) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const memberCount = await getRepositoryMemberCount(id)
+
+    if (memberCount > 1) {
+      await detachRepositoryFromUser(session.user.id, id)
+
+      return NextResponse.json({
+        message: "Repository connection removed.",
+      })
     }
 
     if (repository.webhookId) {
@@ -91,16 +61,26 @@ export async function DELETE(
           hook_id: repository.webhookId,
         })
       } catch {
-        // Webhook 삭제 실패해도 DB 삭제는 계속 진행
+        // Continue deleting the local repository record even if webhook cleanup fails.
       }
     }
 
     await prisma.repository.delete({ where: { id } })
 
     return NextResponse.json({
-      message: "Repository 연동이 해제되었습니다",
+      message: "Repository removed.",
     })
-  } catch {
+  } catch (error) {
+    if (isRepositoryMembershipMigrationError(error)) {
+      return NextResponse.json(
+        {
+          error:
+            'Shared repository migration is not applied. Run the "split_repository_membership" migration first.',
+        },
+        { status: 503 }
+      )
+    }
+
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/app/api/repositories/[id]/sync/route.ts
+++ b/app/api/repositories/[id]/sync/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
 export async function POST(
@@ -14,27 +15,17 @@ export async function POST(
     }
 
     const { id } = await params
+    const repositoryWhere = await buildAccessibleRepositoryWhere(session.user.id, id)
 
-    const repository = await prisma.repository.findUnique({
-      where: { id },
-      select: { id: true, userId: true, fullName: true },
+    const repository = await prisma.repository.findFirst({
+      where: repositoryWhere,
+      select: { id: true, fullName: true },
     })
 
     if (!repository) {
-      return NextResponse.json(
-        { error: "Repository를 찾을 수 없습니다" },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: "Repository not found" }, { status: 404 })
     }
 
-    if (repository.userId !== session.user.id) {
-      return NextResponse.json(
-        { error: "해당 Repository에 대한 권한이 없습니다" },
-        { status: 403 }
-      )
-    }
-
-    // additions=0 AND deletions=0 AND changedFiles=0 인 PR만 보정 대상
     const unsynced = await prisma.pullRequest.findMany({
       where: {
         repoId: id,
@@ -52,7 +43,6 @@ export async function POST(
     const [owner, repo] = repository.fullName.split("/")
     const octokit = await getOctokit(session.user.id)
 
-    // 1단계: GitHub API 결과를 메모리에 수집 (개별 실패는 건너뜀)
     const results: {
       id: string
       additions: number
@@ -68,8 +58,11 @@ export async function POST(
           pull_number: pr.number,
         })
 
-        // GitHub API가 반환하는 값이 실제로도 0인 PR은 건너뜀 (진짜 변경 없는 PR)
-        if (data.additions === 0 && data.deletions === 0 && data.changed_files === 0) {
+        if (
+          data.additions === 0 &&
+          data.deletions === 0 &&
+          data.changed_files === 0
+        ) {
           continue
         }
 
@@ -80,20 +73,19 @@ export async function POST(
           changedFiles: data.changed_files,
         })
       } catch {
-        // 개별 PR 보정 실패는 건너뛰고 계속 진행
+        // Skip PRs that fail detail hydration and continue.
       }
     }
 
-    // 2단계: 단일 트랜잭션으로 DB 업데이트 (N회 왕복 → 1회)
     if (results.length > 0) {
       await prisma.$transaction(
-        results.map((r) =>
+        results.map((result) =>
           prisma.pullRequest.update({
-            where: { id: r.id },
+            where: { id: result.id },
             data: {
-              additions: r.additions,
-              deletions: r.deletions,
-              changedFiles: r.changedFiles,
+              additions: result.additions,
+              deletions: result.deletions,
+              changedFiles: result.changedFiles,
             },
           })
         )

--- a/app/api/repositories/route.ts
+++ b/app/api/repositories/route.ts
@@ -1,91 +1,13 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import {
+  buildAccessibleRepositoryWhere,
+  connectRepositoryToUser,
+  isRepositoryMembershipMigrationError,
+} from "@/lib/repository-access"
 import { NextResponse } from "next/server"
 
-/**
- * @swagger
- * /api/repositories:
- *   post:
- *     summary: Repository 연동
- *     description: GitHub Repository를 CodeMate에 연동합니다.
- *     tags:
- *       - Repository
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - githubId
- *               - name
- *               - fullName
- *             properties:
- *               githubId:
- *                 type: integer
- *                 description: GitHub Repository ID
- *               name:
- *                 type: string
- *                 description: Repository 이름
- *               fullName:
- *                 type: string
- *                 description: "owner/repo 형식의 전체 이름"
- *               description:
- *                 type: string
- *                 nullable: true
- *               language:
- *                 type: string
- *                 nullable: true
- *     responses:
- *       201:
- *         description: Repository 연동 성공
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 repository:
- *                   $ref: '#/components/schemas/Repository'
- *       400:
- *         description: 필수 필드 누락
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       401:
- *         description: 인증되지 않은 사용자
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       409:
- *         description: 이미 연동된 Repository
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: 서버 내부 오류
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- */
-/**
- * @swagger
- * /api/repositories:
- *   get:
- *     summary: 연동된 저장소 목록 조회
- *     description: 현재 사용자의 연동된 저장소 목록을 반환합니다.
- *     tags:
- *       - Repository
- *     responses:
- *       200:
- *         description: 저장소 목록 반환 성공
- *       401:
- *         description: 인증되지 않은 사용자
- */
 export async function GET() {
   try {
     const session = await auth()
@@ -93,14 +15,27 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
+    const repositoryWhere = await buildAccessibleRepositoryWhere(session.user.id)
+
     const repositories = await prisma.repository.findMany({
-      where: { userId: session.user.id },
+      where: repositoryWhere,
       select: { id: true, name: true, fullName: true },
       orderBy: { name: "asc" },
     })
 
     return NextResponse.json({ repositories })
-  } catch {
+  } catch (error) {
+    if (isRepositoryMembershipMigrationError(error)) {
+      return NextResponse.json(
+        {
+          error:
+            'Shared repository migration is not applied. Run the "split_repository_membership" migration first.',
+        },
+        { status: 503 }
+      )
+    }
+
+    console.error("[GET /api/repositories] failed:", error)
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
 }
@@ -118,110 +53,167 @@ export async function POST(request: Request) {
 
     if (!githubId || !name || !fullName) {
       return NextResponse.json(
-        { error: "githubId, name, fullName은 필수 항목입니다" },
+        { error: "githubId, name, fullName are required" },
         { status: 400 }
       )
     }
 
-    const existing = await prisma.repository.findFirst({
-      where: { githubId: BigInt(githubId), userId: session.user.id },
-    })
-
-    if (existing) {
-      return NextResponse.json(
-        { error: "이미 연동된 Repository입니다" },
-        { status: 409 }
-      )
-    }
-
-    const repository = await prisma.repository.create({
-      data: {
-        githubId: BigInt(githubId),
-        name,
-        fullName,
-        description: description ?? null,
-        language: language ?? null,
-        userId: session.user.id,
+    const parsedGithubId = BigInt(githubId)
+    let repository = await prisma.repository.findUnique({
+      where: { githubId: parsedGithubId },
+      select: {
+        id: true,
+        githubId: true,
+        name: true,
+        fullName: true,
+        description: true,
+        language: true,
+        webhookId: true,
       },
     })
 
-    const [owner, repo] = fullName.split("/")
+    if (repository) {
+      const connectionResult = await connectRepositoryToUser(
+        session.user.id,
+        repository.id
+      )
 
-    // Webhook 등록
-    try {
-      const octokit = await getOctokit(session.user.id)
-      const { data: hook } = await octokit.rest.repos.createWebhook({
-        owner,
-        repo,
-        config: {
-          url: `${process.env.NEXTAUTH_URL}/api/webhook/github`,
-          content_type: "json",
-          secret: process.env.GITHUB_WEBHOOK_SECRET,
+      if (connectionResult === "existing") {
+        return NextResponse.json(
+          { error: "Repository is already connected" },
+          { status: 409 }
+        )
+      }
+    } else {
+      repository = await prisma.repository.create({
+        data: {
+          githubId: parsedGithubId,
+          name,
+          fullName,
+          description: description ?? null,
+          language: language ?? null,
+          userRepositories: {
+            create: {
+              userId: session.user.id,
+            },
+          },
         },
-        events: ["pull_request"],
-        active: true,
+        select: {
+          id: true,
+          githubId: true,
+          name: true,
+          fullName: true,
+          description: true,
+          language: true,
+          webhookId: true,
+        },
       })
-      await prisma.repository.update({
-        where: { id: repository.id },
-        data: { webhookId: hook.id },
-      })
-      repository.webhookId = hook.id
-    } catch (err) {
-      console.warn("[Webhook] 등록 실패 (로컬 환경에서는 정상):", err)
     }
 
-    // 기존 PR Backfill: 연동 시점 이전에 생성된 PR을 DB에 동기화
-    try {
-      const octokit = await getOctokit(session.user.id)
-      const { data: prs } = await octokit.rest.pulls.list({
-        owner,
-        repo,
-        state: "all",
-        per_page: 100,
-        sort: "updated",
-        direction: "desc",
-      })
+    if (!repository) {
+      throw new Error("Repository creation failed")
+    }
 
-      console.log(`[Backfill] ${fullName}: GitHub에서 PR ${prs.length}개 조회됨`)
+    const [owner, repo] = fullName.split("/")
 
-      if (prs.length > 0) {
-        const result = await prisma.pullRequest.createMany({
-          data: prs.map((pr) => ({
-            githubId: BigInt(pr.id),
-            number: pr.number,
-            title: pr.title,
-            description: pr.body ?? null,
-            // PR 목록 API는 merged 필드가 없으므로 merged_at으로 판단
-            status: pr.draft
-              ? "DRAFT"
-              : pr.state === "closed"
-                ? pr.merged_at ? "MERGED" : "CLOSED"
-                : "OPEN",
-            baseBranch: pr.base.ref,
-            headBranch: pr.head.ref,
-            // 목록 API는 additions/deletions 미제공 → 상세 페이지 진입 시 lazy 보정
-            additions: 0,
-            deletions: 0,
-            changedFiles: 0,
-            mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
-            closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
-            githubCreatedAt: pr.created_at ? new Date(pr.created_at) : null,
-            githubUpdatedAt: pr.updated_at ? new Date(pr.updated_at) : null,
-            repoId: repository.id,
-          })),
-          skipDuplicates: true,
+    if (!repository.webhookId) {
+      try {
+        const octokit = await getOctokit(session.user.id)
+        const { data: hook } = await octokit.rest.repos.createWebhook({
+          owner,
+          repo,
+          config: {
+            url: `${process.env.NEXTAUTH_URL}/api/webhook/github`,
+            content_type: "json",
+            secret: process.env.GITHUB_WEBHOOK_SECRET,
+          },
+          events: ["pull_request"],
+          active: true,
         })
-        console.log(`[Backfill] DB에 PR ${result.count}개 저장됨`)
+
+        repository = await prisma.repository.update({
+          where: { id: repository.id },
+          data: { webhookId: hook.id },
+          select: {
+            id: true,
+            githubId: true,
+            name: true,
+            fullName: true,
+            description: true,
+            language: true,
+            webhookId: true,
+          },
+        })
+      } catch (error) {
+        console.warn("[Webhook] registration failed:", error)
       }
-    } catch (err) {
-      console.error("[Backfill] PR 동기화 실패:", err)
+    }
+
+    const existingPullRequestCount = await prisma.pullRequest.count({
+      where: { repoId: repository.id },
+    })
+
+    if (existingPullRequestCount === 0) {
+      try {
+        const octokit = await getOctokit(session.user.id)
+        const { data: prs } = await octokit.rest.pulls.list({
+          owner,
+          repo,
+          state: "all",
+          per_page: 100,
+          sort: "updated",
+          direction: "desc",
+        })
+
+        if (prs.length > 0) {
+          await prisma.pullRequest.createMany({
+            data: prs.map((pr) => ({
+              githubId: BigInt(pr.id),
+              number: pr.number,
+              title: pr.title,
+              description: pr.body ?? null,
+              status: pr.draft
+                ? "DRAFT"
+                : pr.state === "closed"
+                  ? pr.merged_at
+                    ? "MERGED"
+                    : "CLOSED"
+                  : "OPEN",
+              baseBranch: pr.base.ref,
+              headBranch: pr.head.ref,
+              additions: 0,
+              deletions: 0,
+              changedFiles: 0,
+              mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
+              closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+              githubCreatedAt: pr.created_at ? new Date(pr.created_at) : null,
+              githubUpdatedAt: pr.updated_at ? new Date(pr.updated_at) : null,
+              repoId: repository.id,
+            })),
+            skipDuplicates: true,
+          })
+        }
+      } catch (error) {
+        console.error("[Backfill] failed:", error)
+      }
     }
 
     return NextResponse.json(
       { repository: { ...repository, githubId: Number(repository.githubId) } },
       { status: 201 }
     )
-  } catch {
+  } catch (error) {
+    if (isRepositoryMembershipMigrationError(error)) {
+      return NextResponse.json(
+        {
+          error:
+            'Shared repository migration is not applied. Run the "split_repository_membership" migration first.',
+        },
+        { status: 503 }
+      )
+    }
+
+    console.error("[POST /api/repositories] failed:", error)
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/app/api/review/analyze/route.ts
+++ b/app/api/review/analyze/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
-import { prisma } from "@/lib/prisma"
 import { analyzeReview } from "@/lib/ai/analyze"
+import { getEnabledUserIds } from "@/lib/notification-settings"
+import { prisma } from "@/lib/prisma"
+import { getRepositoryMemberIds } from "@/lib/repository-access"
 import { emitNotification } from "@/lib/socket/emitter"
-import { isNotificationEnabled } from "@/lib/notification-settings"
 
 export async function POST(request: Request) {
   try {
@@ -18,51 +19,50 @@ export async function POST(request: Request) {
 
     const pr = await prisma.pullRequest.findUnique({
       where: { id: pullRequestId },
-      include: { repo: { select: { userId: true } } },
+      select: {
+        id: true,
+        title: true,
+        repoId: true,
+      },
     })
 
     if (!pr) {
       return NextResponse.json(
-        { error: "PullRequest not found" },
+        { error: "Pull request not found" },
         { status: 404 }
       )
     }
 
-    // Create PENDING review record upfront
-    const review = await prisma.review.create({
-      data: {
-        pullRequestId,
-        status: "PENDING",
-        aiSuggestions: {},
-        qualityScore: 0,
-        severity: "LOW",
-        issueCount: 0,
-      },
-    })
-
-    const prOwnerId = pr.repo.userId
-
-    // Fire-and-forget: respond immediately, notify when done
     analyzeReview(pullRequestId)
       .then(async () => {
-        if (!(await isNotificationEnabled(prOwnerId, "NEW_REVIEW"))) return
-        const notification = await prisma.notification.create({
-          data: {
-            type: "NEW_REVIEW",
-            title: "AI 코드 리뷰가 완료되었습니다",
-            message: `"${pr.title}" PR의 AI 코드 리뷰가 완료되었습니다.`,
-            userId: prOwnerId,
-            prId: pullRequestId,
-          },
-        })
-        emitNotification(prOwnerId, {
-          ...notification,
-          createdAt: notification.createdAt.toISOString(),
-        })
-      })
-      .catch((err) => console.error("[analyze] analyzeReview failed:", err))
+        const repositoryUserIds = await getRepositoryMemberIds(pr.repoId)
+        const recipientIds = await getEnabledUserIds(
+          [...new Set(repositoryUserIds)],
+          "NEW_REVIEW"
+        )
 
-    return NextResponse.json({ reviewId: review.id, status: "PENDING" })
+        await Promise.all(
+          recipientIds.map(async (userId) => {
+            const notification = await prisma.notification.create({
+              data: {
+                type: "NEW_REVIEW",
+                title: "AI review is ready",
+                message: `The AI review for "${pr.title}" is complete.`,
+                userId,
+                prId: pullRequestId,
+              },
+            })
+
+            emitNotification(userId, {
+              ...notification,
+              createdAt: notification.createdAt.toISOString(),
+            })
+          })
+        )
+      })
+      .catch((error) => console.error("[analyze] analyzeReview failed:", error))
+
+    return NextResponse.json({ status: "PENDING" })
   } catch {
     return NextResponse.json(
       { error: "Internal server error" },

--- a/app/api/webhook/github/route.ts
+++ b/app/api/webhook/github/route.ts
@@ -1,9 +1,10 @@
 import { revalidateTag } from "next/cache"
 import { NextResponse, after } from "next/server"
 import { analyzeReview } from "@/lib/ai/analyze"
-import { emitNotification } from "@/lib/socket/emitter"
-import { isNotificationEnabled } from "@/lib/notification-settings"
+import { getEnabledUserIds } from "@/lib/notification-settings"
 import { prisma } from "@/lib/prisma"
+import { getRepositoryMemberIds } from "@/lib/repository-access"
+import { emitNotification } from "@/lib/socket/emitter"
 import { verifyWebhookSignature } from "@/lib/webhook-validator"
 
 export const maxDuration = 300
@@ -30,6 +31,35 @@ function getPRStatus(pr: {
   if (pr.draft) return "DRAFT"
   if (pr.state === "closed") return pr.merged ? "MERGED" : "CLOSED"
   return "OPEN"
+}
+
+async function notifyUsers(params: {
+  userIds: string[]
+  type: "NEW_REVIEW" | "PR_MERGED" | "REVIEW_FAILED"
+  title: string
+  message: string
+  prId: string
+}) {
+  const recipients = await getEnabledUserIds(params.userIds, params.type)
+
+  await Promise.all(
+    recipients.map(async (userId) => {
+      const notification = await prisma.notification.create({
+        data: {
+          type: params.type,
+          title: params.title,
+          message: params.message,
+          userId,
+          prId: params.prId,
+        },
+      })
+
+      emitNotification(userId, {
+        ...notification,
+        createdAt: notification.createdAt.toISOString(),
+      })
+    })
+  )
 }
 
 export async function POST(request: Request) {
@@ -60,7 +90,7 @@ export async function POST(request: Request) {
 
     const repository = await prisma.repository.findFirst({
       where: { githubId: BigInt(repo.id) },
-      select: { id: true, userId: true },
+      select: { id: true },
     })
 
     if (!repository) {
@@ -70,12 +100,18 @@ export async function POST(request: Request) {
       )
     }
 
+    const recipientIds = [...new Set(await getRepositoryMemberIds(repository.id))]
+
     const pullRequest = await prisma.pullRequest.upsert({
       where: { githubId: BigInt(pr.id) },
       update: {
         title: pr.title,
         description: pr.body ?? null,
-        status: getPRStatus({ state: pr.state, draft: pr.draft, merged: pr.merged }),
+        status: getPRStatus({
+          state: pr.state,
+          draft: pr.draft,
+          merged: pr.merged,
+        }),
         additions: pr.additions ?? 0,
         deletions: pr.deletions ?? 0,
         changedFiles: pr.changed_files ?? 0,
@@ -89,7 +125,11 @@ export async function POST(request: Request) {
         number: pr.number,
         title: pr.title,
         description: pr.body ?? null,
-        status: getPRStatus({ state: pr.state, draft: pr.draft, merged: pr.merged }),
+        status: getPRStatus({
+          state: pr.state,
+          draft: pr.draft,
+          merged: pr.merged,
+        }),
         baseBranch: pr.base.ref,
         headBranch: pr.head.ref,
         additions: pr.additions ?? 0,
@@ -104,71 +144,59 @@ export async function POST(request: Request) {
     })
 
     if (isStatusChange) {
-      const newStatus = getPRStatus({ state: pr.state, draft: pr.draft, merged: pr.merged })
-      const isMerged = newStatus === "MERGED"
+      const isMerged =
+        getPRStatus({
+          state: pr.state,
+          draft: pr.draft,
+          merged: pr.merged,
+        }) === "MERGED"
 
-      if (await isNotificationEnabled(repository.userId, "PR_MERGED")) {
-        const statusNotification = await prisma.notification.create({
-          data: {
-            type: "PR_MERGED",
-            title: isMerged ? "PR이 병합되었습니다" : "PR이 닫혔습니다",
-            message: `"${pr.title}" PR이 ${isMerged ? "병합" : "닫"}혔습니다.`,
-            userId: repository.userId,
-            prId: pullRequest.id,
-          },
-        })
-
-        emitNotification(repository.userId, {
-          ...statusNotification,
-          createdAt: statusNotification.createdAt.toISOString(),
+      if (recipientIds.length > 0) {
+        await notifyUsers({
+          userIds: recipientIds,
+          type: "PR_MERGED",
+          title: isMerged ? "PR merged" : "PR closed",
+          message: `"${pr.title}" was ${isMerged ? "merged" : "closed"}.`,
+          prId: pullRequest.id,
         })
       }
 
-      safeRevalidateDashboard(repository.userId)
+      recipientIds.forEach((userId) => safeRevalidateDashboard(userId))
       return NextResponse.json({ message: "PR status processed" })
     }
 
     after(async () => {
       try {
         await analyzeReview(pullRequest.id)
-        safeRevalidateDashboard(repository.userId)
+        recipientIds.forEach((userId) => safeRevalidateDashboard(userId))
 
-        if (!(await isNotificationEnabled(repository.userId, "NEW_REVIEW"))) return
+        if (recipientIds.length === 0) return
 
-        const notification = await prisma.notification.create({
-          data: {
-            type: "NEW_REVIEW",
-            title: "AI 코드 리뷰가 완료되었습니다",
-            message: `"${pr.title}" PR의 AI 코드 리뷰가 완료되었습니다.`,
-            userId: repository.userId,
-            prId: pullRequest.id,
-          },
-        })
-
-        emitNotification(repository.userId, {
-          ...notification,
-          createdAt: notification.createdAt.toISOString(),
+        await notifyUsers({
+          userIds: recipientIds,
+          type: "NEW_REVIEW",
+          title: "AI review is ready",
+          message: `The AI review for "${pr.title}" is complete.`,
+          prId: pullRequest.id,
         })
       } catch (error) {
         console.error("[webhook] analyzeReview failed:", error)
 
         try {
-          const failureNotification = await prisma.notification.create({
-            data: {
-              type: "REVIEW_FAILED",
-              title: "AI 코드 리뷰에 실패했습니다",
-              message: `"${pr.title}" PR의 AI 코드 리뷰를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.`,
-              userId: repository.userId,
-              prId: pullRequest.id,
-            },
-          })
+          if (recipientIds.length === 0) return
 
-          emitNotification(repository.userId, {
-            ...failureNotification,
-            createdAt: failureNotification.createdAt.toISOString(),
+          await notifyUsers({
+            userIds: recipientIds,
+            type: "REVIEW_FAILED",
+            title: "AI review failed",
+            message: `The AI review for "${pr.title}" could not be completed.`,
+            prId: pullRequest.id,
           })
         } catch (notifyError) {
-          console.error("[webhook] failed to send failure notification:", notifyError)
+          console.error(
+            "[webhook] failed to send failure notification:",
+            notifyError
+          )
         }
       }
     })

--- a/components/github/RepoCard.tsx
+++ b/components/github/RepoCard.tsx
@@ -1,10 +1,21 @@
 "use client"
 
 import { useState } from "react"
-import { FolderGit2, Github, Check, Trash2, Plus, RefreshCw } from "lucide-react"
+import {
+  AlertCircle,
+  Check,
+  FolderGit2,
+  Github,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { useSyncRepository } from "@/hooks/useSyncRepository"
+import { controlStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 const LANGUAGE_COLORS: Record<string, string> = {
   TypeScript: "bg-blue-500",
@@ -26,6 +37,8 @@ interface RepoCardProps {
   repositoryId?: string
   onConnect?: () => void
   onDisconnect?: () => void
+  isConnecting?: boolean
+  connectError?: string | null
 }
 
 export default function RepoCard({
@@ -36,53 +49,50 @@ export default function RepoCard({
   repositoryId,
   onConnect,
   onDisconnect,
+  isConnecting = false,
+  connectError = null,
 }: RepoCardProps) {
   const [syncMessage, setSyncMessage] = useState<string | null>(null)
   const { mutate: sync, isPending: isSyncing } = useSyncRepository()
   const dotColor = language ? (LANGUAGE_COLORS[language] ?? "bg-slate-400") : null
 
   return (
-    <div className="group relative bg-white border border-slate-200 rounded-[24px] p-6 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-500/5 transition-all duration-300">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
-
-        {/* 왼쪽: 아이콘 + 정보 */}
+    <div className={cn("group relative", surfaceStyles.interactiveCard)}>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-2xl bg-slate-50 flex items-center justify-center text-slate-400 group-hover:bg-blue-50 group-hover:text-blue-600 transition-colors border border-slate-100 shrink-0">
+          <div className="h-12 w-12 shrink-0 rounded-2xl border border-slate-100 bg-slate-50 text-slate-400 transition-colors group-hover:bg-blue-50 group-hover:text-blue-600 flex items-center justify-center">
             <FolderGit2 size={22} aria-hidden />
           </div>
 
-          <div className="space-y-1 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
               <h3 className="text-lg font-bold text-slate-900">{name}</h3>
               {language && dotColor && (
                 <Badge
                   variant="outline"
-                  className="gap-1.5 px-2 py-0.5 rounded-full bg-slate-50 border-slate-100 text-slate-500 text-[10px] font-bold uppercase tracking-wide"
+                  className="gap-1.5 rounded-full border-slate-100 bg-slate-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-500"
                 >
-                  <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+                  <span className={cn("h-1.5 w-1.5 rounded-full", dotColor)} />
                   {language}
                 </Badge>
               )}
             </div>
-            <p className="text-sm text-slate-400 font-medium flex items-center gap-1.5">
+            <p className="flex items-center gap-1.5 text-sm font-medium text-slate-400">
               <Github size={12} aria-hidden />
               {fullName}
             </p>
           </div>
         </div>
 
-        {/* 오른쪽: 상태 + 액션 */}
-        <div className="flex items-center gap-3 self-end sm:self-center shrink-0">
+        <div className="flex shrink-0 items-center gap-3 self-end sm:self-center">
           {isConnected ? (
             <>
-              <Badge className="gap-1.5 px-3 py-1.5 rounded-xl bg-emerald-50 border border-emerald-100 text-emerald-600 text-xs font-bold">
+              <Badge className="gap-1.5 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-1.5 text-xs font-bold text-emerald-600">
                 <Check size={12} aria-hidden />
                 연동됨
               </Badge>
               {syncMessage && (
-                <span className="text-xs font-medium text-slate-500">
-                  {syncMessage}
-                </span>
+                <span className="text-xs font-medium text-slate-500">{syncMessage}</span>
               )}
               <Button
                 variant="ghost"
@@ -90,12 +100,11 @@ export default function RepoCard({
                 disabled={isSyncing || !repositoryId}
                 onClick={() => {
                   if (!repositoryId) return
+
                   sync(repositoryId, {
                     onSuccess: ({ updated, total }) => {
                       setSyncMessage(
-                        total === 0
-                          ? "보정할 PR 없음"
-                          : `${updated}/${total}건 보정 완료`
+                        total === 0 ? "보정할 PR 없음" : `${updated}/${total}건 보정 완료`
                       )
                       setTimeout(() => setSyncMessage(null), 3000)
                     },
@@ -106,7 +115,10 @@ export default function RepoCard({
                   })
                 }}
                 title="코드 변경량 동기화"
-                className="p-2.5 text-slate-400 hover:text-blue-500 hover:bg-blue-50 rounded-xl border border-transparent hover:border-blue-100 h-auto w-auto disabled:opacity-40"
+                className={cn(
+                  controlStyles.iconButton,
+                  "text-slate-400 hover:border-blue-100 hover:bg-blue-50 hover:text-blue-500 disabled:opacity-40"
+                )}
               >
                 <RefreshCw size={18} className={isSyncing ? "animate-spin" : ""} aria-hidden />
               </Button>
@@ -115,7 +127,10 @@ export default function RepoCard({
                 size="icon"
                 onClick={onDisconnect}
                 title="연동 해제"
-                className="p-2.5 text-slate-400 hover:text-rose-500 hover:bg-rose-50 rounded-xl border border-transparent hover:border-rose-100 h-auto w-auto"
+                className={cn(
+                  controlStyles.iconButton,
+                  "text-slate-400 hover:border-rose-100 hover:bg-rose-50 hover:text-rose-500"
+                )}
               >
                 <Trash2 size={18} aria-hidden />
               </Button>
@@ -124,17 +139,33 @@ export default function RepoCard({
             <Button
               onClick={onConnect}
               size="sm"
-              className="gap-1.5 bg-blue-700 hover:bg-blue-800 text-white rounded-xl font-bold shadow-lg shadow-blue-700/20 h-auto px-4 py-2"
+              disabled={isConnecting}
+              className={cn("h-9 gap-1.5 px-4", controlStyles.primaryAction)}
             >
-              <Plus size={14} aria-hidden />
-              연동
+              {isConnecting ? (
+                <>
+                  <Loader2 size={14} className="animate-spin" aria-hidden />
+                  연동 중...
+                </>
+              ) : (
+                <>
+                  <Plus size={14} aria-hidden />
+                  연동
+                </>
+              )}
             </Button>
           )}
         </div>
       </div>
 
-      {/* 호버 시 왼쪽 파란 인디케이터 */}
-      <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-0 group-hover:h-12 bg-blue-600 rounded-r-full transition-all duration-300" />
+      {connectError && !isConnected && (
+        <div className="mt-3 inline-flex items-center gap-1.5 rounded-xl border border-rose-100 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-600">
+          <AlertCircle size={13} aria-hidden />
+          {connectError}
+        </div>
+      )}
+
+      <div className="absolute left-0 top-1/2 h-0 w-1 -translate-y-1/2 rounded-r-full bg-blue-600 transition-all duration-300 group-hover:h-12" />
     </div>
   )
 }

--- a/components/github/RepoList.tsx
+++ b/components/github/RepoList.tsx
@@ -7,12 +7,17 @@ import RepoCard from "@/components/github/RepoCard"
 import RepoCardSkeleton from "@/components/github/RepoCardSkeleton"
 import RepoListHeader from "@/components/github/RepoListHeader"
 import { InfiniteScrollTrigger } from "@/components/ui/InfiniteScrollTrigger"
+import { layoutStyles, surfaceStyles } from "@/lib/styles"
 
 interface RepoListProps {
   search?: string
+  repositoriesQuery: ReturnType<typeof useRepositories>
 }
 
-export default function RepoList({ search = "" }: RepoListProps) {
+export default function RepoList({
+  search = "",
+  repositoriesQuery,
+}: RepoListProps) {
   const {
     data,
     fetchNextPage,
@@ -20,14 +25,15 @@ export default function RepoList({ search = "" }: RepoListProps) {
     isFetchingNextPage,
     isLoading,
     isError,
-  } = useRepositories()
+    error,
+  } = repositoriesQuery
 
-  const { mutate: connect } = useConnectRepository()
+  const connectMutation = useConnectRepository()
   const { mutate: disconnect } = useDisconnectRepository()
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className={layoutStyles.listStack}>
         {Array.from({ length: 3 }).map((_, i) => (
           <RepoCardSkeleton key={i} />
         ))}
@@ -37,8 +43,10 @@ export default function RepoList({ search = "" }: RepoListProps) {
 
   if (isError) {
     return (
-      <div className="py-20 text-center text-sm text-slate-400 font-medium">
-        저장소 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+      <div className={surfaceStyles.emptyState}>
+        {error instanceof Error
+          ? error.message
+          : "저장소 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."}
       </div>
     )
   }
@@ -50,16 +58,16 @@ export default function RepoList({ search = "" }: RepoListProps) {
 
   if (filtered.length === 0) {
     return (
-      <div className="py-20 text-center text-sm text-slate-400 font-medium">
+      <div className={surfaceStyles.emptyState}>
         {search ? "검색 결과가 없습니다." : "저장소가 없습니다."}
       </div>
     )
   }
 
   return (
-    <div className="space-y-4">
+    <div className={layoutStyles.listStack}>
       <RepoListHeader count={filtered.length} />
-      <div className="space-y-4">
+      <div className={layoutStyles.listStack}>
         {filtered.map((repo) => (
           <RepoCard
             key={repo.id}
@@ -69,12 +77,26 @@ export default function RepoList({ search = "" }: RepoListProps) {
             language={repo.language}
             isConnected={repo.isConnected}
             repositoryId={repo.repositoryId}
-            onConnect={() => connect({
-              githubId: repo.id,
-              name: repo.name,
-              fullName: repo.fullName,
-              language: repo.language,
-            })}
+            isConnecting={
+              connectMutation.isPending &&
+              connectMutation.variables?.githubId === repo.id
+            }
+            connectError={
+              connectMutation.isError &&
+              connectMutation.variables?.githubId === repo.id
+                ? connectMutation.error instanceof Error
+                  ? connectMutation.error.message
+                  : "저장소 연결 중 오류가 발생했습니다."
+                : null
+            }
+            onConnect={() =>
+              connectMutation.mutate({
+                githubId: repo.id,
+                name: repo.name,
+                fullName: repo.fullName,
+                language: repo.language,
+              })
+            }
             onDisconnect={() => repo.repositoryId && disconnect(repo.repositoryId)}
           />
         ))}
@@ -85,7 +107,7 @@ export default function RepoList({ search = "" }: RepoListProps) {
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         loadingFallback={
-          <div className="space-y-4">
+          <div className={layoutStyles.listStack}>
             <RepoCardSkeleton />
             <RepoCardSkeleton />
           </div>

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -1,0 +1,22 @@
+import type { PropsWithChildren } from "react"
+import { layoutStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
+
+interface PageContainerProps extends PropsWithChildren {
+  size?: "default" | "narrow" | "wide"
+  className?: string
+}
+
+const sizeClass = {
+  default: layoutStyles.page,
+  narrow: layoutStyles.narrowPage,
+  wide: layoutStyles.widePage,
+} as const
+
+export function PageContainer({
+  size = "default",
+  className,
+  children,
+}: PageContainerProps) {
+  return <div className={cn(sizeClass[size], className)}>{children}</div>
+}

--- a/components/layout/PageHeader.tsx
+++ b/components/layout/PageHeader.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react"
+import { textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
+
+interface PageHeaderProps {
+  title: string
+  description?: string
+  icon?: ReactNode
+  badge?: ReactNode
+  actions?: ReactNode
+  className?: string
+}
+
+export function PageHeader({
+  title,
+  description,
+  icon,
+  badge,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col justify-between gap-4 md:flex-row md:items-center",
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        {icon ? (
+          <span className="mt-1 flex size-9 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-200">
+            {icon}
+          </span>
+        ) : null}
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className={textStyles.pageTitle}>{title}</h1>
+            {badge}
+          </div>
+          {description ? (
+            <p className={textStyles.pageSubtitle}>{description}</p>
+          ) : null}
+        </div>
+      </div>
+      {actions ? (
+        <div className="flex flex-wrap items-center gap-2">{actions}</div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/repositories/RepositoriesClient.tsx
+++ b/components/repositories/RepositoriesClient.tsx
@@ -5,19 +5,22 @@ import { useRepositories } from "@/hooks/useRepositories"
 import RepositoriesPageHeader from "@/components/github/RepositoriesPageHeader"
 import RepoSearchBar from "@/components/github/RepoSearchBar"
 import RepoList from "@/components/github/RepoList"
+import { PageContainer } from "@/components/layout/PageContainer"
 
 export default function RepositoriesClient() {
   const [search, setSearch] = useState("")
-  const { data } = useRepositories()
+  const repositoriesQuery = useRepositories()
+  const { data } = repositoriesQuery
 
   const connectedCount =
-    data?.pages.flatMap((p) => p.repos).filter((r) => r.isConnected).length ?? 0
+    data?.pages.flatMap((page) => page.repos).filter((repo) => repo.isConnected)
+      .length ?? 0
 
   return (
-    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-2 duration-500">
+    <PageContainer>
       <RepositoriesPageHeader connectedCount={connectedCount} />
       <RepoSearchBar value={search} onChange={setSearch} />
-      <RepoList search={search} />
-    </div>
+      <RepoList search={search} repositoriesQuery={repositoriesQuery} />
+    </PageContainer>
   )
 }

--- a/docs/shared-repository-migration-retrospective.md
+++ b/docs/shared-repository-migration-retrospective.md
@@ -1,0 +1,224 @@
+# 공유 저장소 다대다 전환 회고
+
+## 배경
+
+CodeMate는 GitHub 저장소를 연결한 뒤 PR 목록, 리뷰 결과, 댓글 협업 기능을 제공한다.  
+초기 구조는 저장소 1개를 사용자 1명이 소유하는 형태에 가까웠고, `Repository.userId`를 기준으로 접근 권한을 판단하는 코드가 남아 있었다.
+
+하지만 실제 제품 요구사항은 달랐다.
+
+- 한 저장소를 여러 사용자가 함께 연결할 수 있어야 한다.
+- 같은 저장소의 PR, 댓글, 리뷰 결과를 여러 사용자가 함께 봐야 한다.
+- AI 리뷰는 사용자별 복제가 아니라 저장소/PR 단위의 공유 리뷰로 동작해야 한다.
+
+이 요구사항을 만족시키기 위해 저장소 접근 모델을 `Repository.userId` 단일 소유자 방식에서 `UserRepository` 조인 테이블 기반의 다대다 방식으로 전환했다.
+
+---
+
+## 문제 상황
+
+다른 사용자가 이미 연결한 저장소를 두 번째 사용자가 연결하려고 하면 아래와 같은 에러가 발생했다.
+
+```text
+Repository is already connected by another user
+```
+
+또한 저장소 목록 API에서 다음 에러가 발생했다.
+
+```text
+GET /api/github/repos?page=1 503
+Shared repository migration is not applied. Run the "split_repository_membership" migration first.
+```
+
+이 문제는 단순한 UI 이슈가 아니라, 코드와 실제 운영 DB 스키마가 서로 다른 상태에서 발생한 구조적 문제였다.
+
+---
+
+## 원인 분석
+
+### 1. 코드와 DB 스키마가 서로 다른 상태였다
+
+Prisma schema와 migration 파일은 이미 `UserRepository` 기반 다대다 구조를 정의하고 있었다.
+
+- `prisma/schema.prisma`
+- `prisma/migrations/20260417000000_split_repository_membership/migration.sql`
+
+하지만 실제 연결된 DB는 아직 이전 구조였다.
+
+- `Repository.userId` 컬럼은 존재
+- `UserRepository` 테이블은 없음
+
+즉, 애플리케이션은 다대다를 지향하고 있었지만 실제 DB는 여전히 단일 소유자 구조였다.
+
+### 2. 임시 fallback이 문제를 더 오래 숨겼다
+
+처음에는 런타임 호환을 위해
+
+- `UserRepository`가 있으면 다대다 경로 사용
+- 없으면 `Repository.userId` fallback 사용
+
+방식을 넣었다.
+
+이 방식은 일시적으로 화면을 살리는 데는 도움이 됐지만, 실제로는 제품 요구사항과 충돌했다.  
+특히 저장소 연결(write path)에서는 fallback이 곧 "다른 사용자는 연결할 수 없음"이라는 정책으로 이어졌다.
+
+### 3. Prisma migration 자체도 바로 적용할 수 없는 상태였다
+
+기존 운영 DB에 이미 테이블과 데이터가 존재했기 때문에, Prisma는 첫 `migrate deploy` 시점에 다음 에러를 반환했다.
+
+```text
+P3005: The database schema is not empty
+```
+
+즉, 이 DB는 "빈 DB에 migration을 처음부터 올리는 방식"이 아니라, 현재 상태를 기준점으로 삼는 **baseline migration** 절차가 필요했다.
+
+---
+
+## 해결 방법
+
+### 1. 저장소 접근 코드를 다대다 전용으로 정리했다
+
+`lib/repository-access.ts`를 중심으로 저장소 권한 판단을 `UserRepository`만 기준으로 하도록 정리했다.
+
+핵심 변경:
+
+- 접근 가능한 저장소 목록 조회: `UserRepository`
+- 저장소 연결: `(userId, repositoryId)` membership 생성
+- 저장소 해제: membership 삭제
+- 저장소 멤버 조회: `UserRepository` 기반
+- 대표 사용자/토큰 조회: membership을 통해 조회
+
+즉, 더 이상 `Repository.userId`를 쓰지 않도록 읽기/쓰기 경로를 모두 정리했다.
+
+관련 파일:
+
+- `lib/repository-access.ts`
+- `app/api/repositories/route.ts`
+- `app/api/repositories/[id]/route.ts`
+- `app/api/github/repos/route.ts`
+- `lib/dashboard.ts`
+- `lib/stats.ts`
+- `app/api/pulls/*`
+- `app/api/review/analyze/route.ts`
+- `app/api/webhook/github/route.ts`
+
+### 2. fallback을 제거하고, 마이그레이션 누락을 명시적으로 드러냈다
+
+운영 요구사항이 "공유 저장소"인 이상, 단일 소유자 fallback을 유지하면 안 된다고 판단했다.
+
+그래서 `UserRepository`가 없으면 조용히 예전 구조로 fallback하지 않고, 명시적으로 다음 에러를 반환하도록 바꿨다.
+
+```text
+Shared repository migration is not applied.
+Run the "split_repository_membership" migration first.
+```
+
+이렇게 변경한 이유는:
+
+- 원인을 빠르게 식별할 수 있고
+- 코드가 제품 요구사항과 어긋난 상태로 오래 남지 않으며
+- 운영 환경에서 "왜 다른 사용자는 연결이 안 되지?" 같은 혼란을 줄일 수 있기 때문이다
+
+### 3. 기존 운영 DB를 Prisma baseline 절차로 편입했다
+
+운영 DB가 비어 있지 않았기 때문에 바로 `migrate deploy`를 할 수 없었다.  
+그래서 baseline 절차를 사용했다.
+
+진행 순서:
+
+1. 현재 운영 DB 상태를 `schema.baseline.prisma`로 introspect
+2. 운영 DB 상태를 기준으로 `0_init` baseline migration 생성
+3. `migrate resolve --applied 0_init`로 baseline 등록
+4. 이후 실제 신규 migration인 `split_repository_membership` 적용
+
+이 과정으로 "이미 운영 중인 DB"를 Prisma migration 체계 안으로 안전하게 편입할 수 있었다.
+
+추가로 baseline 작업을 위해 아래 파일도 정리했다.
+
+- `prisma/schema.baseline.prisma`
+
+### 4. Supabase 연결 방식도 migration 친화적으로 분리했다
+
+런타임 쿼리는 pooler URL로 잘 동작했지만, Prisma migration은 direct/session 연결이 더 안정적이었다.
+
+그래서 `prisma.config.ts`에서:
+
+- `DATABASE_URL`: 앱 런타임용
+- `DIRECT_DATABASE_URL`: Prisma migration용
+
+으로 분리해 사용하도록 정리했다.
+
+이 변경으로 다음 문제를 함께 해결했다.
+
+- pooler URL로 migration이 오래 멈추는 현상
+- direct connection / session mode를 구분하지 않아 생기는 운영 혼란
+
+관련 파일:
+
+- `prisma.config.ts`
+- `.env.example`
+- `README.md`
+
+---
+
+## 결과
+
+### 기능적 결과
+
+- 한 저장소를 여러 사용자가 연결할 수 있게 됐다.
+- 같은 저장소의 PR, 댓글, 리뷰 데이터를 여러 사용자가 공유할 수 있게 됐다.
+- `"Repository is already connected by another user"` 정책 충돌이 제거됐다.
+- 저장소 목록 API가 500으로 뭉개지지 않고, 스키마 상태를 정확히 드러내게 됐다.
+
+### 운영 관점 결과
+
+- 코드와 DB 스키마 불일치를 명확하게 드러내도록 개선했다.
+- fallback으로 문제를 숨기지 않고, migration 누락을 명시적으로 노출하도록 바꿨다.
+- 기존 운영 DB를 Prisma migration 체계 안으로 baseline 처리해 이후 migration 적용 가능 상태로 전환했다.
+
+---
+
+## 포트폴리오용 요약 문장
+
+### 짧은 버전
+
+> 단일 소유자 기반 GitHub 저장소 연결 구조를 `UserRepository` 조인 테이블 기반의 다대다 모델로 전환해, 여러 사용자가 같은 저장소와 PR 리뷰 데이터를 공유할 수 있도록 개선했습니다. 기존 운영 DB는 Prisma baseline migration 절차로 편입해 안전하게 스키마를 전환했고, migration 누락 시 명시적 에러를 반환하도록 해 운영 디버깅 난이도도 낮췄습니다.
+
+### 조금 더 자세한 버전
+
+> GitHub 저장소 연결 기능이 `Repository.userId` 단일 소유자 구조에 묶여 있어, 다른 사용자가 이미 연결한 저장소를 추가로 연결할 수 없는 문제가 있었습니다. 이를 해결하기 위해 `UserRepository` 조인 테이블 기반의 다대다 저장소 접근 모델로 전환하고, PR/댓글/AI 리뷰 공유 흐름이 이 모델을 일관되게 사용하도록 API와 접근 제어 로직을 정리했습니다. 또한 비어 있지 않은 기존 운영 DB를 Prisma baseline migration 절차로 편입해 스키마 전환을 안전하게 수행했고, migration 누락 시 500이 아닌 명시적 에러를 반환하도록 개선해 운영 가시성을 높였습니다.
+
+---
+
+## 배운 점
+
+### 1. 읽기 경로 fallback과 쓰기 경로 정책은 분리해서 봐야 한다
+
+읽기 fallback은 일시적인 호환성 확보에 유용할 수 있다.  
+하지만 쓰기 경로까지 fallback을 허용하면, 제품 요구사항과 다른 정책이 실제 운영에 남아 버릴 수 있다.
+
+이번 사례에서는 "여러 사용자가 같은 저장소를 연결할 수 있어야 한다"는 요구가 명확했기 때문에, 쓰기 경로는 다대다 모델만 허용하는 편이 맞았다.
+
+### 2. 운영 DB 전환에서 migration 파일만 있다고 끝이 아니다
+
+코드 저장소에 migration SQL이 존재해도, 실제 운영 DB에 반영되지 않았다면 제품은 여전히 이전 구조로 동작한다.  
+특히 Prisma를 기존 DB에 도입할 때는 baseline 전략이 중요하다는 점을 체감했다.
+
+### 3. 명시적인 장애 메시지는 디버깅 시간을 크게 줄인다
+
+초기에는 `/api/github/repos`가 단순 500으로 보였지만, 원인을 구체적인 503 메시지로 노출한 뒤부터는 문제 범위를 빠르게 좁힐 수 있었다.
+
+운영 환경에서는 "고쳤는가"만큼 "왜 안 되는지 빨리 알 수 있는가"도 중요하다.
+
+---
+
+## 관련 키워드
+
+- Prisma Migrate
+- Baselining Existing Database
+- PostgreSQL Schema Migration
+- Next.js App Router
+- Multi-tenant Repository Access
+- Many-to-Many Modeling
+- GitHub Integration
+- Operational Debugging

--- a/hooks/useRepositories.ts
+++ b/hooks/useRepositories.ts
@@ -1,14 +1,24 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query"
 
-import type { RepoListResponse } from "@/types/repos";
+import type { RepoListResponse } from "@/types/repos"
 
 async function fetchRepositoriesPage(page: number): Promise<RepoListResponse> {
-  const params = new URLSearchParams();
-  params.set("page", String(page));
+  const params = new URLSearchParams()
+  params.set("page", String(page))
 
-  const res = await fetch(`/api/github/repos?${params}`);
-  if (!res.ok) throw new Error("저장소 목록을 불러오는 데 실패했습니다.");
-  return res.json();
+  const res = await fetch(`/api/github/repos?${params}`)
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => null)
+
+    throw new Error(
+      typeof body?.error === "string"
+        ? body.error
+        : "저장소 목록을 불러오지 못했습니다."
+    )
+  }
+
+  return res.json()
 }
 
 export function useRepositories() {
@@ -17,8 +27,8 @@ export function useRepositories() {
     queryFn: ({ pageParam }) => fetchRepositoriesPage(pageParam),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {
-      const { page, hasNextPage } = lastPage.pagination;
-      return hasNextPage ? page + 1 : undefined;
+      const { page, hasNextPage } = lastPage.pagination
+      return hasNextPage ? page + 1 : undefined
     },
-  });
+  })
 }

--- a/lib/ai/analyze.ts
+++ b/lib/ai/analyze.ts
@@ -4,15 +4,9 @@ import { prisma } from "@/lib/prisma"
 import { getAnthropicClient, CLAUDE_MODEL } from "@/lib/ai/claude"
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/ai/prompts"
 import { parseAIReviewResponse } from "@/lib/ai/parsers"
+import { getRepositoryPrimaryUser } from "@/lib/repository-access"
 import { calculateScore } from "@/lib/scoring"
 
-/**
- * DB partial unique index("review_active_unique") 위반 여부를 판별한다.
- *
- * 이 오류는 동일 PR에 대해 PENDING/IN_PROGRESS Review가 이미 존재할 때 발생하며,
- * "다른 인스턴스가 이미 처리 중"이라는 정상적인 중복 차단 신호다.
- * → 오류로 취급하지 않고 조용히 종료(early return)한다.
- */
 function isActiveReviewConflict(err: unknown): boolean {
   return (
     err instanceof Prisma.PrismaClientKnownRequestError &&
@@ -26,12 +20,6 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
   let reviewId: string | null = null
 
   try {
-    // ── Review 레코드 생성 ──────────────────────────────────────────────────
-    // findFirst → create 패턴(TOCTOU race condition)을 제거하고,
-    // create를 먼저 시도한다.
-    //
-    // DB partial unique index가 PENDING/IN_PROGRESS 중복을 원자적으로 차단하므로
-    // 동시 요청이 와도 정확히 하나의 인스턴스만 create에 성공한다.
     let review: { id: string }
     try {
       review = await prisma.review.create({
@@ -45,16 +33,17 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
         },
         select: { id: true },
       })
-    } catch (err) {
-      if (isActiveReviewConflict(err)) {
-        // 이미 다른 인스턴스가 처리 중 — 정상적인 중복 차단
+    } catch (error) {
+      if (isActiveReviewConflict(error)) {
         console.info(
           `[analyzeReview] already active for PR ${pullRequestId}, skipping.`
         )
         return
       }
-      throw err
+
+      throw error
     }
+
     reviewId = review.id
 
     await prisma.review.update({
@@ -62,24 +51,27 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
       data: { status: "IN_PROGRESS" },
     })
 
-    // ── PR + Repository + GitHub 토큰 로드 ─────────────────────────────────
     const pr = await prisma.pullRequest.findUnique({
       where: { id: pullRequestId },
       include: {
-        repo: {
-          include: {
-            owner: { select: { githubToken: true, name: true } },
-          },
-        },
+        repo: true,
       },
     })
 
-    if (!pr) throw new Error(`PullRequest not found: ${pullRequestId}`)
+    if (!pr) {
+      throw new Error(`Pull request not found: ${pullRequestId}`)
+    }
 
-    const { githubToken, name: authorName } = pr.repo.owner
-    if (!githubToken) throw new Error("GitHub token not found for repository owner")
+    const tokenUser = await getRepositoryPrimaryUser(pr.repo.id, {
+      requireGithubToken: true,
+    })
+    const githubToken = tokenUser?.githubToken ?? null
+    const authorName = tokenUser?.name ?? null
 
-    // ── GitHub에서 PR diff 조회 ─────────────────────────────────────────────
+    if (!githubToken) {
+      throw new Error("GitHub token not found for any connected repository user")
+    }
+
     const octokit = new Octokit({ auth: githubToken })
     const [owner, repo] = pr.repo.fullName.split("/")
 
@@ -92,8 +84,8 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
 
     const MAX_DIFF_CHARS = 20000
     let diff = ""
-    for (const f of files.filter((f) => f.patch)) {
-      const chunk = `--- ${f.filename}\n${f.patch}\n\n`
+    for (const file of files.filter((candidate) => candidate.patch)) {
+      const chunk = `--- ${file.filename}\n${file.patch}\n\n`
       if (diff.length + chunk.length > MAX_DIFF_CHARS) {
         diff += "... (diff truncated)"
         break
@@ -101,7 +93,6 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
       diff += chunk
     }
 
-    // ── Claude 호출 ─────────────────────────────────────────────────────────
     const response = await getAnthropicClient().messages.create({
       model: CLAUDE_MODEL,
       max_tokens: 8192,
@@ -138,8 +129,8 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
         status: "COMPLETED",
       },
     })
-  } catch (err) {
-    console.error("[analyzeReview] failed:", err)
+  } catch (error) {
+    console.error("[analyzeReview] failed:", error)
 
     if (reviewId) {
       await prisma.review.update({

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache"
 import { prisma } from "@/lib/prisma"
 import {
   fetchQualityTrend,
@@ -5,16 +6,17 @@ import {
   type QualityTrendItem,
   type IssueSeverityItem,
 } from "@/lib/stats"
+import { getAccessibleRepositoryIds } from "@/lib/repository-access"
 
 export type { QualityTrendItem, IssueSeverityItem }
 
 export interface DashboardStats {
   avgQualityScore: number
-  qualityScoreTrend: number // 이전 30일 대비 변화율 (%)
+  qualityScoreTrend: number
   openPRs: number
-  pendingReviewPRs: number // 리뷰 없는 OPEN PR 수
+  pendingReviewPRs: number
   weeklyReviews: number
-  weeklyReviewsDiff: number // 지난주 대비 차이
+  weeklyReviewsDiff: number
 }
 
 export interface DashboardRecentPR {
@@ -27,17 +29,18 @@ export interface DashboardRecentPR {
 }
 
 function getWeekStart(date: Date): Date {
-  const d = new Date(date)
-  const day = d.getDay()
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
-  d.setDate(diff)
-  d.setHours(0, 0, 0, 0)
-  return d
+  const current = new Date(date)
+  const day = current.getDay()
+  const diff = current.getDate() - day + (day === 0 ? -6 : 1)
+  current.setDate(diff)
+  current.setHours(0, 0, 0, 0)
+  return current
 }
 
 export async function fetchDashboardStats(
   userId: string
 ): Promise<DashboardStats> {
+  const repoIds = await getAccessibleRepositoryIds(userId)
   const now = new Date()
 
   const thirtyDaysAgo = new Date(now)
@@ -52,7 +55,11 @@ export async function fetchDashboardStats(
   const lastWeekStart = new Date(thisWeekStart)
   lastWeekStart.setDate(thisWeekStart.getDate() - 7)
 
-  const repoFilter = { repo: { userId } }
+  const pullRequestFilter = {
+    repoId: {
+      in: repoIds,
+    },
+  }
 
   const [
     currentQuality,
@@ -64,7 +71,7 @@ export async function fetchDashboardStats(
   ] = await Promise.all([
     prisma.review.aggregate({
       where: {
-        pullRequest: repoFilter,
+        pullRequest: pullRequestFilter,
         status: "COMPLETED",
         reviewedAt: { gte: thirtyDaysAgo },
       },
@@ -72,32 +79,32 @@ export async function fetchDashboardStats(
     }),
     prisma.review.aggregate({
       where: {
-        pullRequest: repoFilter,
+        pullRequest: pullRequestFilter,
         status: "COMPLETED",
         reviewedAt: { gte: sixtyDaysAgo, lt: thirtyDaysAgo },
       },
       _avg: { qualityScore: true },
     }),
     prisma.pullRequest.count({
-      where: { ...repoFilter, status: "OPEN" },
+      where: { ...pullRequestFilter, status: "OPEN" },
     }),
     prisma.pullRequest.count({
       where: {
-        ...repoFilter,
+        ...pullRequestFilter,
         status: "OPEN",
         reviews: { none: { status: "COMPLETED" } },
       },
     }),
     prisma.review.count({
       where: {
-        pullRequest: repoFilter,
+        pullRequest: pullRequestFilter,
         status: "COMPLETED",
         reviewedAt: { gte: thisWeekStart },
       },
     }),
     prisma.review.count({
       where: {
-        pullRequest: repoFilter,
+        pullRequest: pullRequestFilter,
         status: "COMPLETED",
         reviewedAt: { gte: lastWeekStart, lt: thisWeekStart },
       },
@@ -132,15 +139,21 @@ export async function fetchDashboardQualityTrend(
 export async function fetchDashboardIssueSeverity(
   userId: string
 ): Promise<IssueSeverityItem[]> {
-  const dist = await fetchIssueDistribution(userId, "30d")
-  return dist.bySeverity
+  const distribution = await fetchIssueDistribution(userId, "30d")
+  return distribution.bySeverity
 }
 
 export async function fetchDashboardRecentPRs(
   userId: string
 ): Promise<DashboardRecentPR[]> {
-  const prs = await prisma.pullRequest.findMany({
-    where: { repo: { userId } },
+  const repoIds = await getAccessibleRepositoryIds(userId)
+
+  const pullRequests = await prisma.pullRequest.findMany({
+    where: {
+      repoId: {
+        in: repoIds,
+      },
+    },
     select: {
       id: true,
       number: true,
@@ -161,12 +174,40 @@ export async function fetchDashboardRecentPRs(
     take: 5,
   })
 
-  return prs.map((pr) => ({
-    id: pr.id,
-    number: pr.number,
-    title: pr.title,
-    repoName: pr.repo.name,
-    score: pr.reviews[0]?.qualityScore ?? null,
-    status: pr.status as DashboardRecentPR["status"],
+  return pullRequests.map((pullRequest) => ({
+    id: pullRequest.id,
+    number: pullRequest.number,
+    title: pullRequest.title,
+    repoName: pullRequest.repo.name,
+    score: pullRequest.reviews[0]?.qualityScore ?? null,
+    status: pullRequest.status as DashboardRecentPR["status"],
   }))
 }
+
+export const getCachedDashboardStats = (userId: string) =>
+  unstable_cache(
+    () => fetchDashboardStats(userId),
+    ["dashboard-stats", userId],
+    { revalidate: 3600, tags: ["dashboard", `dashboard-${userId}`] }
+  )()
+
+export const getCachedDashboardQualityTrend = (userId: string) =>
+  unstable_cache(
+    () => fetchDashboardQualityTrend(userId),
+    ["dashboard-quality-trend", userId],
+    { revalidate: 3600, tags: ["dashboard", `dashboard-${userId}`] }
+  )()
+
+export const getCachedDashboardIssueSeverity = (userId: string) =>
+  unstable_cache(
+    () => fetchDashboardIssueSeverity(userId),
+    ["dashboard-issue-severity", userId],
+    { revalidate: 3600, tags: ["dashboard", `dashboard-${userId}`] }
+  )()
+
+export const getCachedDashboardRecentPRs = (userId: string) =>
+  unstable_cache(
+    () => fetchDashboardRecentPRs(userId),
+    ["dashboard-recent-prs", userId],
+    { revalidate: 3600, tags: ["dashboard", `dashboard-${userId}`] }
+  )()

--- a/lib/repository-access.ts
+++ b/lib/repository-access.ts
@@ -1,0 +1,235 @@
+import type { Prisma } from "@/lib/generated/prisma/client"
+import { prisma } from "@/lib/prisma"
+
+type MembershipTableRow = {
+  exists: boolean
+}
+
+const REPOSITORY_MEMBERSHIP_MIGRATION_ERROR =
+  'Database migration required: "UserRepository" table is missing.'
+
+export interface RepositoryUser {
+  id: string
+  name: string | null
+  image: string | null
+  githubToken: string | null
+}
+
+let membershipTableReadyPromise: Promise<void> | null = null
+
+async function ensureRepositoryMembershipTable(): Promise<void> {
+  if (!membershipTableReadyPromise) {
+    membershipTableReadyPromise = prisma
+      .$queryRaw<MembershipTableRow[]>`
+        SELECT EXISTS (
+          SELECT 1
+          FROM information_schema.tables
+          WHERE table_schema = 'public'
+            AND table_name = 'UserRepository'
+        ) AS "exists"
+      `
+      .then((rows) => {
+        if (!rows[0]?.exists) {
+          throw new Error(REPOSITORY_MEMBERSHIP_MIGRATION_ERROR)
+        }
+      })
+      .catch((error) => {
+        membershipTableReadyPromise = null
+        throw error
+      })
+  }
+
+  await membershipTableReadyPromise
+}
+
+export async function getAccessibleRepositoryIds(
+  userId: string,
+  repositoryId?: string
+): Promise<string[]> {
+  await ensureRepositoryMembershipTable()
+
+  const memberships = await prisma.userRepository.findMany({
+    where: {
+      userId,
+      ...(repositoryId ? { repositoryId } : {}),
+    },
+    select: {
+      repositoryId: true,
+    },
+  })
+
+  return memberships.map((membership) => membership.repositoryId)
+}
+
+export async function buildAccessibleRepositoryWhere(
+  userId: string,
+  repositoryId?: string
+): Promise<Prisma.RepositoryWhereInput> {
+  const ids = await getAccessibleRepositoryIds(userId, repositoryId)
+
+  return {
+    id: {
+      in: ids,
+    },
+  }
+}
+
+export async function buildAccessiblePullRequestWhere(
+  userId: string,
+  repositoryId?: string
+): Promise<Prisma.PullRequestWhereInput> {
+  const ids = await getAccessibleRepositoryIds(userId, repositoryId)
+
+  return {
+    repoId: {
+      in: ids,
+    },
+  }
+}
+
+export async function isRepositoryAccessibleToUser(
+  userId: string,
+  repositoryId: string
+): Promise<boolean> {
+  await ensureRepositoryMembershipTable()
+
+  const membership = await prisma.userRepository.findUnique({
+    where: {
+      userId_repositoryId: {
+        userId,
+        repositoryId,
+      },
+    },
+    select: {
+      id: true,
+    },
+  })
+
+  return Boolean(membership)
+}
+
+export async function getRepositoryMemberIds(
+  repositoryId: string
+): Promise<string[]> {
+  await ensureRepositoryMembershipTable()
+
+  const memberships = await prisma.userRepository.findMany({
+    where: {
+      repositoryId,
+    },
+    select: {
+      userId: true,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  })
+
+  return memberships.map((membership) => membership.userId)
+}
+
+export async function getRepositoryMemberCount(
+  repositoryId: string
+): Promise<number> {
+  await ensureRepositoryMembershipTable()
+
+  return prisma.userRepository.count({
+    where: {
+      repositoryId,
+    },
+  })
+}
+
+export async function getRepositoryPrimaryUser(
+  repositoryId: string,
+  options: { requireGithubToken?: boolean } = {}
+): Promise<RepositoryUser | null> {
+  await ensureRepositoryMembershipTable()
+
+  const membership = await prisma.userRepository.findFirst({
+    where: {
+      repositoryId,
+      ...(options.requireGithubToken
+        ? {
+            user: {
+              githubToken: {
+                not: null,
+              },
+            },
+          }
+        : {}),
+    },
+    select: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          image: true,
+          githubToken: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  })
+
+  return membership?.user ?? null
+}
+
+export async function connectRepositoryToUser(
+  userId: string,
+  repositoryId: string
+): Promise<"created" | "existing"> {
+  await ensureRepositoryMembershipTable()
+
+  const existingMembership = await prisma.userRepository.findUnique({
+    where: {
+      userId_repositoryId: {
+        userId,
+        repositoryId,
+      },
+    },
+    select: {
+      id: true,
+    },
+  })
+
+  if (existingMembership) {
+    return "existing"
+  }
+
+  await prisma.userRepository.create({
+    data: {
+      userId,
+      repositoryId,
+    },
+  })
+
+  return "created"
+}
+
+export async function detachRepositoryFromUser(
+  userId: string,
+  repositoryId: string
+): Promise<void> {
+  await ensureRepositoryMembershipTable()
+
+  await prisma.userRepository.delete({
+    where: {
+      userId_repositoryId: {
+        userId,
+        repositoryId,
+      },
+    },
+  })
+}
+
+export function isRepositoryMembershipMigrationError(
+  error: unknown
+): boolean {
+  return (
+    error instanceof Error &&
+    error.message === REPOSITORY_MEMBERSHIP_MIGRATION_ERROR
+  )
+}

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma"
 import type { AIReviewIssue } from "@/lib/ai/parsers"
+import { getAccessibleRepositoryIds } from "@/lib/repository-access"
 
 export type StatsRange = "7d" | "30d" | "90d" | "all"
 export type StatsType =
@@ -87,20 +88,19 @@ export function isValidRange(range: string): range is StatsRange {
 function getStartDate(range: StatsRange): Date | undefined {
   if (range === "all") return undefined
   const days = range === "7d" ? 7 : range === "30d" ? 30 : 90
-  const d = new Date()
-  d.setDate(d.getDate() - days)
-  d.setHours(0, 0, 0, 0)
-  return d
+  const startDate = new Date()
+  startDate.setDate(startDate.getDate() - days)
+  startDate.setHours(0, 0, 0, 0)
+  return startDate
 }
 
-// 해당 날짜가 속한 주의 월요일을 반환
 function getWeekStart(date: Date): Date {
-  const d = new Date(date)
-  const day = d.getDay()
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
-  d.setDate(diff)
-  d.setHours(0, 0, 0, 0)
-  return d
+  const current = new Date(date)
+  const day = current.getDay()
+  const diff = current.getDate() - day + (day === 0 ? -6 : 1)
+  current.setDate(diff)
+  current.setHours(0, 0, 0, 0)
+  return current
 }
 
 function formatWeekLabel(date: Date): string {
@@ -116,32 +116,29 @@ export async function fetchStatsOverview(
   range: StatsRange,
   repoId?: string
 ): Promise<StatsOverview> {
+  const repoIds = await getAccessibleRepositoryIds(userId, repoId)
   const startDate = getStartDate(range)
 
-  const prDateFilter = startDate
-    ? { githubCreatedAt: { gte: startDate } }
-    : {}
-  const reviewDateFilter = startDate
-    ? { reviewedAt: { gte: startDate } }
-    : {}
-  const commentDateFilter = startDate
-    ? { createdAt: { gte: startDate } }
-    : {}
+  const prDateFilter = startDate ? { githubCreatedAt: { gte: startDate } } : {}
+  const reviewDateFilter = startDate ? { reviewedAt: { gte: startDate } } : {}
+  const commentDateFilter = startDate ? { createdAt: { gte: startDate } } : {}
 
-  const prRepoFilter = {
-    repo: { userId, ...(repoId ? { id: repoId } : {}) },
+  const pullRequestFilter = {
+    repoId: {
+      in: repoIds,
+    },
   }
 
-  const [prStats, reviewAgg, issueAgg, totalComments, resolvedComments] =
+  const [prStats, reviewAggregate, issueAggregate, totalComments, resolvedComments] =
     await Promise.all([
       prisma.pullRequest.groupBy({
         by: ["status"],
-        where: { ...prRepoFilter, ...prDateFilter },
+        where: { ...pullRequestFilter, ...prDateFilter },
         _count: { id: true },
       }),
       prisma.review.aggregate({
         where: {
-          pullRequest: prRepoFilter,
+          pullRequest: pullRequestFilter,
           status: "COMPLETED",
           ...reviewDateFilter,
         },
@@ -149,27 +146,26 @@ export async function fetchStatsOverview(
       }),
       prisma.review.aggregate({
         where: {
-          pullRequest: prRepoFilter,
+          pullRequest: pullRequestFilter,
           status: "COMPLETED",
           ...reviewDateFilter,
         },
         _sum: { issueCount: true },
       }),
       prisma.comment.count({
-        where: { pullRequest: prRepoFilter, ...commentDateFilter },
+        where: { pullRequest: pullRequestFilter, ...commentDateFilter },
       }),
       prisma.comment.count({
         where: {
-          pullRequest: prRepoFilter,
+          pullRequest: pullRequestFilter,
           isResolved: true,
           ...commentDateFilter,
         },
       }),
     ])
 
-  const totalPRs = prStats.reduce((sum, s) => sum + s._count.id, 0)
-  const mergedPRs =
-    prStats.find((s) => s.status === "MERGED")?._count.id ?? 0
+  const totalPRs = prStats.reduce((sum, item) => sum + item._count.id, 0)
+  const mergedPRs = prStats.find((item) => item.status === "MERGED")?._count.id ?? 0
   const mergeRate =
     totalPRs > 0 ? Math.round((mergedPRs / totalPRs) * 1000) / 10 : 0
 
@@ -178,8 +174,8 @@ export async function fetchStatsOverview(
     mergedPRs,
     mergeRate,
     avgQualityScore:
-      Math.round((reviewAgg._avg.qualityScore ?? 0) * 10) / 10,
-    totalIssues: issueAgg._sum.issueCount ?? 0,
+      Math.round((reviewAggregate._avg.qualityScore ?? 0) * 10) / 10,
+    totalIssues: issueAggregate._sum.issueCount ?? 0,
     resolvedComments,
     totalComments,
   }
@@ -190,11 +186,12 @@ export async function fetchPRTrend(
   range: StatsRange,
   repoId?: string
 ): Promise<PRTrendItem[]> {
+  const repoIds = await getAccessibleRepositoryIds(userId, repoId)
   const startDate = getStartDate(range)
 
-  const prs = await prisma.pullRequest.findMany({
+  const pullRequests = await prisma.pullRequest.findMany({
     where: {
-      repo: { userId, ...(repoId ? { id: repoId } : {}) },
+      repoId: { in: repoIds },
       ...(startDate ? { githubCreatedAt: { gte: startDate } } : {}),
     },
     select: { status: true, githubCreatedAt: true, createdAt: true },
@@ -203,8 +200,8 @@ export async function fetchPRTrend(
 
   const weekMap = new Map<string, PRTrendItem>()
 
-  for (const pr of prs) {
-    const date = pr.githubCreatedAt ?? pr.createdAt
+  for (const pullRequest of pullRequests) {
+    const date = pullRequest.githubCreatedAt ?? pullRequest.createdAt
     const weekStart = getWeekStart(date)
     const key = weekStart.toISOString()
 
@@ -219,10 +216,10 @@ export async function fetchPRTrend(
     }
 
     const entry = weekMap.get(key)!
-    if (pr.status === "OPEN") entry.open++
-    else if (pr.status === "MERGED") entry.merged++
-    else if (pr.status === "CLOSED") entry.closed++
-    else if (pr.status === "DRAFT") entry.draft++
+    if (pullRequest.status === "OPEN") entry.open++
+    else if (pullRequest.status === "MERGED") entry.merged++
+    else if (pullRequest.status === "CLOSED") entry.closed++
+    else if (pullRequest.status === "DRAFT") entry.draft++
   }
 
   return Array.from(weekMap.values())
@@ -233,13 +230,12 @@ export async function fetchQualityTrend(
   range: StatsRange,
   repoId?: string
 ): Promise<QualityTrendItem[]> {
+  const repoIds = await getAccessibleRepositoryIds(userId, repoId)
   const startDate = getStartDate(range)
 
   const reviews = await prisma.review.findMany({
     where: {
-      pullRequest: {
-        repo: { userId, ...(repoId ? { id: repoId } : {}) },
-      },
+      pullRequest: { repoId: { in: repoIds } },
       status: "COMPLETED",
       ...(startDate ? { reviewedAt: { gte: startDate } } : {}),
     },
@@ -249,21 +245,24 @@ export async function fetchQualityTrend(
 
   const dayMap = new Map<string, { total: number; count: number }>()
 
-  for (const r of reviews) {
-    const d = new Date(r.reviewedAt)
-    d.setHours(0, 0, 0, 0)
-    const key = d.toISOString()
+  for (const review of reviews) {
+    const day = new Date(review.reviewedAt)
+    day.setHours(0, 0, 0, 0)
+    const key = day.toISOString()
 
-    if (!dayMap.has(key)) dayMap.set(key, { total: 0, count: 0 })
+    if (!dayMap.has(key)) {
+      dayMap.set(key, { total: 0, count: 0 })
+    }
+
     const entry = dayMap.get(key)!
-    entry.total += r.qualityScore
+    entry.total += review.qualityScore
     entry.count++
   }
 
-  return Array.from(dayMap.entries()).map(([key, val]) => ({
+  return Array.from(dayMap.entries()).map(([key, value]) => ({
     date: formatDayLabel(new Date(key)),
-    avgScore: Math.round((val.total / val.count) * 10) / 10,
-    reviewCount: val.count,
+    avgScore: Math.round((value.total / value.count) * 10) / 10,
+    reviewCount: value.count,
   }))
 }
 
@@ -272,12 +271,11 @@ export async function fetchIssueDistribution(
   range: StatsRange,
   repoId?: string
 ): Promise<IssueDistribution> {
+  const repoIds = await getAccessibleRepositoryIds(userId, repoId)
   const startDate = getStartDate(range)
 
   const reviewFilter = {
-    pullRequest: {
-      repo: { userId, ...(repoId ? { id: repoId } : {}) },
-    },
+    pullRequest: { repoId: { in: repoIds } },
     status: "COMPLETED" as const,
     ...(startDate ? { reviewedAt: { gte: startDate } } : {}),
   }
@@ -298,22 +296,21 @@ export async function fetchIssueDistribution(
   const bySeverity: IssueSeverityItem[] = severityOrder
     .map((name) => ({
       name,
-      value:
-        severityGroups.find((g) => g.severity === name)?._count.id ?? 0,
+      value: severityGroups.find((group) => group.severity === name)?._count.id ?? 0,
       color: SEVERITY_COLORS[name],
     }))
     .filter((item) => item.value > 0)
 
-  // aiSuggestions JSON에서 카테고리별 이슈 수 집계
   const categoryCount = new Map<string, number>()
 
-  for (const r of reviews) {
-    const suggestions = r.aiSuggestions as { issues?: AIReviewIssue[] }
+  for (const review of reviews) {
+    const suggestions = review.aiSuggestions as { issues?: AIReviewIssue[] }
     if (!suggestions?.issues) continue
+
     for (const issue of suggestions.issues) {
-      const cat = issue.category
-      if ((ISSUE_CATEGORIES as readonly string[]).includes(cat)) {
-        categoryCount.set(cat, (categoryCount.get(cat) ?? 0) + 1)
+      const category = issue.category
+      if ((ISSUE_CATEGORIES as readonly string[]).includes(category)) {
+        categoryCount.set(category, (categoryCount.get(category) ?? 0) + 1)
       }
     }
   }
@@ -331,11 +328,12 @@ export async function fetchCodeChanges(
   range: StatsRange,
   repoId?: string
 ): Promise<CodeChangesItem[]> {
+  const repoIds = await getAccessibleRepositoryIds(userId, repoId)
   const startDate = getStartDate(range)
 
-  const prs = await prisma.pullRequest.findMany({
+  const pullRequests = await prisma.pullRequest.findMany({
     where: {
-      repo: { userId, ...(repoId ? { id: repoId } : {}) },
+      repoId: { in: repoIds },
       ...(startDate ? { githubCreatedAt: { gte: startDate } } : {}),
     },
     select: {
@@ -350,8 +348,8 @@ export async function fetchCodeChanges(
 
   const weekMap = new Map<string, CodeChangesItem>()
 
-  for (const pr of prs) {
-    const date = pr.githubCreatedAt ?? pr.createdAt
+  for (const pullRequest of pullRequests) {
+    const date = pullRequest.githubCreatedAt ?? pullRequest.createdAt
     const weekStart = getWeekStart(date)
     const key = weekStart.toISOString()
 
@@ -365,9 +363,9 @@ export async function fetchCodeChanges(
     }
 
     const entry = weekMap.get(key)!
-    entry.additions += pr.additions
-    entry.deletions += pr.deletions
-    entry.files += pr.changedFiles
+    entry.additions += pullRequest.additions
+    entry.deletions += pullRequest.deletions
+    entry.files += pullRequest.changedFiles
   }
 
   return Array.from(weekMap.values())

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: process.env["DATABASE_URL"]!,
+    // Prefer a direct connection for Prisma schema/migration commands.
+    // Pooler URLs can work for runtime queries but often hang or fail for DDL.
+    url: process.env["DIRECT_DATABASE_URL"] ?? process.env["DATABASE_URL"]!,
   },
 });

--- a/prisma/migrations/20260417000000_split_repository_membership/migration.sql
+++ b/prisma/migrations/20260417000000_split_repository_membership/migration.sql
@@ -1,0 +1,43 @@
+CREATE TABLE "UserRepository" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "repositoryId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "UserRepository_pkey" PRIMARY KEY ("id")
+);
+
+INSERT INTO "UserRepository" ("id", "userId", "repositoryId", "createdAt", "updatedAt")
+SELECT
+  CONCAT('ur_', "id"),
+  "userId",
+  "id",
+  "createdAt",
+  "updatedAt"
+FROM "Repository";
+
+CREATE UNIQUE INDEX "UserRepository_userId_repositoryId_key"
+  ON "UserRepository"("userId", "repositoryId");
+
+CREATE INDEX "UserRepository_userId_idx"
+  ON "UserRepository"("userId");
+
+CREATE INDEX "UserRepository_repositoryId_idx"
+  ON "UserRepository"("repositoryId");
+
+ALTER TABLE "UserRepository"
+  ADD CONSTRAINT "UserRepository_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "UserRepository"
+  ADD CONSTRAINT "UserRepository_repositoryId_fkey"
+  FOREIGN KEY ("repositoryId") REFERENCES "Repository"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+DROP INDEX IF EXISTS "Repository_userId_idx";
+
+ALTER TABLE "Repository"
+  DROP CONSTRAINT IF EXISTS "Repository_userId_fkey";
+
+ALTER TABLE "Repository"
+  DROP COLUMN "userId";

--- a/prisma/schema.baseline.prisma
+++ b/prisma/schema.baseline.prisma
@@ -1,0 +1,214 @@
+generator client {
+  provider = "prisma-client"
+  output   = "../lib/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model Account {
+  id                String  @id
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+  User              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@index([userId])
+}
+
+model Comment {
+  id            String      @id
+  content       String
+  lineNumber    Int?
+  filePath      String?
+  isResolved    Boolean     @default(false)
+  pullRequestId String
+  authorId      String
+  parentId      String?
+  mentions      String[]
+  reactions     Json?
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime
+  User          User        @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  Comment       Comment?    @relation("CommentToComment", fields: [parentId], references: [id], onDelete: Cascade)
+  other_Comment Comment[]   @relation("CommentToComment")
+  PullRequest   PullRequest @relation(fields: [pullRequestId], references: [id], onDelete: Cascade)
+
+  @@index([authorId])
+  @@index([pullRequestId])
+}
+
+model Notification {
+  id        String           @id
+  type      NotificationType
+  title     String
+  message   String?
+  isRead    Boolean          @default(false)
+  userId    String
+  prId      String?
+  commentId String?
+  createdAt DateTime         @default(now())
+  User      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isRead])
+}
+
+model NotificationSetting {
+  id                  String   @id
+  userId              String   @unique
+  mentionEnabled      Boolean  @default(true)
+  newReviewEnabled    Boolean  @default(true)
+  prMergedEnabled     Boolean  @default(true)
+  commentReplyEnabled Boolean  @default(true)
+  updatedAt           DateTime
+  User                User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model PullRequest {
+  id              String     @id
+  githubId        BigInt     @unique
+  number          Int
+  title           String
+  description     String?
+  status          PRStatus   @default(OPEN)
+  baseBranch      String
+  headBranch      String
+  additions       Int        @default(0)
+  deletions       Int        @default(0)
+  changedFiles    Int        @default(0)
+  repoId          String
+  mergedAt        DateTime?
+  closedAt        DateTime?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime
+  githubCreatedAt DateTime?
+  githubUpdatedAt DateTime?
+  Comment         Comment[]
+  Repository      Repository @relation(fields: [repoId], references: [id], onDelete: Cascade)
+  Review          Review[]
+
+  @@index([repoId])
+  @@index([status])
+}
+
+model Repository {
+  id          String        @id
+  githubId    BigInt        @unique
+  name        String
+  fullName    String
+  description String?
+  language    String?
+  isActive    Boolean       @default(true)
+  webhookId   Int?
+  userId      String
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime
+  PullRequest PullRequest[]
+  User        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([fullName])
+  @@index([userId])
+}
+
+model Review {
+  id            String       @id
+  aiSuggestions Json
+  qualityScore  Int
+  severity      Severity     @default(LOW)
+  issueCount    Int          @default(0)
+  status        ReviewStatus @default(PENDING)
+  pullRequestId String
+  reviewedAt    DateTime     @default(now())
+  PullRequest   PullRequest  @relation(fields: [pullRequestId], references: [id], onDelete: Cascade)
+
+  @@index([pullRequestId])
+  @@index([status])
+}
+
+model ReviewSetting {
+  id            String   @id
+  userId        String   @unique
+  autoReview    Boolean  @default(true)
+  language      String   @default("ko")
+  severityLevel String   @default("normal")
+  updatedAt     DateTime
+  User          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Session {
+  id           String   @id
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  User         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model User {
+  id                  String               @id
+  email               String?              @unique
+  name                String?
+  image               String?
+  emailVerified       DateTime?
+  githubId            BigInt?              @unique
+  githubToken         String?
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime
+  Account             Account[]
+  Comment             Comment[]
+  Notification        Notification[]
+  NotificationSetting NotificationSetting?
+  Repository          Repository[]
+  ReviewSetting       ReviewSetting?
+  Session             Session[]
+
+  @@index([email])
+  @@index([githubId])
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+enum NotificationType {
+  MENTION
+  NEW_REVIEW
+  PR_MERGED
+  COMMENT_REPLY
+}
+
+enum PRStatus {
+  OPEN
+  CLOSED
+  MERGED
+  DRAFT
+}
+
+enum ReviewStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+  FAILED
+}
+
+enum Severity {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
   // Relations
   accounts      Account[]
   sessions      Session[]
-  repositories  Repository[]
+  repositories  UserRepository[]
   comments      Comment[]
   notifications       Notification[]
   notificationSetting NotificationSetting?
@@ -92,15 +92,27 @@ model Repository {
   webhookId    Int?      // GitHub Webhook ID
 
   // Relations
-  owner        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId       String
+  userRepositories UserRepository[]
   pullRequests PullRequest[]
 
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
-  @@index([userId])
   @@index([fullName])
+}
+
+model UserRepository {
+  id           String     @id @default(cuid())
+  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String
+  repository   Repository @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  repositoryId String
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  @@unique([userId, repositoryId])
+  @@index([userId])
+  @@index([repositoryId])
 }
 
 model PullRequest {


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [x] 문서 (docs)
- [x] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [x] Week 9-10: 대시보드 & 배포

## 개요

기존 `Repository.userId` 단일 소유 구조에서 `UserRepository` 기반 공유 저장소 구조로 전환하고, 기존 운영 DB에서도 Prisma migration을 안전하게 적용할 수 있도록 baseline/migration 흐름을 정비했습니다. 이 변경으로 하나의 저장소를 여러 사용자가 함께 연결하고 동일한 PR 리뷰 데이터를 공유할 수 있습니다.

Closes #115

## 변경 사항

- `UserRepository` 조인 테이블 기반으로 저장소 접근 로직을 통일하고 단일 소유자 fallback 제거
- 대시보드, 통계, PR/댓글/리뷰/웹훅 경로를 공유 저장소 membership 기준으로 수정
- `/api/github/repos`와 저장소 연결 API에서 migration 누락/인증 만료를 더 명확한 응답으로 처리
- Prisma baseline 파일과 `0_init` migration, `split_repository_membership` migration 정리
- `DIRECT_DATABASE_URL` 우선 사용 설정과 회고 문서 추가

## 스크린샷 (선택)

UI 변경 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

## 참고 사항

- 이 브랜치는 `feat/113-pr-detail-comments-ux`에서 분기되어 해당 브랜치를 base로 설정했습니다.
- 실제 운영 DB에는 `split_repository_membership` migration 적용이 필요하며, baseline 후 `prisma migrate deploy`로 반영했습니다.
- 이번 PR에는 문서 커밋(`docs/shared-repository-migration-retrospective.md`)이 포함되어 있습니다.

