### PR TITLE
fix: 댓글 렌더 계측 무한 루프 수정 (#128)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# CodeMate - Codex Working Notes
+
+This file is the Codex-facing companion to `CLAUDE.md`.
+
+## Page Structure
+
+- Keep `app/**/page.tsx` as server components when possible.
+- Put client state and event logic in dedicated client components such as `*Client.tsx`.
+- Split page concerns by feature and keep components under `components/<feature>/`.
+
+## GitHub Workflow
+
+- When creating issues, follow `.github/ISSUE_TEMPLATE/*`.
+- For hotfix issues, use the title format `hotfix: 한글제목`.
+- When creating pull requests, follow `.github/pull_request_template.md`.
+- Prefer small, focused PRs with the correct base branch for the actual diff scope.
+
+## Branch and Commit Naming
+
+- Hotfix branch format: `hotfix/<issue-number>-<change-slug>`.
+- Write intentional commit messages with conventional prefixes such as `fix:` or `hotfix:`.
+
+## Notes
+
+- Check for existing local changes before branching or committing.
+- Avoid mixing unrelated workspace changes into GitHub work.

--- a/components/comment/CommentItem.tsx
+++ b/components/comment/CommentItem.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Image from "next/image"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
 import { Pencil, Trash2, CheckCheck, MessageSquare } from "lucide-react"
@@ -52,8 +52,10 @@ export default function CommentItem({
   onReply,
   isUpdating = false,
 }: CommentItemProps) {
-  recordRender("CommentItem")
-  recordRender(comment.parentId ? "CommentItem:reply" : "CommentItem:root")
+  useEffect(() => {
+    recordRender("CommentItem")
+    recordRender(comment.parentId ? "CommentItem:reply" : "CommentItem:root")
+  })
 
   const [editing, setEditing] = useState(false)
   const isOwner = comment.authorId === currentUserId

--- a/components/comment/CommentList.tsx
+++ b/components/comment/CommentList.tsx
@@ -271,7 +271,9 @@ export default function CommentList({
   prId,
   currentUserId,
 }: CommentListProps) {
-  recordRender("CommentList")
+  useEffect(() => {
+    recordRender("CommentList")
+  })
 
   const { data: allComments = [], isLoading } = useRealtimeComments(prId)
   const createComment = useCreateComment(prId)

--- a/lib/measurements/renderCounter.ts
+++ b/lib/measurements/renderCounter.ts
@@ -4,9 +4,12 @@ type RenderMetricListener = () => void
 
 const listeners = new Set<RenderMetricListener>()
 const renderCounts = new Map<string, number>()
+const emptySnapshot: RenderCountSnapshot = {}
 
 let manualMeasurementEnabled = false
 let notifyScheduled = false
+let snapshotDirty = false
+let cachedSnapshot: RenderCountSnapshot = emptySnapshot
 
 function scheduleNotify() {
   if (notifyScheduled) return
@@ -30,11 +33,14 @@ export function isRenderMeasurementEnabled() {
 
 export function setRenderMeasurementEnabled(next: boolean) {
   manualMeasurementEnabled = next
+  snapshotDirty = true
   scheduleNotify()
 }
 
 export function resetRenderCounts() {
+  if (renderCounts.size === 0 && cachedSnapshot === emptySnapshot) return
   renderCounts.clear()
+  snapshotDirty = true
   scheduleNotify()
 }
 
@@ -42,13 +48,27 @@ export function recordRender(metricId: string) {
   if (!isRenderMeasurementEnabled()) return
 
   renderCounts.set(metricId, (renderCounts.get(metricId) ?? 0) + 1)
+  snapshotDirty = true
   scheduleNotify()
 }
 
 export function getRenderCountSnapshot(): RenderCountSnapshot {
-  return Object.fromEntries(
+  if (!snapshotDirty) {
+    return cachedSnapshot
+  }
+
+  if (renderCounts.size === 0) {
+    cachedSnapshot = emptySnapshot
+    snapshotDirty = false
+    return cachedSnapshot
+  }
+
+  cachedSnapshot = Object.fromEntries(
     [...renderCounts.entries()].sort(([left], [right]) => left.localeCompare(right))
   )
+  snapshotDirty = false
+
+  return cachedSnapshot
 }
 
 export function subscribeRenderCounts(listener: RenderMetricListener) {


### PR DESCRIPTION
## 작업 유형

- [x] 버그 수정 (fix)
- [ ] 새로운 기능 (feat)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

댓글 렌더 계측 로직 때문에 PR 상세 페이지가 React 무한 업데이트 루프에 빠지는 문제를 `main` 기준으로 hotfix 합니다.

## 변경 사항

- `renderCounter` snapshot을 캐시해서 `useSyncExternalStore`가 매 렌더 새 객체를 받지 않도록 수정했습니다.
- `CommentList`, `CommentItem`의 렌더 카운트 기록 시점을 렌더 함수 본문에서 commit 이후(`useEffect`)로 이동했습니다.
- 이후 Codex 작업에서도 이슈/브랜치/PR 템플릿 규칙을 따를 수 있도록 `AGENTS.md`를 추가했습니다.

## 스크린샷 (선택)

- 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

변경 파일 기준 `npx eslint components/comment/CommentList.tsx components/comment/CommentItem.tsx lib/measurements/renderCounter.ts` 실행은 통과했습니다.

## 참고 사항

- Related: #128
- Follow-up to: #129
- Base branch: `main`
- Branch: `hotfix/128-comment-render-loop-main`
- Commit: `423d008`