### PR TITLE
[Feature] AI review completion toast for real-time notifications

### DIFF
--- a/__tests__/lib/notification-link.test.ts
+++ b/__tests__/lib/notification-link.test.ts
@@ -20,36 +20,36 @@ function makeNotification(overrides: Partial<Notification> = {}): Notification {
 }
 
 describe("getNotificationLink", () => {
-  it("prId가 없으면 null을 반환한다", () => {
+  it("returns null when prId is missing", () => {
     const link = getNotificationLink(makeNotification({ prId: null }))
     expect(link).toBeNull()
   })
 
-  it("NEW_REVIEW 타입은 PR 상세 페이지로 이동한다", () => {
+  it("routes NEW_REVIEW to the PR detail review panel", () => {
     const link = getNotificationLink(makeNotification({ type: "NEW_REVIEW" }))
-    expect(link).toBe("/pulls/pr-1")
+    expect(link).toBe("/pulls/pr-1?review=open")
   })
 
-  it("PR_MERGED 타입은 PR 상세 페이지로 이동한다", () => {
+  it("routes PR_MERGED to the PR detail page", () => {
     const link = getNotificationLink(makeNotification({ type: "PR_MERGED" }))
     expect(link).toBe("/pulls/pr-1")
   })
 
-  it("MENTION 타입은 commentId가 있으면 해시 포함 URL을 반환한다", () => {
+  it("keeps comment anchors for MENTION with commentId", () => {
     const link = getNotificationLink(
       makeNotification({ type: "MENTION", commentId: "comment-1" })
     )
     expect(link).toBe("/pulls/pr-1#comment-comment-1")
   })
 
-  it("COMMENT_REPLY 타입은 commentId가 있으면 해시 포함 URL을 반환한다", () => {
+  it("keeps comment anchors for COMMENT_REPLY with commentId", () => {
     const link = getNotificationLink(
       makeNotification({ type: "COMMENT_REPLY", commentId: "comment-2" })
     )
     expect(link).toBe("/pulls/pr-1#comment-comment-2")
   })
 
-  it("MENTION 타입이지만 commentId가 없으면 PR 페이지로 이동한다", () => {
+  it("routes MENTION without commentId to the PR detail page", () => {
     const link = getNotificationLink(
       makeNotification({ type: "MENTION", commentId: null })
     )

--- a/app/api/review/analyze/route.ts
+++ b/app/api/review/analyze/route.ts
@@ -22,6 +22,7 @@ export async function POST(request: Request) {
       select: {
         id: true,
         title: true,
+        number: true,
         repoId: true,
       },
     })
@@ -56,6 +57,8 @@ export async function POST(request: Request) {
             emitNotification(userId, {
               ...notification,
               createdAt: notification.createdAt.toISOString(),
+              prTitle: pr.title,
+              prNumber: pr.number,
             })
           })
         )

--- a/app/api/webhook/github/route.ts
+++ b/app/api/webhook/github/route.ts
@@ -39,6 +39,8 @@ async function notifyUsers(params: {
   title: string
   message: string
   prId: string
+  prTitle: string
+  prNumber: number
 }) {
   const recipients = await getEnabledUserIds(params.userIds, params.type)
 
@@ -57,6 +59,8 @@ async function notifyUsers(params: {
       emitNotification(userId, {
         ...notification,
         createdAt: notification.createdAt.toISOString(),
+        prTitle: params.prTitle,
+        prNumber: params.prNumber,
       })
     })
   )
@@ -158,6 +162,8 @@ export async function POST(request: Request) {
           title: isMerged ? "PR merged" : "PR closed",
           message: `"${pr.title}" was ${isMerged ? "merged" : "closed"}.`,
           prId: pullRequest.id,
+          prTitle: pr.title,
+          prNumber: pr.number,
         })
       }
 
@@ -178,6 +184,8 @@ export async function POST(request: Request) {
           title: "AI review is ready",
           message: `The AI review for "${pr.title}" is complete.`,
           prId: pullRequest.id,
+          prTitle: pr.title,
+          prNumber: pr.number,
         })
       } catch (error) {
         console.error("[webhook] analyzeReview failed:", error)
@@ -191,6 +199,8 @@ export async function POST(request: Request) {
             title: "AI review failed",
             message: `The AI review for "${pr.title}" could not be completed.`,
             prId: pullRequest.id,
+            prTitle: pr.title,
+            prNumber: pr.number,
           })
         } catch (notifyError) {
           console.error(

--- a/components/pulls/detail/PRDetailLayout.tsx
+++ b/components/pulls/detail/PRDetailLayout.tsx
@@ -115,10 +115,15 @@ export default function PRDetailLayout({
   useEffect(() => {
     const filePath = searchParams.get("filePath");
     const lineNumber = searchParams.get("lineNumber");
+    const reviewParam = searchParams.get("review");
     const prId = pr.id;
 
     // 이미 처리했으면 스킵
     if (initializedRef.current === prId) return;
+
+    if (reviewParam === "open") {
+      setReviewOpen(true);
+    }
 
     if (!filePath || !lineNumber) {
       initializedRef.current = prId;

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -2,10 +2,23 @@
 
 import { useEffect, useCallback, useMemo } from "react"
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import { toast } from "sonner"
 import { useSocket } from "./useSocket"
-import type { BaseNotification, Notification, NotificationsResponse, NotificationFilterType, NotificationFilterRead } from "@/types/notification"
+import type {
+  BaseNotification,
+  Notification,
+  NotificationsResponse,
+  NotificationFilterType,
+  NotificationFilterRead,
+} from "@/types/notification"
+import {
+  recordHandlerInvocation,
+  recordHandlerRegistered,
+  recordHandlerRemoved,
+} from "@/lib/measurements/socketMetrics"
 
 const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
+const toastedNotificationIds = new Set<string>()
 
 async function fetchNotifications(
   type?: NotificationFilterType,
@@ -33,6 +46,72 @@ async function deleteNotificationApi(id: string): Promise<void> {
   await fetch(`/api/notifications/${id}`, { method: "DELETE" })
 }
 
+function getToastMessage(notification: BaseNotification) {
+  const prTitle =
+    notification.prTitle && notification.prTitle.trim().length > 0
+      ? notification.prTitle
+      : null
+
+  if (notification.type === "NEW_REVIEW") {
+    return {
+      title: prTitle ? `AI review is ready for "${prTitle}"` : "AI review is ready",
+      description: notification.message ?? "Open the PR to review the result.",
+      kind: "success" as const,
+    }
+  }
+
+  if (notification.type === "REVIEW_FAILED") {
+    return {
+      title: "AI review failed",
+      description: notification.message ?? "The review process hit an error.",
+      kind: "error" as const,
+    }
+  }
+
+  return {
+    title: notification.title,
+    description: notification.message ?? "You have a new notification.",
+    kind: "default" as const,
+  }
+}
+
+function showNotificationToast(notification: BaseNotification) {
+  const toastContent = getToastMessage(notification)
+  const action =
+    notification.prId && notification.type === "NEW_REVIEW"
+      ? {
+          label: "Open PR",
+          onClick: () => {
+            window.location.assign(`/pulls/${notification.prId}?review=open`)
+          },
+        }
+      : undefined
+
+  if (toastContent.kind === "success") {
+    toast.success(toastContent.title, {
+      description: toastContent.description,
+      duration: 5000,
+      action,
+    })
+    return
+  }
+
+  if (toastContent.kind === "error") {
+    toast.error(toastContent.title, {
+      description: toastContent.description,
+      duration: 5000,
+      action,
+    })
+    return
+  }
+
+  toast(toastContent.title, {
+    description: toastContent.description,
+    duration: 5000,
+    action,
+  })
+}
+
 export function useNotifications(
   typeFilter?: NotificationFilterType,
   readFilter?: NotificationFilterRead
@@ -51,13 +130,20 @@ export function useNotifications(
 
   const handleNew = useCallback(
     (base: BaseNotification) => {
-      // 소켓에서 받은 BaseNotification을 Notification으로 확장
+      recordHandlerInvocation("notification:new")
+
+      if (!toastedNotificationIds.has(base.id)) {
+        toastedNotificationIds.add(base.id)
+        showNotificationToast(base)
+      }
+
       const notification: Notification = {
         ...base,
         prTitle: null,
         prNumber: null,
         repoFullName: null,
       }
+
       queryClient.setQueryData<NotificationsResponse>(
         ["notifications", typeFilter, readFilter],
         (old) => {
@@ -69,7 +155,7 @@ export function useNotifications(
           }
         }
       )
-      // 전체 데이터를 다시 가져와서 PR 상세 정보 포함
+
       queryClient.invalidateQueries({ queryKey: ["notifications"] })
     },
     [queryClient, typeFilter, readFilter]
@@ -78,9 +164,11 @@ export function useNotifications(
   useEffect(() => {
     if (!socket) return
 
+    recordHandlerRegistered("notification:new")
     socket.on("notification:new", handleNew)
     return () => {
       socket.off("notification:new", handleNew)
+      recordHandlerRemoved("notification:new")
     }
   }, [socket, handleNew])
 

--- a/lib/notification-link.ts
+++ b/lib/notification-link.ts
@@ -17,6 +17,7 @@ export function getNotificationLink(notification: Notification): string | null {
         ? `${base}#comment-${notification.commentId}`
         : base
     case "NEW_REVIEW":
+      return `${base}?review=open`
     case "PR_MERGED":
       return base
     default:

--- a/lib/providers.tsx
+++ b/lib/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { Toaster } from "@/components/ui/sonner";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -17,6 +18,9 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <Toaster position="bottom-right" richColors closeButton />
+    </QueryClientProvider>
   );
 }

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -11,6 +11,9 @@ export interface BaseNotification {
   prId: string | null
   commentId: string | null
   createdAt: string
+  prTitle?: string | null
+  prNumber?: number | null
+  repoFullName?: string | null
 }
 
 /** API 응답에서 사용되는 확장 알림 타입 (PR 상세 정보 포함) */


### PR DESCRIPTION
## 🧩 기능 설명
- AI review가 완료되면 우하단 toast가 표시되도록 합니다.
- toast 클릭 시 해당 PR의 리뷰 패널이 열린 상태로 이동합니다.
- 토스트 문구에 PR 제목을 포함합니다.

## 🎯 목표
- 사용자가 알림을 놓치지 않고 바로 확인할 수 있게 합니다.
- AI review 완료 이벤트의 가시성을 높입니다.
- 알림 진입 경로를 줄여 UX를 개선합니다.

## 🧪 테스트
- [x] AI review 완료 시 우하단 toast 표시
- [x] toast 클릭 시 PR 상세 화면의 리뷰 패널 자동 오픈
- [x] AI review 실패 시 error toast 표시
- [x] TypeScript build / typecheck 통과

## 🔗 참고 자료
- `hooks/useNotifications.ts`
- `components/pulls/detail/PRDetailLayout.tsx`
- `app/api/review/analyze/route.ts`
- `app/api/webhook/github/route.ts`