### PR TITLE
feat: 실패한 AI 리뷰 재시도 UI 구현 (#131)

### DIFF
--- a/__tests__/api/review/analyze/route.test.ts
+++ b/__tests__/api/review/analyze/route.test.ts
@@ -1,6 +1,7 @@
 import { POST } from "@/app/api/review/analyze/route"
 import { prisma } from "@/lib/prisma"
 import * as analyzeModule from "@/lib/ai/analyze"
+import * as emitterModule from "@/lib/socket/emitter"
 import { getRepositoryMemberIds } from "@/lib/repository-access"
 
 jest.mock("@/lib/prisma", () => ({
@@ -29,6 +30,7 @@ jest.mock("@/lib/repository-access", () => ({
 const mockedFindUnique = prisma.pullRequest.findUnique as jest.Mock
 const mockedNotificationCreate = prisma.notification.create as jest.Mock
 const mockedAnalyze = analyzeModule.analyzeReview as jest.Mock
+const mockedEmitNotification = emitterModule.emitNotification as jest.Mock
 const mockedGetRepositoryMemberIds = getRepositoryMemberIds as jest.Mock
 
 function makeRequest(body: object) {
@@ -39,9 +41,15 @@ function makeRequest(body: object) {
   })
 }
 
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 const mockPR = {
   id: "pr-1",
   title: "Fix bug",
+  number: 42,
   repoId: "repo-1",
 }
 
@@ -50,7 +58,10 @@ describe("POST /api/review/analyze", () => {
 
   it("starts review analysis and returns PENDING", async () => {
     mockedFindUnique.mockResolvedValue(mockPR)
-    mockedAnalyze.mockResolvedValue(undefined)
+    mockedAnalyze.mockResolvedValue({
+      status: "COMPLETED",
+      reviewId: "review-1",
+    })
     mockedNotificationCreate.mockResolvedValue({
       id: "notif-1",
       type: "NEW_REVIEW",
@@ -65,11 +76,74 @@ describe("POST /api/review/analyze", () => {
 
     const res = await POST(makeRequest({ pullRequestId: "pr-1" }))
     const body = await res.json()
+    await flushPromises()
 
     expect(res.status).toBe(200)
     expect(body.status).toBe("PENDING")
     expect(mockedAnalyze).toHaveBeenCalledWith("pr-1")
     expect(mockedGetRepositoryMemberIds).toHaveBeenCalledWith("repo-1")
+    expect(mockedNotificationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ type: "NEW_REVIEW", userId: "user-1" }),
+      })
+    )
+    expect(mockedEmitNotification).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ type: "NEW_REVIEW" })
+    )
+  })
+
+  it("sends REVIEW_FAILED notifications when analysis fails", async () => {
+    mockedFindUnique.mockResolvedValue(mockPR)
+    mockedAnalyze.mockResolvedValue({
+      status: "FAILED",
+      reviewId: "review-1",
+      failureReason: "Claude timeout",
+    })
+    mockedNotificationCreate.mockResolvedValue({
+      id: "notif-fail",
+      type: "REVIEW_FAILED",
+      title: "AI review failed",
+      message: "Claude timeout",
+      isRead: false,
+      userId: "user-1",
+      prId: "pr-1",
+      commentId: null,
+      createdAt: new Date(),
+    })
+
+    const res = await POST(makeRequest({ pullRequestId: "pr-1" }))
+    await flushPromises()
+
+    expect(res.status).toBe(200)
+    expect(mockedNotificationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "REVIEW_FAILED",
+          message: "Claude timeout",
+          userId: "user-1",
+        }),
+      })
+    )
+    expect(mockedEmitNotification).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ type: "REVIEW_FAILED" })
+    )
+  })
+
+  it("does not notify when an active review already exists", async () => {
+    mockedFindUnique.mockResolvedValue(mockPR)
+    mockedAnalyze.mockResolvedValue({
+      status: "SKIPPED_ACTIVE",
+      reviewId: null,
+    })
+
+    const res = await POST(makeRequest({ pullRequestId: "pr-1" }))
+    await flushPromises()
+
+    expect(res.status).toBe(200)
+    expect(mockedNotificationCreate).not.toHaveBeenCalled()
+    expect(mockedEmitNotification).not.toHaveBeenCalled()
   })
 
   it("returns 400 when pullRequestId is missing", async () => {

--- a/__tests__/api/webhook/github/route.test.ts
+++ b/__tests__/api/webhook/github/route.test.ts
@@ -36,7 +36,10 @@ jest.mock("@/lib/webhook-validator", () => ({
 }))
 
 jest.mock("@/lib/ai/analyze", () => ({
-  analyzeReview: jest.fn().mockResolvedValue(undefined),
+  analyzeReview: jest.fn().mockResolvedValue({
+    status: "COMPLETED",
+    reviewId: "review-1",
+  }),
 }))
 
 jest.mock("@/lib/socket/emitter", () => ({
@@ -158,12 +161,16 @@ describe("POST /api/webhook/github", () => {
   })
 
   it("sends REVIEW_FAILED notifications when analysis fails", async () => {
-    mockedAnalyzeReview.mockRejectedValueOnce(new Error("Claude timeout"))
+    mockedAnalyzeReview.mockResolvedValueOnce({
+      status: "FAILED",
+      reviewId: "review-1",
+      failureReason: "Claude timeout",
+    })
     ;(prisma.notification.create as jest.Mock).mockResolvedValue({
       id: "notif-fail",
       type: "REVIEW_FAILED",
       title: "AI review failed",
-      message: null,
+      message: "Claude timeout",
       isRead: false,
       userId: "user-1",
       prId: "pr-1",

--- a/__tests__/lib/notification-link.test.ts
+++ b/__tests__/lib/notification-link.test.ts
@@ -30,6 +30,11 @@ describe("getNotificationLink", () => {
     expect(link).toBe("/pulls/pr-1?review=open")
   })
 
+  it("routes REVIEW_FAILED to the PR detail review panel", () => {
+    const link = getNotificationLink(makeNotification({ type: "REVIEW_FAILED" }))
+    expect(link).toBe("/pulls/pr-1?review=open")
+  })
+
   it("routes PR_MERGED to the PR detail page", () => {
     const link = getNotificationLink(makeNotification({ type: "PR_MERGED" }))
     expect(link).toBe("/pulls/pr-1")

--- a/app/api/review/analyze/route.ts
+++ b/app/api/review/analyze/route.ts
@@ -5,6 +5,45 @@ import { prisma } from "@/lib/prisma"
 import { getRepositoryMemberIds } from "@/lib/repository-access"
 import { emitNotification } from "@/lib/socket/emitter"
 
+async function notifyReviewResult(params: {
+  pullRequestId: string
+  repoId: string
+  prNumber: number
+  prTitle: string
+  type: "NEW_REVIEW" | "REVIEW_FAILED"
+  message: string
+}) {
+  const repositoryUserIds = await getRepositoryMemberIds(params.repoId)
+  const recipientIds = await getEnabledUserIds(
+    [...new Set(repositoryUserIds)],
+    params.type
+  )
+
+  await Promise.all(
+    recipientIds.map(async (userId) => {
+      const notification = await prisma.notification.create({
+        data: {
+          type: params.type,
+          title:
+            params.type === "NEW_REVIEW"
+              ? "AI review is ready"
+              : "AI review failed",
+          message: params.message,
+          userId,
+          prId: params.pullRequestId,
+        },
+      })
+
+      emitNotification(userId, {
+        ...notification,
+        createdAt: notification.createdAt.toISOString(),
+        prTitle: params.prTitle,
+        prNumber: params.prNumber,
+      })
+    })
+  )
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json()
@@ -34,34 +73,32 @@ export async function POST(request: Request) {
       )
     }
 
-    analyzeReview(pullRequestId)
-      .then(async () => {
-        const repositoryUserIds = await getRepositoryMemberIds(pr.repoId)
-        const recipientIds = await getEnabledUserIds(
-          [...new Set(repositoryUserIds)],
-          "NEW_REVIEW"
-        )
+    void analyzeReview(pullRequestId)
+      .then(async (result) => {
+        if (result.status === "SKIPPED_ACTIVE") {
+          return
+        }
 
-        await Promise.all(
-          recipientIds.map(async (userId) => {
-            const notification = await prisma.notification.create({
-              data: {
-                type: "NEW_REVIEW",
-                title: "AI review is ready",
-                message: `The AI review for "${pr.title}" is complete.`,
-                userId,
-                prId: pullRequestId,
-              },
-            })
-
-            emitNotification(userId, {
-              ...notification,
-              createdAt: notification.createdAt.toISOString(),
-              prTitle: pr.title,
-              prNumber: pr.number,
-            })
+        if (result.status === "COMPLETED") {
+          await notifyReviewResult({
+            pullRequestId,
+            repoId: pr.repoId,
+            prNumber: pr.number,
+            prTitle: pr.title,
+            type: "NEW_REVIEW",
+            message: `The AI review for "${pr.title}" is complete.`,
           })
-        )
+          return
+        }
+
+        await notifyReviewResult({
+          pullRequestId,
+          repoId: pr.repoId,
+          prNumber: pr.number,
+          prTitle: pr.title,
+          type: "REVIEW_FAILED",
+          message: result.failureReason,
+        })
       })
       .catch((error) => console.error("[analyze] analyzeReview failed:", error))
 

--- a/app/api/webhook/github/route.ts
+++ b/app/api/webhook/github/route.ts
@@ -173,10 +173,23 @@ export async function POST(request: Request) {
 
     after(async () => {
       try {
-        await analyzeReview(pullRequest.id)
+        const result = await analyzeReview(pullRequest.id)
         recipientIds.forEach((userId) => safeRevalidateDashboard(userId))
 
-        if (recipientIds.length === 0) return
+        if (recipientIds.length === 0 || result.status === "SKIPPED_ACTIVE") return
+
+        if (result.status === "FAILED") {
+          await notifyUsers({
+            userIds: recipientIds,
+            type: "REVIEW_FAILED",
+            title: "AI review failed",
+            message: result.failureReason,
+            prId: pullRequest.id,
+            prTitle: pr.title,
+            prNumber: pr.number,
+          })
+          return
+        }
 
         await notifyUsers({
           userIds: recipientIds,
@@ -189,25 +202,6 @@ export async function POST(request: Request) {
         })
       } catch (error) {
         console.error("[webhook] analyzeReview failed:", error)
-
-        try {
-          if (recipientIds.length === 0) return
-
-          await notifyUsers({
-            userIds: recipientIds,
-            type: "REVIEW_FAILED",
-            title: "AI review failed",
-            message: `The AI review for "${pr.title}" could not be completed.`,
-            prId: pullRequest.id,
-            prTitle: pr.title,
-            prNumber: pr.number,
-          })
-        } catch (notifyError) {
-          console.error(
-            "[webhook] failed to send failure notification:",
-            notifyError
-          )
-        }
       }
     })
 

--- a/components/notification/NotificationList.tsx
+++ b/components/notification/NotificationList.tsx
@@ -2,17 +2,29 @@
 
 import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
-import { AtSign, MessageSquare, GitPullRequest, GitMerge, X } from "lucide-react"
+import {
+  AlertTriangle,
+  AtSign,
+  GitMerge,
+  GitPullRequest,
+  MessageSquare,
+  X,
+} from "lucide-react"
 import type { Notification } from "@/types/notification"
 
 const typeConfig: Record<
   string,
   { icon: typeof AtSign; label: string; color: string; bgColor: string }
 > = {
-  MENTION: { icon: AtSign, label: "멘션", color: "text-blue-500", bgColor: "bg-blue-50" },
+  MENTION: {
+    icon: AtSign,
+    label: "멘션",
+    color: "text-blue-500",
+    bgColor: "bg-blue-50",
+  },
   COMMENT_REPLY: {
     icon: MessageSquare,
-    label: "답글",
+    label: "댓글",
     color: "text-green-500",
     bgColor: "bg-green-50",
   },
@@ -22,7 +34,18 @@ const typeConfig: Record<
     color: "text-purple-500",
     bgColor: "bg-purple-50",
   },
-  PR_MERGED: { icon: GitMerge, label: "머지", color: "text-orange-500", bgColor: "bg-orange-50" },
+  REVIEW_FAILED: {
+    icon: AlertTriangle,
+    label: "리뷰 실패",
+    color: "text-rose-500",
+    bgColor: "bg-rose-50",
+  },
+  PR_MERGED: {
+    icon: GitMerge,
+    label: "머지",
+    color: "text-orange-500",
+    bgColor: "bg-orange-50",
+  },
 }
 
 interface NotificationListProps {
@@ -51,77 +74,78 @@ export default function NotificationList({
   return (
     <div>
       {showHeader && (
-        <div className="flex items-center justify-between px-4 py-2 border-b border-slate-100">
+        <div className="flex items-center justify-between border-b border-slate-100 px-4 py-2">
           <span className="text-xs font-semibold text-slate-500">알림</span>
           <button
             onClick={onMarkAllRead}
-            className="text-xs text-blue-500 hover:text-blue-700 transition-colors"
+            className="text-xs text-blue-500 transition-colors hover:text-blue-700"
           >
             모두 읽음
           </button>
         </div>
       )}
       <div className="max-h-80 overflow-y-auto">
-        {notifications.map((n) => {
-          const config = typeConfig[n.type] ?? typeConfig.MENTION
+        {notifications.map((notification) => {
+          const config = typeConfig[notification.type] ?? typeConfig.MENTION
           const Icon = config.icon
+
           return (
             <div
-              key={n.id}
-              className={`group relative w-full text-left px-4 py-3 flex items-start gap-3 hover:bg-slate-50 transition-colors border-b border-slate-50 ${
-                !n.isRead ? "bg-blue-50/50" : ""
+              key={notification.id}
+              className={`group relative flex w-full items-start gap-3 border-b border-slate-50 px-4 py-3 text-left transition-colors hover:bg-slate-50 ${
+                !notification.isRead ? "bg-blue-50/50" : ""
               }`}
             >
               <button
-                onClick={() => onClickItem(n)}
-                className="flex items-start gap-3 flex-1 min-w-0 text-left"
+                onClick={() => onClickItem(notification)}
+                className="flex min-w-0 flex-1 items-start gap-3 text-left"
               >
                 <div
-                  className={`mt-0.5 shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${config.bgColor} ${config.color}`}
+                  className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${config.bgColor} ${config.color}`}
                 >
-                  <Icon className="w-3.5 h-3.5" />
+                  <Icon className="h-3.5 w-3.5" />
                 </div>
-                <div className="flex-1 min-w-0">
+                <div className="min-w-0 flex-1">
                   <p
-                    className={`text-sm leading-snug ${!n.isRead ? "font-medium text-slate-900" : "text-slate-600"}`}
+                    className={`text-sm leading-snug ${
+                      !notification.isRead ? "font-medium text-slate-900" : "text-slate-600"
+                    }`}
                   >
-                    {n.title}
+                    {notification.title}
                   </p>
-                  {n.prTitle && (
-                    <p className="text-xs text-blue-500 mt-0.5 truncate">
-                      {n.repoFullName && (
-                        <span className="text-slate-400">{n.repoFullName} </span>
+                  {notification.prTitle && (
+                    <p className="mt-0.5 truncate text-xs text-blue-500">
+                      {notification.repoFullName && (
+                        <span className="text-slate-400">{notification.repoFullName} </span>
                       )}
-                      #{n.prNumber} {n.prTitle}
+                      #{notification.prNumber} {notification.prTitle}
                     </p>
                   )}
-                  {n.message && (
-                    <p className="text-xs text-slate-400 mt-0.5 truncate">
-                      {n.message}
+                  {notification.message && (
+                    <p className="mt-0.5 truncate text-xs text-slate-400">
+                      {notification.message}
                     </p>
                   )}
-                  <p className="text-xs text-slate-300 mt-1">
-                    {formatDistanceToNow(new Date(n.createdAt), {
+                  <p className="mt-1 text-xs text-slate-300">
+                    {formatDistanceToNow(new Date(notification.createdAt), {
                       addSuffix: true,
                       locale: ko,
                     })}
                   </p>
                 </div>
               </button>
-              <div className="flex items-center gap-1 shrink-0 mt-1">
-                {!n.isRead && (
-                  <div className="w-2 h-2 rounded-full bg-blue-500" />
-                )}
+              <div className="mt-1 flex shrink-0 items-center gap-1">
+                {!notification.isRead && <div className="h-2 w-2 rounded-full bg-blue-500" />}
                 {onDelete && (
                   <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onDelete(n.id)
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onDelete(notification.id)
                     }}
-                    className="opacity-0 group-hover:opacity-100 p-0.5 hover:bg-slate-200 rounded transition-all"
+                    className="rounded p-0.5 opacity-0 transition-all hover:bg-slate-200 group-hover:opacity-100"
                     title="알림 삭제"
                   >
-                    <X className="w-3.5 h-3.5 text-slate-400" />
+                    <X className="h-3.5 w-3.5 text-slate-400" />
                   </button>
                 )}
               </div>

--- a/components/pulls/detail/PRDetailContainer.tsx
+++ b/components/pulls/detail/PRDetailContainer.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import PRDetailLayout from "@/components/pulls/detail/PRDetailLayout";
 import { usePRDetail } from "@/hooks/usePRDetail";
 import { usePRFiles } from "@/hooks/usePRFiles";
 import { useReview } from "@/hooks/useReview";
-import { useQueryClient } from "@tanstack/react-query";
-import PRDetailLayout from "@/components/pulls/detail/PRDetailLayout";
 import { layoutStyles } from "@/lib/styles";
+import type { Review } from "@/types/review";
 
 interface PRDetailContainerProps {
   id: string;
@@ -33,8 +34,18 @@ export default function PRDetailContainer({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ pullRequestId: id }),
       });
+
       if (res.ok) {
-        // PENDING 상태로 즉시 반영 → polling + 소켓 알림이 완료 시 자동 갱신
+        queryClient.setQueryData<Review | null>(["review", id], (current) =>
+          current
+            ? {
+                ...current,
+                status: "PENDING",
+                failureReason: null,
+              }
+            : current
+        );
+
         await queryClient.invalidateQueries({ queryKey: ["review", id] });
       }
     } finally {
@@ -45,12 +56,12 @@ export default function PRDetailContainer({
   if (prPending || filesPending) {
     return (
       <div className={`${layoutStyles.detailFrame} animate-pulse`}>
-        <div className="w-72 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900" />
-        <div className="flex-1 p-6 space-y-4">
-          <div className="h-8 bg-slate-200 dark:bg-slate-800 rounded-xl w-2/3" />
-          <div className="h-4 bg-slate-200 dark:bg-slate-800 rounded-xl w-1/3" />
-          <div className="h-48 bg-slate-200 dark:bg-slate-800 rounded-2xl" />
-          <div className="h-48 bg-slate-200 dark:bg-slate-800 rounded-2xl" />
+        <div className="w-72 shrink-0 border-r border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900" />
+        <div className="flex-1 space-y-4 p-6">
+          <div className="h-8 w-2/3 rounded-xl bg-slate-200 dark:bg-slate-800" />
+          <div className="h-4 w-1/3 rounded-xl bg-slate-200 dark:bg-slate-800" />
+          <div className="h-48 rounded-2xl bg-slate-200 dark:bg-slate-800" />
+          <div className="h-48 rounded-2xl bg-slate-200 dark:bg-slate-800" />
         </div>
       </div>
     );
@@ -59,9 +70,13 @@ export default function PRDetailContainer({
   if (prError || filesError || !pr || !files) {
     return (
       <div className={`${layoutStyles.detailFrame} items-center justify-center`}>
-        <div className="text-center space-y-2">
-          <p className="text-slate-500 dark:text-slate-400 text-sm">PR 정보를 불러오는 데 실패했습니다.</p>
-          <p className="text-slate-400 dark:text-slate-500 text-xs">잠시 후 다시 시도해주세요.</p>
+        <div className="space-y-2 text-center">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            PR 정보를 불러오는 데 실패했습니다.
+          </p>
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            잠시 후 다시 시도해 주세요.
+          </p>
         </div>
       </div>
     );

--- a/components/review/ReviewPanel.tsx
+++ b/components/review/ReviewPanel.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, BotMessageSquare, CheckCircle } from "lucide-react";
+import {
+  AlertTriangle,
+  BotMessageSquare,
+  CheckCircle,
+  Loader2,
+  RotateCcw,
+} from "lucide-react";
 import type { Review, ReviewIssue } from "@/types/review";
 import type { AIReviewIssue } from "@/lib/ai/parsers";
 import { SEVERITY_ORDER } from "@/constants/review";
@@ -24,26 +30,27 @@ export default function ReviewPanel({
   isRequesting = false,
   onIssueClick,
 }: ReviewPanelProps) {
-  const [filterSeverity, setFilterSeverity] = useState<AIReviewIssue["severity"] | "ALL">("ALL");
+  const [filterSeverity, setFilterSeverity] =
+    useState<AIReviewIssue["severity"] | "ALL">("ALL");
 
   if (isPending) {
     return (
-      <div className="flex items-center justify-center py-10 text-slate-400 gap-2">
+      <div className="flex items-center justify-center gap-2 py-10 text-slate-400">
         <Loader2 size={18} className="animate-spin" />
-        <span className="text-sm">리뷰 데이터 로딩 중...</span>
+        <span className="text-sm">리뷰 데이터를 불러오는 중입니다...</span>
       </div>
     );
   }
 
   if (!review) {
     return (
-      <div className="flex flex-col items-center justify-center py-10 gap-4">
+      <div className="flex flex-col items-center justify-center gap-4 py-10">
         <BotMessageSquare size={36} className="text-slate-300 dark:text-slate-600" />
         <div className="text-center">
           <p className="text-sm font-semibold text-slate-600 dark:text-slate-400">
             AI 리뷰가 없습니다
           </p>
-          <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
             AI가 이 PR의 코드를 분석하게 합니다
           </p>
         </div>
@@ -51,7 +58,7 @@ export default function ReviewPanel({
           type="button"
           onClick={onRequestReview}
           disabled={isRequesting}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-60 text-white text-sm font-semibold transition-colors"
+          className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-60"
         >
           {isRequesting ? (
             <>
@@ -69,14 +76,57 @@ export default function ReviewPanel({
     );
   }
 
+  if (review.status === "FAILED") {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 dark:border-rose-900/50 dark:bg-rose-950/30">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 rounded-full bg-rose-100 p-2 text-rose-600 dark:bg-rose-900/40 dark:text-rose-300">
+              <AlertTriangle size={18} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-rose-800 dark:text-rose-200">
+                AI 리뷰에 실패했습니다
+              </p>
+              <p className="mt-1 text-sm text-rose-700 dark:text-rose-300">
+                {review.failureReason ?? "원인을 확인할 수 없었습니다. 다시 시도해 주세요."}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRequestReview}
+          disabled={isRequesting}
+          className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+        >
+          {isRequesting ? (
+            <>
+              <Loader2 size={14} className="animate-spin" />
+              재시도 중...
+            </>
+          ) : (
+            <>
+              <RotateCcw size={14} />
+              AI 리뷰 재시도
+            </>
+          )}
+        </button>
+      </div>
+    );
+  }
+
   if (review.status === "PENDING" || review.status === "IN_PROGRESS") {
     return (
-      <div className="flex flex-col items-center justify-center py-10 gap-3">
+      <div className="flex flex-col items-center justify-center gap-3 py-10">
         <Loader2 size={32} className="animate-spin text-blue-500" />
         <p className="text-sm font-semibold text-slate-600 dark:text-slate-400">
           AI가 코드를 분석하고 있습니다...
         </p>
-        <p className="text-xs text-slate-400 dark:text-slate-500">잠시 후 결과가 표시됩니다</p>
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          잠시 후 결과가 표시됩니다
+        </p>
       </div>
     );
   }
@@ -85,31 +135,36 @@ export default function ReviewPanel({
   const assessment = review.aiSuggestions?.overallAssessment;
   const summary = review.aiSuggestions?.summary;
 
-  const indexedSuggestions: ReviewIssue[] = suggestions.map((issue, i) => ({ ...issue, originalIndex: i }));
+  const indexedSuggestions: ReviewIssue[] = suggestions.map((issue, index) => ({
+    ...issue,
+    originalIndex: index,
+  }));
 
   const filtered =
     filterSeverity === "ALL"
       ? indexedSuggestions
-      : indexedSuggestions.filter((s) => s.severity === filterSeverity);
+      : indexedSuggestions.filter((suggestion) => suggestion.severity === filterSeverity);
 
   const sorted = [...filtered].sort(
     (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
   );
 
   const counts = {
-    HIGH: suggestions.filter((s) => s.severity === "HIGH").length,
-    MEDIUM: suggestions.filter((s) => s.severity === "MEDIUM").length,
-    LOW: suggestions.filter((s) => s.severity === "LOW").length,
+    HIGH: suggestions.filter((suggestion) => suggestion.severity === "HIGH").length,
+    MEDIUM: suggestions.filter((suggestion) => suggestion.severity === "MEDIUM").length,
+    LOW: suggestions.filter((suggestion) => suggestion.severity === "LOW").length,
   };
 
   const assessmentMeta = assessment ? ASSESSMENT_LABEL[assessment] : null;
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
+      <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
         <ReviewScore score={review.qualityScore} />
         {assessmentMeta && (
-          <div className={`inline-flex items-center gap-1.5 text-sm font-semibold ${assessmentMeta.color}`}>
+          <div
+            className={`inline-flex items-center gap-1.5 text-sm font-semibold ${assessmentMeta.color}`}
+          >
             {assessmentMeta.icon}
             {assessmentMeta.label}
           </div>
@@ -117,32 +172,36 @@ export default function ReviewPanel({
       </div>
 
       {summary && (
-        <div className="px-4 py-3 rounded-xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700">
-          <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
             요약
           </p>
-          <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">{summary}</p>
+          <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+            {summary}
+          </p>
         </div>
       )}
 
       {suggestions.length > 0 && (
         <div>
-          <div className="flex items-center gap-2 mb-3 flex-wrap">
-            <span className="text-xs text-slate-500 dark:text-slate-400 font-semibold">필터:</span>
-            {(["ALL", "HIGH", "MEDIUM", "LOW"] as const).map((sv) => {
-              const count = sv === "ALL" ? suggestions.length : counts[sv];
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+              필터:
+            </span>
+            {(["ALL", "HIGH", "MEDIUM", "LOW"] as const).map((severity) => {
+              const count = severity === "ALL" ? suggestions.length : counts[severity];
               return (
                 <button
-                  key={sv}
+                  key={severity}
                   type="button"
-                  onClick={() => setFilterSeverity(sv)}
-                  className={`px-2.5 py-1 rounded-full text-[11px] font-semibold border transition-colors ${
-                    filterSeverity === sv
-                      ? "bg-slate-800 text-white border-slate-800 dark:bg-slate-200 dark:text-slate-900 dark:border-slate-200"
-                      : "bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700"
+                  onClick={() => setFilterSeverity(severity)}
+                  className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                    filterSeverity === severity
+                      ? "border-slate-800 bg-slate-800 text-white dark:border-slate-200 dark:bg-slate-200 dark:text-slate-900"
+                      : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700"
                   }`}
                 >
-                  {sv === "ALL" ? "전체" : sv} {count > 0 && `(${count})`}
+                  {severity === "ALL" ? "전체" : severity} {count > 0 && `(${count})`}
                 </button>
               );
             })}
@@ -150,7 +209,7 @@ export default function ReviewPanel({
 
           <div className="space-y-2">
             {sorted.length === 0 ? (
-              <p className="text-sm text-slate-400 text-center py-4">
+              <p className="py-4 text-center text-sm text-slate-400">
                 해당 심각도의 이슈가 없습니다.
               </p>
             ) : (
@@ -167,12 +226,14 @@ export default function ReviewPanel({
       )}
 
       {suggestions.length === 0 && review.status === "COMPLETED" && (
-        <div className="flex flex-col items-center py-8 gap-2">
+        <div className="flex flex-col items-center gap-2 py-8">
           <CheckCircle size={32} className="text-emerald-500" />
           <p className="text-sm font-semibold text-slate-600 dark:text-slate-400">
             발견된 이슈가 없습니다
           </p>
-          <p className="text-xs text-slate-400 dark:text-slate-500">코드가 양호한 상태입니다.</p>
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            코드가 양호한 상태입니다.
+          </p>
         </div>
       )}
     </div>

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -78,7 +78,9 @@ function getToastMessage(notification: BaseNotification) {
 function showNotificationToast(notification: BaseNotification) {
   const toastContent = getToastMessage(notification)
   const action =
-    notification.prId && notification.type === "NEW_REVIEW"
+    notification.prId &&
+    (notification.type === "NEW_REVIEW" ||
+      notification.type === "REVIEW_FAILED")
       ? {
           label: "Open PR",
           onClick: () => {

--- a/hooks/useReview.ts
+++ b/hooks/useReview.ts
@@ -5,6 +5,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSocket } from "./useSocket"
 import type { Review } from "@/types/review"
 import type { BaseNotification } from "@/types/notification"
+import {
+  recordHandlerInvocation,
+  recordHandlerRegistered,
+  recordHandlerRemoved,
+} from "@/lib/measurements/socketMetrics"
 
 async function fetchReview(prId: string): Promise<Review | null> {
   const res = await fetch(`/api/pulls/${prId}/review`)
@@ -21,14 +26,21 @@ export function useReview(prId: string) {
     if (!socket) return
 
     const handleNotification = (notification: BaseNotification) => {
-      if (notification.type === "NEW_REVIEW" && notification.prId === prId) {
+      recordHandlerInvocation("notification:new")
+      if (
+        (notification.type === "NEW_REVIEW" ||
+          notification.type === "REVIEW_FAILED") &&
+        notification.prId === prId
+      ) {
         queryClient.invalidateQueries({ queryKey: ["review", prId] })
       }
     }
 
+    recordHandlerRegistered("notification:new")
     socket.on("notification:new", handleNotification)
     return () => {
       socket.off("notification:new", handleNotification)
+      recordHandlerRemoved("notification:new")
     }
   }, [socket, prId, queryClient])
 

--- a/lib/ai/analyze.ts
+++ b/lib/ai/analyze.ts
@@ -12,43 +12,127 @@ function isActiveReviewConflict(err: unknown): boolean {
     err instanceof Prisma.PrismaClientKnownRequestError &&
     err.code === "P2002" &&
     Array.isArray(err.meta?.target) &&
-    (err.meta.target as string[]).includes("review_active_unique")
+    (err.meta.target as string[]).some(
+      (target) => target === "review_active_unique" || target === "pullRequestId"
+    )
   )
 }
 
-export async function analyzeReview(pullRequestId: string): Promise<void> {
+function getResetReviewData() {
+  return {
+    status: "PENDING" as const,
+    aiSuggestions: {},
+    qualityScore: 0,
+    severity: "LOW" as const,
+    issueCount: 0,
+    failureReason: null,
+    reviewedAt: new Date(),
+  }
+}
+
+function getFailureReason(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return "AI review could not be completed."
+}
+
+export type AnalyzeReviewResult =
+  | {
+      status: "COMPLETED"
+      reviewId: string
+    }
+  | {
+      status: "FAILED"
+      reviewId: string | null
+      failureReason: string
+    }
+  | {
+      status: "SKIPPED_ACTIVE"
+      reviewId: null
+    }
+
+export async function analyzeReview(
+  pullRequestId: string
+): Promise<AnalyzeReviewResult> {
   let reviewId: string | null = null
 
   try {
+    const activeReview = await prisma.review.findFirst({
+      where: {
+        pullRequestId,
+        status: { in: ["PENDING", "IN_PROGRESS"] },
+      },
+      select: { id: true },
+      orderBy: { reviewedAt: "desc" },
+    })
+
+    if (activeReview) {
+      console.info(
+        `[analyzeReview] already active for PR ${pullRequestId}, skipping.`
+      )
+      return {
+        status: "SKIPPED_ACTIVE",
+        reviewId: null,
+      }
+    }
+
     let review: { id: string }
     try {
       review = await prisma.review.create({
         data: {
           pullRequestId,
-          status: "PENDING",
-          aiSuggestions: {},
-          qualityScore: 0,
-          severity: "LOW",
-          issueCount: 0,
+          ...getResetReviewData(),
         },
         select: { id: true },
       })
     } catch (error) {
       if (isActiveReviewConflict(error)) {
-        console.info(
-          `[analyzeReview] already active for PR ${pullRequestId}, skipping.`
-        )
-        return
-      }
+        const existingReview = await prisma.review.findFirst({
+          where: { pullRequestId },
+          select: { id: true, status: true },
+          orderBy: { reviewedAt: "desc" },
+        })
 
-      throw error
+        if (
+          existingReview &&
+          (existingReview.status === "PENDING" ||
+            existingReview.status === "IN_PROGRESS")
+        ) {
+          console.info(
+            `[analyzeReview] already active for PR ${pullRequestId}, skipping.`
+          )
+          return {
+            status: "SKIPPED_ACTIVE",
+            reviewId: null,
+          }
+        }
+
+        if (existingReview) {
+          await prisma.review.update({
+            where: { id: existingReview.id },
+            data: getResetReviewData(),
+            select: { id: true },
+          })
+
+          review = { id: existingReview.id }
+        } else {
+          throw error
+        }
+      } else {
+        throw error
+      }
     }
 
     reviewId = review.id
 
     await prisma.review.update({
       where: { id: reviewId },
-      data: { status: "IN_PROGRESS" },
+      data: {
+        status: "IN_PROGRESS",
+        failureReason: null,
+      },
     })
 
     const pr = await prisma.pullRequest.findUnique({
@@ -127,16 +211,32 @@ export async function analyzeReview(pullRequestId: string): Promise<void> {
         severity: overallSeverity,
         issueCount,
         status: "COMPLETED",
+        failureReason: null,
       },
     })
+
+    return {
+      status: "COMPLETED",
+      reviewId,
+    }
   } catch (error) {
+    const failureReason = getFailureReason(error)
     console.error("[analyzeReview] failed:", error)
 
     if (reviewId) {
       await prisma.review.update({
         where: { id: reviewId },
-        data: { status: "FAILED" },
+        data: {
+          status: "FAILED",
+          failureReason,
+        },
       })
+    }
+
+    return {
+      status: "FAILED",
+      reviewId,
+      failureReason,
     }
   }
 }

--- a/lib/notification-link.ts
+++ b/lib/notification-link.ts
@@ -17,6 +17,7 @@ export function getNotificationLink(notification: Notification): string | null {
         ? `${base}#comment-${notification.commentId}`
         : base
     case "NEW_REVIEW":
+    case "REVIEW_FAILED":
       return `${base}?review=open`
     case "PR_MERGED":
       return base

--- a/prisma/migrations/20260422000000_add_review_failure_reason/migration.sql
+++ b/prisma/migrations/20260422000000_add_review_failure_reason/migration.sql
@@ -1,0 +1,9 @@
+DO $$
+BEGIN
+  ALTER TYPE "NotificationType" ADD VALUE 'REVIEW_FAILED';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "Review"
+ADD COLUMN "failureReason" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,7 @@ model Review {
   severity        Severity     @default(LOW)
   issueCount      Int          @default(0)
   status          ReviewStatus @default(PENDING)
+  failureReason   String?      @db.Text
 
   // Relations
   pullRequest     PullRequest  @relation(fields: [pullRequestId], references: [id], onDelete: Cascade)

--- a/types/review.ts
+++ b/types/review.ts
@@ -13,6 +13,7 @@ export interface Review {
   severity: ReviewSeverity;
   issueCount: number;
   status: ReviewStatus;
+  failureReason: string | null;
   aiSuggestions: AIReviewResponse;
   reviewedAt: string;
 }


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

실패한 AI 리뷰를 PR 상세 화면에서 명확히 표시하고, 실패 사유를 노출하며, 사용자가 같은 PR에서 다시 리뷰를 요청할 수 있도록 재시도 흐름을 추가했습니다. 또한 수동 분석 API와 webhook의 성공/실패 알림 분기를 정리해 `NEW_REVIEW`와 `REVIEW_FAILED`가 실제 결과와 일치하도록 맞췄습니다.

## 변경 사항

- `Review.failureReason` 필드와 migration을 추가했습니다.
- `analyzeReview`가 `COMPLETED / FAILED / SKIPPED_ACTIVE` 결과를 반환하도록 정리했습니다.
- 활성 리뷰가 이미 있으면 중복 생성을 막고, 기존 리뷰를 재사용해 재시도할 수 있게 했습니다.
- PR 상세 `ReviewPanel`에 실패 상태 카드와 재시도 버튼을 추가했습니다.
- 재시도 직후 로컬 캐시를 `PENDING`으로 전환해 즉시 진행 상태가 보이도록 했습니다.
- `REVIEW_FAILED` 알림 타입을 목록, toast 진입 링크, review refetch 흐름에 반영했습니다.
- 관련 API 및 notification-link 테스트를 보강했습니다.

## 스크린샷 (선택)

- 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

추가로 아래 테스트를 실행했습니다.

- `npx jest __tests__/api/review/analyze/route.test.ts __tests__/api/webhook/github/route.test.ts __tests__/lib/notification-link.test.ts --runInBand`
- `npx tsc --noEmit --pretty false`

## 참고 사항

- 작업 트리에 다른 미커밋 변경이 많이 남아 있어, 이번 PR에는 `#131` 범위 파일만 선택적으로 커밋했습니다.
- 성공한 리뷰를 다시 실행하는 UX와 리뷰 진행 단계 세분화는 이번 PR 범위에 포함하지 않았습니다.
- Closes #131