### PR TITLE
feat: 댓글 측정 초안 및 렌더 카운터 추가

### DIFF
--- a/components/comment/CommentItem.tsx
+++ b/components/comment/CommentItem.tsx
@@ -6,6 +6,7 @@ import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
 import { Pencil, Trash2, CheckCheck, MessageSquare } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { recordRender } from "@/lib/measurements/renderCounter"
 import ReactionBar from "./ReactionBar"
 import CommentInput from "./CommentInput"
 import type { CommentWithAuthor, ReactionEmoji, MentionUser } from "@/types/comment"
@@ -51,6 +52,9 @@ export default function CommentItem({
   onReply,
   isUpdating = false,
 }: CommentItemProps) {
+  recordRender("CommentItem")
+  recordRender(comment.parentId ? "CommentItem:reply" : "CommentItem:root")
+
   const [editing, setEditing] = useState(false)
   const isOwner = comment.authorId === currentUserId
 

--- a/components/comment/CommentList.tsx
+++ b/components/comment/CommentList.tsx
@@ -20,8 +20,10 @@ import { usePRDetail } from "@/hooks/usePRDetail"
 import { useRealtimeComments } from "@/hooks/useRealtimeComments"
 import { useSocket } from "@/hooks/useSocket"
 import { useTypingIndicator } from "@/hooks/useTypingIndicator"
+import { recordRender } from "@/lib/measurements/renderCounter"
 import { cn } from "@/lib/utils"
 import type { CommentWithAuthor, MentionUser } from "@/types/comment"
+import CommentRenderMetricsPanel from "./CommentRenderMetricsPanel"
 
 interface CommentListProps {
   prId: string
@@ -269,6 +271,8 @@ export default function CommentList({
   prId,
   currentUserId,
 }: CommentListProps) {
+  recordRender("CommentList")
+
   const { data: allComments = [], isLoading } = useRealtimeComments(prId)
   const createComment = useCreateComment(prId)
   const { names: typingNames, onTyping, onTypingStop } = useTypingIndicator(prId)
@@ -475,6 +479,8 @@ export default function CommentList({
           </div>
         </>
       )}
+
+      <CommentRenderMetricsPanel prId={prId} />
     </div>
   )
 }

--- a/components/comment/CommentRenderMetricsPanel.tsx
+++ b/components/comment/CommentRenderMetricsPanel.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+import {
+  getRenderCountSnapshot,
+  isRenderMeasurementEnabled,
+  resetRenderCounts,
+  subscribeRenderCounts,
+} from "@/lib/measurements/renderCounter"
+
+type RenderCountSnapshot = Record<string, number>
+
+const trackedRows = [
+  { key: "CommentList", label: "CommentList renders" },
+  { key: "CommentItem", label: "CommentItem renders" },
+  { key: "CommentItem:root", label: "Top-level CommentItem renders" },
+  { key: "CommentItem:reply", label: "Reply CommentItem renders" },
+]
+
+const emptySnapshot: RenderCountSnapshot = {}
+
+export default function CommentRenderMetricsPanel({ prId }: { prId: string }) {
+  const snapshot = useSyncExternalStore<RenderCountSnapshot>(
+    subscribeRenderCounts,
+    getRenderCountSnapshot,
+    () => emptySnapshot
+  )
+
+  if (!isRenderMeasurementEnabled()) return null
+
+  return (
+    <div className="border-t border-slate-200 bg-slate-50 px-5 py-4 dark:border-slate-700 dark:bg-slate-900/60">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-600">
+            Render Metrics
+          </p>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            `?measureRenders=1` query flag is active. These counts are the secondary proof for the
+            real PR comment UI.
+          </p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            Suggested capture path: `/pulls/{prId}?measureRenders=1`
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={resetRenderCounts}
+          className="rounded-md border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Counter reset
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {trackedRows.map((row) => (
+          <div
+            key={row.key}
+            className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-950"
+          >
+            <p className="text-xs font-medium text-slate-500 dark:text-slate-400">{row.label}</p>
+            <p className="mt-2 text-2xl font-bold text-slate-950 dark:text-slate-50">
+              {snapshot[row.key] ?? 0}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+        Current PR: <span className="font-mono">{prId}</span>
+      </p>
+    </div>
+  )
+}

--- a/components/measurements/CommentCacheMeasurementClient.tsx
+++ b/components/measurements/CommentCacheMeasurementClient.tsx
@@ -53,13 +53,25 @@ export default function CommentCacheMeasurementClient() {
     renderDiff,
     renderReductionRate,
     summaryReport,
+    documentDraft,
   } = useCommentCacheMeasurement(prId, iterations, delayMs, false)
+
+  const [copyState, setCopyState] = useState<"idle" | "done" | "error">("idle")
 
   const latestIds =
     commentsQuery.data
       ?.slice(-3)
       .map((comment) => comment.id.slice(-6))
       .join(", ") ?? ""
+
+  const handleCopyDraft = async () => {
+    try {
+      await navigator.clipboard.writeText(documentDraft)
+      setCopyState("done")
+    } catch {
+      setCopyState("error")
+    }
+  }
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
@@ -86,6 +98,28 @@ export default function CommentCacheMeasurementClient() {
           </Link>
         </div>
       </header>
+
+      {prId ? (
+        <section className={`${panelClass} ${panelPaddingClass}`}>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-slate-950 dark:text-slate-50">
+                Secondary Reinforcement
+              </h2>
+              <p className="mt-1 text-sm text-slate-500">
+                Open the real PR detail page with render counters enabled to capture CommentList and
+                CommentItem counts.
+              </p>
+            </div>
+            <Link
+              href={`/pulls/${prId}?measureRenders=1`}
+              className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-100"
+            >
+              Open 2nd pass UI probe
+            </Link>
+          </div>
+        </section>
+      ) : null}
 
       <section className={`grid md:grid-cols-3 ${gridGapClass} ${panelClass} ${panelPaddingClass}`}>
         <label className="flex flex-col gap-2 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -250,8 +284,32 @@ export default function CommentCacheMeasurementClient() {
       </section>
 
       <section className={`${panelClass} ${panelPaddingClass}`}>
-        <h2 className="text-lg font-bold text-slate-950 dark:text-slate-50">
-        </h2>
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-slate-950 dark:text-slate-50">Document Draft</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Paste this block into section 3 of the measurement markdown document.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleCopyDraft}
+            className="rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+          >
+            {copyState === "done"
+              ? "Draft copied"
+              : copyState === "error"
+                ? "Copy failed"
+                : "Copy draft"}
+          </button>
+        </div>
+        <pre className="mt-4 overflow-x-auto whitespace-pre-wrap rounded-md bg-slate-950 p-4 text-sm leading-6 text-slate-100">
+          {documentDraft}
+        </pre>
+      </section>
+
+      <section className={`${panelClass} ${panelPaddingClass}`}>
+        <h2 className="text-lg font-bold text-slate-950 dark:text-slate-50">Measurement Summary</h2>
         <pre className="mt-4 overflow-x-auto whitespace-pre-wrap rounded-md bg-slate-950 p-4 text-sm leading-6 text-slate-100">
           {summaryReport}
         </pre>

--- a/hooks/useCommentCacheMeasurement.ts
+++ b/hooks/useCommentCacheMeasurement.ts
@@ -3,6 +3,10 @@
 import { useMemo, useRef, useState, type ProfilerOnRenderCallback } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 
+import {
+  resetRenderCounts,
+  setRenderMeasurementEnabled,
+} from "@/lib/measurements/renderCounter"
 import type { CommentWithAuthor } from "@/types/comment"
 import {
   type RunResult,
@@ -65,6 +69,8 @@ export function useCommentCacheMeasurement(
 
     setIsRunning(true)
     resetCounters()
+    resetRenderCounts()
+    setRenderMeasurementEnabled(false)
     measurementActiveRef.current = true
 
     const startedAt = new Date()
@@ -109,6 +115,7 @@ export function useCommentCacheMeasurement(
       ])
     } finally {
       measurementActiveRef.current = false
+      setRenderMeasurementEnabled(false)
       setIsRunning(false)
     }
   }
@@ -164,6 +171,53 @@ export function useCommentCacheMeasurement(
     requestReductionRate,
   ])
 
+  const documentDraft = useMemo(() => {
+    if (!latestSetQueryData || !latestInvalidate) {
+      return [
+        "### 3. 캐시 동기화로 인한 렌더링 횟수 변화",
+        "",
+        "- 두 전략을 모두 실행하면 이 영역에 문서 초안이 자동으로 생성됩니다.",
+        `- 측정 페이지: /measurements/comments${prId ? `?prId=${prId}` : ""}`,
+        prId ? `- 2차 보강 페이지: /pulls/${prId}?measureRenders=1` : "- 2차 보강 페이지: PR ID 입력 후 활성화",
+      ].join("\n")
+    }
+
+    return [
+      "### 3. 캐시 동기화로 인한 렌더링 횟수 변화",
+      "",
+      "#### 1차 측정 개요",
+      `- 시나리오: 동일 PR(${prId})에서 댓글 동기화 이벤트 ${Math.min(
+        latestSetQueryData.iterations,
+        latestInvalidate.iterations
+      )}회 반복`,
+      `- 측정 페이지: /measurements/comments?prId=${prId}`,
+      `- 측정 일자: ${new Date().toISOString().slice(0, 10)}`,
+      "",
+      "#### 1차 측정 결과",
+      `- invalidate/refetch 요청 수: ${latestInvalidate.requestCount}회`,
+      `- setQueryData 요청 수: ${latestSetQueryData.requestCount}회`,
+      `- 요청 감소량: ${requestDiff ?? 0}회 (${requestReductionRate ?? 0}%)`,
+      `- invalidate/refetch render commit: ${latestInvalidate.renderCommitCount}회`,
+      `- setQueryData render commit: ${latestSetQueryData.renderCommitCount}회`,
+      `- render commit 감소량: ${renderDiff ?? 0}회 (${renderReductionRate ?? 0}%)`,
+      `- invalidate/refetch commit duration 합계: ${latestInvalidate.totalActualDurationMs}ms`,
+      `- setQueryData commit duration 합계: ${latestSetQueryData.totalActualDurationMs}ms`,
+      "",
+      "#### 2차 보강 계획",
+      `- 실제 댓글 UI 렌더 카운터 확인 경로: /pulls/${prId}?measureRenders=1`,
+      "- 측정 대상: CommentList, CommentItem",
+      "- 보강 방식: 실제 PR 상세 화면에서 렌더 카운터 패널 캡처 후 본 문단에 보강",
+    ].join("\n")
+  }, [
+    latestInvalidate,
+    latestSetQueryData,
+    prId,
+    renderDiff,
+    renderReductionRate,
+    requestDiff,
+    requestReductionRate,
+  ])
+
   return {
     commentsQuery,
     handleCommentListRender,
@@ -175,5 +229,6 @@ export function useCommentCacheMeasurement(
     renderDiff,
     renderReductionRate,
     summaryReport,
+    documentDraft,
   }
 }

--- a/lib/measurements/renderCounter.ts
+++ b/lib/measurements/renderCounter.ts
@@ -1,0 +1,60 @@
+export type RenderCountSnapshot = Record<string, number>
+
+type RenderMetricListener = () => void
+
+const listeners = new Set<RenderMetricListener>()
+const renderCounts = new Map<string, number>()
+
+let manualMeasurementEnabled = false
+let notifyScheduled = false
+
+function scheduleNotify() {
+  if (notifyScheduled) return
+
+  notifyScheduled = true
+  queueMicrotask(() => {
+    notifyScheduled = false
+    listeners.forEach((listener) => listener())
+  })
+}
+
+function hasRenderQueryFlag() {
+  if (typeof window === "undefined") return false
+
+  return new URLSearchParams(window.location.search).get("measureRenders") === "1"
+}
+
+export function isRenderMeasurementEnabled() {
+  return manualMeasurementEnabled || hasRenderQueryFlag()
+}
+
+export function setRenderMeasurementEnabled(next: boolean) {
+  manualMeasurementEnabled = next
+  scheduleNotify()
+}
+
+export function resetRenderCounts() {
+  renderCounts.clear()
+  scheduleNotify()
+}
+
+export function recordRender(metricId: string) {
+  if (!isRenderMeasurementEnabled()) return
+
+  renderCounts.set(metricId, (renderCounts.get(metricId) ?? 0) + 1)
+  scheduleNotify()
+}
+
+export function getRenderCountSnapshot(): RenderCountSnapshot {
+  return Object.fromEntries(
+    [...renderCounts.entries()].sort(([left], [right]) => left.localeCompare(right))
+  )
+}
+
+export function subscribeRenderCounts(listener: RenderMetricListener) {
+  listeners.add(listener)
+
+  return () => {
+    listeners.delete(listener)
+  }
+}


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

댓글 캐시 동기화 측정 페이지에서 바로 문서 초안을 만들 수 있도록 보강하고, 실제 PR 상세 화면에서도 렌더 횟수를 2차로 확인할 수 있는 render counter를 추가했습니다.

## 변경 사항

- `/measurements/comments?prId=...` 페이지에 문서용 `Document Draft` 블록과 복사 버튼 추가
- 측정 페이지에서 실제 PR 상세 화면(`/pulls/{prId}?measureRenders=1`)으로 이동하는 2차 보강 링크 추가
- `CommentList`, `CommentItem` 렌더 횟수를 기록하는 render counter 저장소 추가
- `?measureRenders=1` 활성화 시 PR 상세 화면 하단에 렌더 측정 패널 노출
- 측정 훅에서 1차 측정 결과를 문서 섹션 형태로 바로 만들 수 있도록 `documentDraft` 생성 로직 추가

## 스크린샷 (선택)

- 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

## 참고 사항

- 이번 PR에는 측정 관련 6개 파일만 포함했습니다.
- 워킹 트리에 존재하던 다른 로컬 변경 사항은 스테이징하지 않았고, 이번 PR 범위에 포함하지 않았습니다.
- 현재 PR은 draft 상태이며, 실제 측정 결과를 확인한 뒤 문서/포트폴리오용 문구를 추가로 다듬을 예정입니다.