### PR TITLE
fix: 성공한 AI 리뷰도 다시 실행 가능하도록 보완

### DIFF
--- a/components/review/ReviewPanel.tsx
+++ b/components/review/ReviewPanel.tsx
@@ -161,14 +161,34 @@ export default function ReviewPanel({
     <div className="space-y-4">
       <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
         <ReviewScore score={review.qualityScore} />
-        {assessmentMeta && (
-          <div
-            className={`inline-flex items-center gap-1.5 text-sm font-semibold ${assessmentMeta.color}`}
+        <div className="flex flex-wrap items-center gap-2">
+          {assessmentMeta && (
+            <div
+              className={`inline-flex items-center gap-1.5 text-sm font-semibold ${assessmentMeta.color}`}
+            >
+              {assessmentMeta.icon}
+              {assessmentMeta.label}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onRequestReview}
+            disabled={isRequesting}
+            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
           >
-            {assessmentMeta.icon}
-            {assessmentMeta.label}
-          </div>
-        )}
+            {isRequesting ? (
+              <>
+                <Loader2 size={14} className="animate-spin" />
+                AI 리뷰 다시 실행 중...
+              </>
+            ) : (
+              <>
+                <RotateCcw size={14} />
+                AI 리뷰 다시 실행
+              </>
+            )}
+          </button>
+        </div>
       </div>
 
       {summary && (


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

기존 AI 리뷰 재시도 UI는 실패한 경우에만 다시 실행할 수 있었습니다. 이번 수정으로 성공(`COMPLETED`)한 리뷰도 PR 상세 화면에서 다시 실행할 수 있도록 보완했습니다.

## 변경 사항

- 완료된 AI 리뷰 화면 상단에 `AI 리뷰 다시 실행` 버튼을 추가했습니다.
- 기존 실패 상태의 재시도 버튼 동작은 그대로 유지했습니다.
- 성공 상태에서도 동일한 분석 요청 흐름을 사용할 수 있도록 UI 접근 경로를 열었습니다.

## 스크린샷 (선택)

- 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

추가로 아래 테스트를 실행했습니다.

- `npx.cmd eslint components/review/ReviewPanel.tsx`

## 참고 사항

- `feat/131-ai-review-retry-ui`가 이미 머지된 뒤 같은 브랜치에 후속 수정 커밋을 추가한 PR입니다.
- 작업 트리에 다른 미커밋 변경이 많이 남아 있어, 이번 PR에는 `components/review/ReviewPanel.tsx`만 선택적으로 커밋했습니다.
- 관련 선행 PR: #132