### PR TITLE
design: 보호 페이지 공통 레이아웃/표면 스타일 정리 (#137)

### DIFF
--- a/app/(protected)/dashboard/loading.tsx
+++ b/app/(protected)/dashboard/loading.tsx
@@ -1,12 +1,15 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { layoutStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function DashboardLoading() {
   return (
-    <div className="max-w-350 mx-auto space-y-4 sm:space-y-6">
+    <PageContainer size="wide">
       {/* Stat Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 ${layoutStyles.gridGap}`}>
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 space-y-4 shadow-sm">
+          <div key={i} className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-4")}>
             <div className="flex items-center justify-between">
               <Skeleton className="h-4 w-24" />
               <Skeleton className="h-8 w-8 rounded-lg" />
@@ -18,20 +21,20 @@ export default function DashboardLoading() {
       </div>
 
       {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-4">
+      <div className={`grid grid-cols-1 lg:grid-cols-2 ${layoutStyles.gridGap}`}>
+        <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-4")}>
           <Skeleton className="h-5 w-32" />
           <Skeleton className="h-56 w-full rounded-xl" />
         </div>
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-4">
+        <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-4")}>
           <Skeleton className="h-5 w-32" />
           <Skeleton className="h-56 w-full rounded-xl" />
         </div>
       </div>
 
       {/* Recent PRs */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl shadow-sm overflow-hidden">
-        <div className="p-4 sm:p-6 md:p-8 border-b border-slate-200 dark:border-slate-800">
+      <div className={cn(surfaceStyles.panel, "overflow-hidden")}>
+        <div className="border-b border-slate-200 p-4 sm:p-6 dark:border-slate-800">
           <Skeleton className="h-5 w-40" />
         </div>
         <div className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -47,6 +50,6 @@ export default function DashboardLoading() {
           ))}
         </div>
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next"
 import { auth } from "@/lib/auth"
 import {
-  fetchDashboardStats,
-  fetchDashboardQualityTrend,
-  fetchDashboardIssueSeverity,
-  fetchDashboardRecentPRs,
+  getCachedDashboardStats,
+  getCachedDashboardQualityTrend,
+  getCachedDashboardIssueSeverity,
+  getCachedDashboardRecentPRs,
 } from "@/lib/dashboard"
 import StatCards from "@/components/dashboard/stat-cards/StatCards"
 import ChartsSection from "@/components/dashboard/charts/ChartsSection"
 import RecentPRSection from "@/components/dashboard/recent-prs/RecentPRSection"
+import { PageContainer } from "@/components/layout/PageContainer"
 
 export const metadata: Metadata = {
   title: "대시보드",
@@ -20,17 +21,17 @@ export default async function Page() {
   if (!session?.user?.id) return null
 
   const [stats, qualityTrend, issueSeverity, recentPRs] = await Promise.all([
-    fetchDashboardStats(session.user.id),
-    fetchDashboardQualityTrend(session.user.id),
-    fetchDashboardIssueSeverity(session.user.id),
-    fetchDashboardRecentPRs(session.user.id),
+    getCachedDashboardStats(session.user.id),
+    getCachedDashboardQualityTrend(session.user.id),
+    getCachedDashboardIssueSeverity(session.user.id),
+    getCachedDashboardRecentPRs(session.user.id),
   ])
 
   return (
-    <div className="max-w-350 mx-auto space-y-4 sm:space-y-6">
+    <PageContainer size="wide">
       <StatCards stats={stats} />
       <ChartsSection qualityTrend={qualityTrend} issueSeverity={issueSeverity} />
       <RecentPRSection prs={recentPRs} />
-    </div>
+    </PageContainer>
   )
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -12,7 +12,7 @@ export default function ProtectedLayout({
       <AppSidebar />
       <SidebarInset>
         <AppHeader />
-        <main className="flex-1 p-4 md:p-8 lg:p-10">
+        <main className="flex-1 p-4 sm:p-6 lg:p-8">
           {children}
         </main>
       </SidebarInset>

--- a/app/(protected)/notifications/loading.tsx
+++ b/app/(protected)/notifications/loading.tsx
@@ -1,8 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function NotificationsLoading() {
   return (
-    <div className="w-full max-w-2xl mx-auto space-y-6">
+    <PageContainer>
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="space-y-2">
@@ -20,7 +23,7 @@ export default function NotificationsLoading() {
       </div>
 
       {/* Notification List */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-sm divide-y divide-slate-100 dark:divide-slate-800">
+      <div className={cn(surfaceStyles.panel, "divide-y divide-slate-100 overflow-hidden dark:divide-slate-800")}>
         {Array.from({ length: 7 }).map((_, i) => (
           <div key={i} className="flex items-start gap-4 p-4">
             <Skeleton className="h-9 w-9 rounded-full shrink-0" />
@@ -32,6 +35,6 @@ export default function NotificationsLoading() {
           </div>
         ))}
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/app/(protected)/pulls/[id]/loading.tsx
+++ b/app/(protected)/pulls/[id]/loading.tsx
@@ -1,10 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { layoutStyles } from "@/lib/styles"
 
 export default function PRDetailLoading() {
   return (
-    <div className="flex h-[calc(100svh-6.5rem)] md:h-[calc(100svh-8.5rem)] lg:h-[calc(100svh-9.5rem)] bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-[24px] shadow-sm mt-2">
+    <div className={layoutStyles.detailFrame}>
       {/* Sidebar */}
-      <div className="w-72 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 rounded-l-[24px] p-4 space-y-3">
+      <div className="w-72 shrink-0 space-y-3 rounded-l-md border-r border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
         <Skeleton className="h-4 w-24" />
         {Array.from({ length: 8 }).map((_, i) => (
           <Skeleton key={i} className="h-9 w-full rounded-lg" />

--- a/app/(protected)/pulls/loading.tsx
+++ b/app/(protected)/pulls/loading.tsx
@@ -1,9 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { layoutStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function PullsLoading() {
   return (
-    <div className="w-full flex justify-center">
-      <div className="w-full max-w-4xl space-y-6">
+    <PageContainer>
         {/* Header */}
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div className="space-y-2">
@@ -24,9 +26,9 @@ export default function PullsLoading() {
         </div>
 
         {/* PR List */}
-        <div className="space-y-3">
+        <div className={layoutStyles.listStack}>
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-sm space-y-3">
+            <div key={i} className={cn(surfaceStyles.card, "space-y-3")}>
               <div className="flex items-start justify-between gap-3">
                 <div className="flex items-center gap-3 flex-1">
                   <Skeleton className="h-5 w-5 rounded-full shrink-0" />
@@ -42,7 +44,6 @@ export default function PullsLoading() {
             </div>
           ))}
         </div>
-      </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/app/(protected)/pulls/page.tsx
+++ b/app/(protected)/pulls/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react"
 import PRFilterBar from "@/components/pulls/PRFilterBar"
 import PRList from "@/components/pulls/PRList"
 import PRPageHeader from "@/components/pulls/PRPageHeader"
+import { PageContainer } from "@/components/layout/PageContainer"
 
 export const metadata: Metadata = {
   title: "Pull Requests",
@@ -11,14 +12,12 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <div className="w-full flex justify-center">
-      <div className="w-full max-w-4xl space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
-        <PRPageHeader />
-        <PRFilterBar />
-        <Suspense>
-          <PRList />
-        </Suspense>
-      </div>
-    </div>
+    <PageContainer>
+      <PRPageHeader />
+      <PRFilterBar />
+      <Suspense>
+        <PRList />
+      </Suspense>
+    </PageContainer>
   );
 }

--- a/app/(protected)/repositories/loading.tsx
+++ b/app/(protected)/repositories/loading.tsx
@@ -1,8 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { layoutStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function RepositoriesLoading() {
   return (
-    <div className="w-full max-w-4xl mx-auto space-y-6">
+    <PageContainer>
       {/* Header */}
       <div className="space-y-2">
         <Skeleton className="h-9 w-36" />
@@ -13,9 +16,9 @@ export default function RepositoriesLoading() {
       <Skeleton className="h-10 w-full rounded-xl" />
 
       {/* Repo List */}
-      <div className="space-y-3">
+      <div className={layoutStyles.listStack}>
         {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-sm flex items-center justify-between gap-4">
+          <div key={i} className={cn(surfaceStyles.card, "flex items-center justify-between gap-4")}>
             <div className="flex items-center gap-4 flex-1">
               <Skeleton className="h-10 w-10 rounded-xl shrink-0" />
               <div className="space-y-2 flex-1">
@@ -27,6 +30,6 @@ export default function RepositoriesLoading() {
           </div>
         ))}
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/app/(protected)/settings/loading.tsx
+++ b/app/(protected)/settings/loading.tsx
@@ -1,8 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function SettingsLoading() {
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
+    <PageContainer>
       {/* Header */}
       <div className="space-y-2">
         <Skeleton className="h-9 w-16" />
@@ -10,7 +13,7 @@ export default function SettingsLoading() {
       </div>
 
       {/* Profile Card */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-6">
+      <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-6")}>
         <Skeleton className="h-5 w-24" />
         <div className="flex items-center gap-4">
           <Skeleton className="h-16 w-16 rounded-full shrink-0" />
@@ -31,7 +34,7 @@ export default function SettingsLoading() {
       </div>
 
       {/* GitHub Section */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-4">
+      <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-4")}>
         <Skeleton className="h-5 w-32" />
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -46,7 +49,7 @@ export default function SettingsLoading() {
       </div>
 
       {/* AI Review Section */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-4">
+      <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-4")}>
         <Skeleton className="h-5 w-28" />
         {Array.from({ length: 3 }).map((_, i) => (
           <div key={i} className="flex items-center justify-between">
@@ -58,6 +61,6 @@ export default function SettingsLoading() {
           </div>
         ))}
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/app/(protected)/stats/loading.tsx
+++ b/app/(protected)/stats/loading.tsx
@@ -1,8 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { layoutStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function StatsLoading() {
   return (
-    <div className="space-y-6">
+    <PageContainer size="wide">
       {/* Header */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div className="space-y-2">
@@ -17,9 +20,9 @@ export default function StatsLoading() {
       </div>
 
       {/* Overview Cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className={`grid grid-cols-2 lg:grid-cols-4 ${layoutStyles.gridGap}`}>
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-sm space-y-3">
+          <div key={i} className={cn(surfaceStyles.card, "space-y-3")}>
             <Skeleton className="h-4 w-20" />
             <Skeleton className="h-8 w-16" />
             <Skeleton className="h-3 w-24" />
@@ -28,9 +31,9 @@ export default function StatsLoading() {
       </div>
 
       {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className={`grid grid-cols-1 lg:grid-cols-2 ${layoutStyles.gridGap}`}>
         {Array.from({ length: 2 }).map((_, i) => (
-          <div key={i} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-4">
+          <div key={i} className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "space-y-4")}>
             <Skeleton className="h-5 w-36" />
             <Skeleton className="h-64 w-full rounded-xl" />
           </div>
@@ -38,8 +41,8 @@ export default function StatsLoading() {
       </div>
 
       {/* Table */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-sm overflow-hidden">
-        <div className="p-6 border-b border-slate-200 dark:border-slate-800">
+      <div className={cn(surfaceStyles.panel, "overflow-hidden")}>
+        <div className="border-b border-slate-200 p-4 sm:p-6 dark:border-slate-800">
           <Skeleton className="h-5 w-40" />
         </div>
         <div className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -53,6 +56,6 @@ export default function StatsLoading() {
           ))}
         </div>
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/components/comment/CommentCard.tsx
+++ b/components/comment/CommentCard.tsx
@@ -5,6 +5,7 @@ import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
 import { MessageSquare, GitPullRequest, FileCode } from "lucide-react"
 import { Card } from "@/components/ui/card"
+import { surfaceStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { CommentWithPR } from "@/types/comment"
 
@@ -24,9 +25,8 @@ export default function CommentCard({ comment, onClick, animationDelay = 0 }: Co
     <Card
       onClick={() => onClick(comment)}
       className={cn(
-        "group relative rounded-[24px] p-4 md:p-5 border-slate-200 shadow-none cursor-pointer",
-        "hover:border-blue-200 hover:shadow-xl hover:shadow-blue-500/5",
-        "transition-all duration-300",
+        "group relative cursor-pointer",
+        surfaceStyles.interactiveCard,
         "animate-in fade-in slide-in-from-bottom-4 fill-mode-both"
       )}
       style={{ animationDelay: `${animationDelay}ms` }}

--- a/components/comment/CommentCardSkeleton.tsx
+++ b/components/comment/CommentCardSkeleton.tsx
@@ -1,8 +1,10 @@
 import { Card } from "@/components/ui/card"
+import { surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function CommentCardSkeleton() {
   return (
-    <Card className="rounded-[24px] p-4 md:p-5 border-slate-200 shadow-none animate-pulse">
+    <Card className={cn(surfaceStyles.card, "animate-pulse")}>
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">

--- a/components/comment/CommentFilter.tsx
+++ b/components/comment/CommentFilter.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { User } from "lucide-react"
+import { controlStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 interface ConnectedRepo {
   id: string
@@ -24,16 +26,16 @@ export default function CommentFilter({
   onMyOnlyChange,
 }: CommentFilterProps) {
   return (
-    <div className="flex flex-col sm:flex-row gap-3">
+    <div className={cn(surfaceStyles.toolbar, "flex flex-col gap-3 sm:flex-row")}>
       {/* 저장소 필터 */}
-      <div className="flex gap-1 flex-wrap">
+      <div className="flex flex-wrap gap-1">
         <button
           onClick={() => onRepoChange(undefined)}
-          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+          className={cn(controlStyles.filterButton,
             !selectedRepoId
               ? "bg-blue-100 text-blue-700"
               : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-          }`}
+          )}
         >
           전체 저장소
         </button>
@@ -41,11 +43,11 @@ export default function CommentFilter({
           <button
             key={repo.id}
             onClick={() => onRepoChange(repo.id)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+            className={cn(controlStyles.filterButton,
               selectedRepoId === repo.id
                 ? "bg-blue-100 text-blue-700"
                 : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-            }`}
+            )}
           >
             {repo.name}
           </button>
@@ -55,11 +57,11 @@ export default function CommentFilter({
       {/* 내 댓글만 토글 */}
       <button
         onClick={() => onMyOnlyChange(!myOnly)}
-        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors self-start ${
+        className={cn(controlStyles.filterButton, "self-start",
           myOnly
             ? "bg-blue-100 text-blue-700"
             : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-        }`}
+        )}
       >
         <User className="w-3 h-3" />
         내 댓글만

--- a/components/comment/CommentsClient.tsx
+++ b/components/comment/CommentsClient.tsx
@@ -6,6 +6,7 @@ import { useAllComments } from "@/hooks/useComments"
 import AllCommentList from "@/components/comment/AllCommentList"
 import CommentFilter from "@/components/comment/CommentFilter"
 import CommentsHeader from "@/components/comment/CommentsHeader"
+import { PageContainer } from "@/components/layout/PageContainer"
 import type { CommentWithPR } from "@/types/comment"
 import type { ConnectedRepo } from "@/lib/comments"
 
@@ -50,26 +51,24 @@ export default function CommentsClient({ repos, userId }: CommentsClientProps) {
   }
 
   return (
-    <div className="w-full flex justify-center">
-      <div className="w-full max-w-4xl space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
-        <CommentsHeader totalCount={totalCount} isLoading={isLoading} />
-        <CommentFilter
-          repos={repos}
-          selectedRepoId={selectedRepoId}
-          myOnly={myOnly}
-          onRepoChange={setSelectedRepoId}
-          onMyOnlyChange={setMyOnly}
-        />
-        <AllCommentList
-          comments={comments}
-          isLoading={isLoading}
-          isError={isError}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          onLoadMore={fetchNextPage}
-          onClickComment={handleClickComment}
-        />
-      </div>
-    </div>
+    <PageContainer>
+      <CommentsHeader totalCount={totalCount} isLoading={isLoading} />
+      <CommentFilter
+        repos={repos}
+        selectedRepoId={selectedRepoId}
+        myOnly={myOnly}
+        onRepoChange={setSelectedRepoId}
+        onMyOnlyChange={setMyOnly}
+      />
+      <AllCommentList
+        comments={comments}
+        isLoading={isLoading}
+        isError={isError}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={fetchNextPage}
+        onClickComment={handleClickComment}
+      />
+    </PageContainer>
   )
 }

--- a/components/comment/CommentsHeader.tsx
+++ b/components/comment/CommentsHeader.tsx
@@ -1,4 +1,4 @@
-import { textStyles } from "@/lib/styles"
+import { PageHeader } from "@/components/layout/PageHeader"
 
 interface CommentsHeaderProps {
   totalCount: number
@@ -7,18 +7,16 @@ interface CommentsHeaderProps {
 
 export default function CommentsHeader({ totalCount, isLoading }: CommentsHeaderProps) {
   return (
-    <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-      <div>
-        <h1 className={textStyles.pageTitle}>댓글</h1>
-        <p className={textStyles.pageSubtitle}>
-          모든 PR에 걸쳐 작성된 댓글을 한눈에 확인하세요.
-        </p>
-      </div>
-      {!isLoading && totalCount > 0 && (
-        <span className="px-3 py-1.5 bg-slate-100 text-slate-600 text-sm font-semibold rounded-xl self-start md:self-auto">
-          총 {totalCount}개
-        </span>
-      )}
-    </div>
+    <PageHeader
+      title="댓글"
+      description="모든 PR에 걸쳐 작성된 댓글을 한눈에 확인하세요."
+      actions={
+        !isLoading && totalCount > 0 ? (
+          <span className="rounded-xl bg-slate-100 px-3 py-1.5 text-sm font-semibold text-slate-600">
+            총 {totalCount}개
+          </span>
+        ) : null
+      }
+    />
   )
 }

--- a/components/dashboard/charts/CodeQualityChartCard.tsx
+++ b/components/dashboard/charts/CodeQualityChartCard.tsx
@@ -1,6 +1,7 @@
 import { type QualityTrendItem } from "@/lib/dashboard"
 import CodeQualityChart from "./CodeQualityChart"
-import { textStyles } from "@/lib/styles"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function CodeQualityChartCard({
   qualityTrend,
@@ -8,7 +9,7 @@ export default function CodeQualityChartCard({
   qualityTrend: QualityTrendItem[]
 }) {
   return (
-    <div className="lg:col-span-3 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn("lg:col-span-3", surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         코드 품질 추이 (최근 30일)
       </h3>

--- a/components/dashboard/charts/IssueDistributionCard.tsx
+++ b/components/dashboard/charts/IssueDistributionCard.tsx
@@ -1,6 +1,7 @@
 import { type IssueSeverityItem } from "@/lib/dashboard"
 import IssueDistributionChart from "./IssueDistributionChart"
-import { textStyles } from "@/lib/styles"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function IssueDistributionCard({
   issueSeverity,
@@ -8,7 +9,7 @@ export default function IssueDistributionCard({
   issueSeverity: IssueSeverityItem[]
 }) {
   return (
-    <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn("lg:col-span-2", surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>이슈 분포</h3>
       <IssueDistributionChart data={issueSeverity} />
     </div>

--- a/components/dashboard/recent-prs/RecentPRSection.tsx
+++ b/components/dashboard/recent-prs/RecentPRSection.tsx
@@ -1,11 +1,12 @@
 import { type DashboardRecentPR } from "@/lib/dashboard"
 import RecentPRTable from "./RecentPRTable"
-import { textStyles } from "@/lib/styles"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function RecentPRSection({ prs }: { prs: DashboardRecentPR[] }) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-      <div className="p-4 sm:p-6 md:p-8 border-b border-slate-200">
+    <div className={cn(surfaceStyles.panel, "overflow-hidden")}>
+      <div className="border-b border-slate-200 p-4 sm:p-6">
         <h3 className={textStyles.sectionTitle}>최근 Pull Requests</h3>
       </div>
       <RecentPRTable prs={prs} />

--- a/components/dashboard/stat-cards/StatCard.tsx
+++ b/components/dashboard/stat-cards/StatCard.tsx
@@ -1,4 +1,5 @@
 import type { LucideIcon } from "lucide-react"
+import { surfaceStyles } from "@/lib/styles"
 
 interface StatCardProps {
   icon: LucideIcon
@@ -9,7 +10,7 @@ interface StatCardProps {
 
 export default function StatCard({ icon: Icon, value, label, badge }: StatCardProps) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-8 hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
+    <div className={surfaceStyles.interactiveCard}>
       <div className="flex items-start justify-between mb-4 sm:mb-6">
         <div className="w-10 h-10 sm:w-12 sm:h-12 bg-linear-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center shadow-lg shadow-blue-500/30">
           <Icon className="w-5 h-5 sm:w-6 sm:h-6 text-white" />

--- a/components/github/RepoCardSkeleton.tsx
+++ b/components/github/RepoCardSkeleton.tsx
@@ -1,9 +1,10 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles } from "@/lib/styles"
 
 export default function RepoCardSkeleton() {
   return (
-    <div className="bg-white border border-slate-200 rounded-[24px] p-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
+    <div className={surfaceStyles.card}>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div className="flex items-start gap-4">
           <Skeleton className="w-12 h-12 rounded-2xl shrink-0" />
           <div className="space-y-2">

--- a/components/github/RepoSearchBar.tsx
+++ b/components/github/RepoSearchBar.tsx
@@ -2,6 +2,7 @@
 
 import { Search } from "lucide-react"
 import { Input } from "@/components/ui/input"
+import { surfaceStyles } from "@/lib/styles"
 
 interface RepoSearchBarProps {
   value: string
@@ -11,7 +12,7 @@ interface RepoSearchBarProps {
 export default function RepoSearchBar({ value, onChange }: RepoSearchBarProps) {
   return (
     <div className="max-w-2xl">
-      <div className="bg-white border border-slate-200 p-2 rounded-[24px] shadow-sm">
+      <div className={surfaceStyles.toolbar}>
         <div className="relative flex-1">
           <Search
             className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400 pointer-events-none"
@@ -22,7 +23,7 @@ export default function RepoSearchBar({ value, onChange }: RepoSearchBarProps) {
             placeholder="레포지토리 이름으로 검색..."
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            className="w-full pl-12 pr-4 py-3 h-auto bg-slate-50 border-none rounded-[18px] text-sm placeholder:text-slate-400 placeholder:font-medium font-medium shadow-none focus-visible:ring-blue-700/10"
+            className="h-11 w-full rounded-xl border-none bg-slate-50 py-3 pl-12 pr-4 text-sm font-medium shadow-none placeholder:font-medium placeholder:text-slate-400 focus-visible:ring-blue-700/10"
           />
         </div>
       </div>

--- a/components/github/RepositoriesPageHeader.tsx
+++ b/components/github/RepositoriesPageHeader.tsx
@@ -1,24 +1,20 @@
+import { PageHeader } from "@/components/layout/PageHeader"
+
 interface RepositoriesPageHeaderProps {
   connectedCount: number
 }
 
 export default function RepositoriesPageHeader({ connectedCount }: RepositoriesPageHeaderProps) {
   return (
-    <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-      <div className="space-y-1">
-        <h1 className="text-3xl font-bold text-slate-900 tracking-tight">
-          저장소
-        </h1>
-        <p className="text-sm text-slate-500 font-medium">
-          GitHub 저장소를 연동하여 AI 코드 리뷰를 시작하세요.
-        </p>
-      </div>
-      <div className="flex items-center">
+    <PageHeader
+      title="저장소"
+      description="GitHub 저장소를 연동하여 AI 코드 리뷰를 시작하세요."
+      actions={
         <div className="px-4 py-2 bg-blue-50 border border-blue-100 rounded-full flex items-center gap-2">
           <span className="w-2 h-2 bg-blue-600 rounded-full animate-pulse" />
           <span className="text-sm font-bold text-blue-700">{connectedCount}개 연동됨</span>
         </div>
-      </div>
-    </div>
+      }
+    />
   )
 }

--- a/components/notification/NotificationFilter.tsx
+++ b/components/notification/NotificationFilter.tsx
@@ -2,6 +2,8 @@
 
 import { AtSign, MessageSquare, GitPullRequest, GitMerge } from "lucide-react"
 import type { NotificationFilterType, NotificationFilterRead } from "@/types/notification"
+import { controlStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 const typeOptions: { value: NotificationFilterType; label: string; icon: typeof AtSign }[] = [
   { value: "ALL", label: "전체", icon: AtSign },
@@ -31,8 +33,8 @@ export default function NotificationFilter({
   onReadChange,
 }: NotificationFilterProps) {
   return (
-    <div className="flex flex-col sm:flex-row gap-3">
-      <div className="flex gap-1 flex-wrap">
+    <div className="flex flex-col gap-3 sm:flex-row">
+      <div className="flex flex-wrap gap-1">
         {typeOptions.map((opt) => {
           const Icon = opt.icon
           const isActive = typeFilter === opt.value
@@ -40,11 +42,11 @@ export default function NotificationFilter({
             <button
               key={opt.value}
               onClick={() => onTypeChange(opt.value)}
-              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              className={cn(controlStyles.filterButton,
                 isActive
                   ? "bg-blue-100 text-blue-700"
                   : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-              }`}
+              )}
             >
               {opt.value !== "ALL" && <Icon className="w-3 h-3" />}
               {opt.label}
@@ -59,11 +61,11 @@ export default function NotificationFilter({
             <button
               key={opt.value}
               onClick={() => onReadChange(opt.value)}
-              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              className={cn(controlStyles.filterButton,
                 isActive
                   ? "bg-blue-100 text-blue-700"
                   : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-              }`}
+              )}
             >
               {opt.label}
             </button>

--- a/components/notifications/NotificationsClient.tsx
+++ b/components/notifications/NotificationsClient.tsx
@@ -8,6 +8,10 @@ import { getNotificationLink } from "@/lib/notification-link"
 import NotificationList from "@/components/notification/NotificationList"
 import NotificationFilter from "@/components/notification/NotificationFilter"
 import NotificationSettings from "@/components/notification/NotificationSettings"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { PageHeader } from "@/components/layout/PageHeader"
+import { controlStyles, surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type {
   Notification,
   NotificationFilterType,
@@ -42,18 +46,20 @@ export default function NotificationsClient() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-3">
-          <Bell className="w-6 h-6 text-slate-700" />
-          <h1 className="text-xl font-bold text-slate-900">알림</h1>
-          {unreadCount > 0 && (
-            <span className="px-2 py-0.5 bg-red-100 text-red-600 text-xs font-semibold rounded-full">
+    <PageContainer>
+      <PageHeader
+        title="알림"
+        description="코드 리뷰 알림과 피드백을 확인하세요."
+        icon={<Bell className="size-5" aria-hidden />}
+        badge={
+          unreadCount > 0 ? (
+            <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-600">
               {unreadCount}
             </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
+          ) : null
+        }
+        actions={
+          <>
           <button
             onClick={handleMarkAllRead}
             className="text-sm text-blue-500 hover:text-blue-700 transition-colors"
@@ -62,24 +68,26 @@ export default function NotificationsClient() {
           </button>
           <button
             onClick={() => setShowSettings((prev) => !prev)}
-            className={`p-2 rounded-lg transition-colors ${
+            className={cn(
+              controlStyles.iconButton,
               showSettings ? "bg-blue-100 text-blue-600" : "hover:bg-slate-100 text-slate-500"
-            }`}
+            )}
             title="알림 설정"
           >
             <Settings className="w-5 h-5" />
           </button>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {showSettings && (
-        <div className="mb-6 bg-white rounded-xl border border-slate-200 p-4">
-          <h2 className="text-sm font-semibold text-slate-700 mb-3">알림 구독 설정</h2>
+        <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">알림 구독 설정</h2>
           <NotificationSettings />
         </div>
       )}
 
-      <div className="mb-4">
+      <div className={surfaceStyles.toolbar}>
         <NotificationFilter
           typeFilter={typeFilter}
           readFilter={readFilter}
@@ -88,7 +96,7 @@ export default function NotificationsClient() {
         />
       </div>
 
-      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+      <div className={cn(surfaceStyles.panel, "overflow-hidden")}>
         {isLoading ? (
           <div className="px-4 py-8 text-center text-sm text-slate-400">
             알림을 불러오는 중...
@@ -103,6 +111,6 @@ export default function NotificationsClient() {
           />
         )}
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/components/pulls/PRCard.tsx
+++ b/components/pulls/PRCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { surfaceStyles } from "@/lib/styles";
 import { cn } from "@/lib/utils";
 import type { PullRequest } from "@/types/pulls";
 
@@ -35,14 +36,13 @@ export default function PRCard({
   return (
     <Card
       className={cn(
-        "group relative rounded-[24px] p-4 md:p-5 border-slate-200 shadow-none",
-        "hover:border-blue-200 hover:shadow-xl hover:shadow-blue-500/5",
-        "transition-all duration-300 cursor-pointer",
+        "group relative cursor-pointer",
+        surfaceStyles.interactiveCard,
         "animate-in fade-in slide-in-from-bottom-4 fill-mode-both"
       )}
       style={{ animationDelay: `${animationDelay}ms` }}
     >
-      <Link href={`/pulls/${id}`} className="absolute inset-0 z-0 rounded-[24px]" aria-label={title} />
+      <Link href={`/pulls/${id}`} className="absolute inset-0 z-0 rounded-md" aria-label={title} />
 
       <div className="flex flex-col gap-3 h-full">
         {/* Header: Status badge + PR number */}

--- a/components/pulls/PRCardSkeleton.tsx
+++ b/components/pulls/PRCardSkeleton.tsx
@@ -1,8 +1,10 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { surfaceStyles } from "@/lib/styles";
+import { cn } from "@/lib/utils";
 
 export default function PRCardSkeleton() {
   return (
-    <div className="bg-white border border-slate-200 rounded-[24px] p-6 md:p-8 space-y-3">
+    <div className={cn(surfaceStyles.card, "space-y-3")}>
       <div className="flex items-center gap-3">
         <Skeleton className="h-5 w-14 rounded-full" />
         <Skeleton className="h-4 w-8" />

--- a/components/pulls/PRFilterBar.tsx
+++ b/components/pulls/PRFilterBar.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
+import { surfaceStyles } from "@/lib/styles";
 import PRStatusFilter from "./PRStatusFilter";
 
 function PRStatusFilterFallback() {
@@ -15,7 +16,7 @@ function PRStatusFilterFallback() {
 
 export default function PRFilterBar() {
   return (
-    <div className="bg-white border border-slate-200 p-2 rounded-[24px] flex flex-col md:flex-row items-stretch md:items-center justify-between gap-4 shadow-sm">
+    <div className={`${surfaceStyles.toolbar} flex flex-col items-stretch justify-between gap-4 md:flex-row md:items-center`}>
       <Suspense fallback={<PRStatusFilterFallback />}>
         <PRStatusFilter />
       </Suspense>

--- a/components/pulls/PRList.tsx
+++ b/components/pulls/PRList.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { InfiniteScrollTrigger } from "@/components/ui/InfiniteScrollTrigger";
 import { FILTER_TAB_TO_STATUS, type PRFilterTab } from "@/constants";
 import { usePullRequests } from "@/hooks/usePullRequests";
+import { layoutStyles, surfaceStyles } from "@/lib/styles";
 import PRCard from "./PRCard";
 import PRCardSkeleton from "./PRCardSkeleton";
 import PREmptyState from "./PREmptyState";
@@ -26,7 +27,7 @@ export default function PRList() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className={layoutStyles.listStack}>
         {Array.from({ length: 3 }).map((_, i) => (
           <PRCardSkeleton key={i} />
         ))}
@@ -36,7 +37,7 @@ export default function PRList() {
 
   if (isError) {
     return (
-      <div className="py-20 text-center text-sm text-slate-400 font-medium">
+      <div className={surfaceStyles.emptyState}>
         PR 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
       </div>
     );
@@ -49,7 +50,7 @@ export default function PRList() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className={layoutStyles.listStack}>
         {pullRequests.map((pr, index) => (
           <PRCard key={pr.id} {...pr} animationDelay={index * 75} />
         ))}
@@ -59,7 +60,7 @@ export default function PRList() {
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           loadingFallback={
-            <div className="space-y-4">
+            <div className={layoutStyles.listStack}>
               <PRCardSkeleton />
               <PRCardSkeleton />
             </div>

--- a/components/pulls/PRPageHeader.tsx
+++ b/components/pulls/PRPageHeader.tsx
@@ -1,30 +1,30 @@
 import { ChevronDown, GitPullRequest } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { textStyles } from "@/lib/styles";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { controlStyles } from "@/lib/styles";
+import { cn } from "@/lib/utils";
 
 export default function PRPageHeader() {
   return (
-    <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-      <div>
-        <h1 className={textStyles.pageTitle}>Pull Requests</h1>
-        <p className={textStyles.pageSubtitle}>
-          저장소의 코드 변경 사항을 검토하고 병합을 관리하세요.
-        </p>
-      </div>
-      <div className="flex items-center gap-3">
+    <PageHeader
+      title="Pull Requests"
+      description="저장소의 코드 변경 사항을 검토하고 병합을 관리하세요."
+      actions={
+        <>
         <Button
           variant="outline"
-          className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-sm font-bold text-slate-700 hover:border-slate-300 transition-all shadow-sm"
+          className={cn("gap-2 px-4 py-2.5 text-sm", controlStyles.secondaryAction)}
         >
           <span>모든 저장소</span>
           <ChevronDown className="text-slate-400" size={16} aria-hidden />
         </Button>
-        <Button className="bg-blue-700 hover:bg-blue-800 rounded-xl font-bold shadow-lg shadow-blue-700/20 flex items-center gap-2">
+        <Button className={cn("gap-2", controlStyles.primaryAction)}>
           <GitPullRequest size={18} aria-hidden />
           <span>새 PR 생성</span>
         </Button>
-      </div>
-    </div>
+        </>
+      }
+    />
   );
 }

--- a/components/settings/AIReviewSection.tsx
+++ b/components/settings/AIReviewSection.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { controlStyles, surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 interface ReviewSettings {
   autoReview: boolean
@@ -52,16 +54,16 @@ export default function AIReviewSection() {
 
   if (isLoading) {
     return (
-      <section className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-base font-semibold text-slate-800 mb-4">AI 리뷰 설정</h2>
+      <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+        <h2 className={cn(textStyles.sectionTitle, "mb-4")}>AI 리뷰 설정</h2>
         <p className="text-sm text-slate-400">설정을 불러오는 중...</p>
       </section>
     )
   }
 
   return (
-    <section className="bg-white rounded-xl border border-slate-200 p-6">
-      <h2 className="text-base font-semibold text-slate-800 mb-4">AI 리뷰 설정</h2>
+    <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+      <h2 className={cn(textStyles.sectionTitle, "mb-4")}>AI 리뷰 설정</h2>
       <div className="space-y-5">
         {/* 자동 리뷰 토글 */}
         <div className="flex items-center justify-between">
@@ -94,11 +96,11 @@ export default function AIReviewSection() {
               <button
                 key={lang}
                 onClick={() => save({ ...settings, language: lang })}
-                className={`px-3 py-1 text-xs font-medium rounded-lg border transition-colors ${
+                className={cn(controlStyles.filterButton, "rounded-lg border",
                   settings.language === lang
                     ? "bg-blue-500 text-white border-blue-500"
                     : "text-slate-600 border-slate-300 hover:bg-slate-50"
-                }`}
+                )}
               >
                 {lang === "ko" ? "한국어" : "English"}
               </button>
@@ -123,11 +125,11 @@ export default function AIReviewSection() {
               <button
                 key={opt.value}
                 onClick={() => save({ ...settings, severityLevel: opt.value })}
-                className={`flex-1 px-3 py-2 text-xs font-medium rounded-lg border transition-colors text-center ${
+                className={cn("flex-1 rounded-lg border px-3 py-2 text-center text-xs font-medium transition-colors",
                   settings.severityLevel === opt.value
                     ? "bg-blue-500 text-white border-blue-500"
                     : "text-slate-600 border-slate-300 hover:bg-slate-50"
-                }`}
+                )}
               >
                 <span className="block">{opt.label}</span>
                 <span className={`block mt-0.5 font-normal ${settings.severityLevel === opt.value ? "text-blue-100" : "text-slate-400"}`}>

--- a/components/settings/DangerZoneSection.tsx
+++ b/components/settings/DangerZoneSection.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react"
 import { signOut } from "next-auth/react"
 import { AlertTriangle } from "lucide-react"
+import { surfaceStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 export default function DangerZoneSection() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -36,7 +38,7 @@ export default function DangerZoneSection() {
   }
 
   return (
-    <section className="bg-white rounded-xl border border-red-200 p-6">
+    <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "border-red-200")}>
       <div className="flex items-center gap-2 mb-4">
         <AlertTriangle className="w-4 h-4 text-red-500" />
         <h2 className="text-base font-semibold text-red-600">위험 구역</h2>
@@ -80,7 +82,7 @@ export default function DangerZoneSection() {
       {/* 삭제 확인 다이얼로그 */}
       {showDeleteConfirm && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl max-w-sm w-full p-6">
+          <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding, "w-full max-w-sm shadow-xl")}>
             <div className="flex items-center gap-2 mb-3">
               <AlertTriangle className="w-5 h-5 text-red-500" />
               <h3 className="text-base font-semibold text-slate-900">계정 삭제</h3>

--- a/components/settings/GitHubConnectionSection.tsx
+++ b/components/settings/GitHubConnectionSection.tsx
@@ -2,6 +2,8 @@
 
 import { Github, RefreshCw } from "lucide-react"
 import { signIn } from "next-auth/react"
+import { controlStyles, surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 interface GitHubConnectionSectionProps {
   isConnected: boolean
@@ -24,8 +26,8 @@ export default function GitHubConnectionSection({ isConnected, githubId, scope }
   }
 
   return (
-    <section className="bg-white rounded-xl border border-slate-200 p-6">
-      <h2 className="text-base font-semibold text-slate-800 mb-4">GitHub 연결</h2>
+    <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+      <h2 className={cn(textStyles.sectionTitle, "mb-4")}>GitHub 연결</h2>
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 rounded-full bg-slate-900 flex items-center justify-center flex-shrink-0">
@@ -44,7 +46,7 @@ export default function GitHubConnectionSection({ isConnected, githubId, scope }
         </div>
         <button
           onClick={handleReconnect}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors flex-shrink-0"
+          className={cn("flex h-9 flex-shrink-0 items-center gap-1.5 px-3 text-sm", controlStyles.secondaryAction)}
         >
           <RefreshCw className="w-3.5 h-3.5" />
           재연결

--- a/components/settings/NotificationSection.tsx
+++ b/components/settings/NotificationSection.tsx
@@ -2,6 +2,8 @@
 
 import { useNotificationSettings } from "@/hooks/useNotificationSettings"
 import type { NotificationSetting } from "@/types/notification"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 const settingItems: { key: keyof NotificationSetting; label: string; description: string }[] = [
   {
@@ -31,16 +33,16 @@ export default function NotificationSection() {
 
   if (isLoading) {
     return (
-      <section className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-base font-semibold text-slate-800 mb-4">알림 설정</h2>
+      <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+        <h2 className={cn(textStyles.sectionTitle, "mb-4")}>알림 설정</h2>
         <p className="text-sm text-slate-400">설정을 불러오는 중...</p>
       </section>
     )
   }
 
   return (
-    <section className="bg-white rounded-xl border border-slate-200 p-6">
-      <h2 className="text-base font-semibold text-slate-800 mb-4">알림 설정</h2>
+    <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+      <h2 className={cn(textStyles.sectionTitle, "mb-4")}>알림 설정</h2>
       <div className="space-y-1">
         {settingItems.map((item) => (
           <div

--- a/components/settings/ProfileSection.tsx
+++ b/components/settings/ProfileSection.tsx
@@ -1,5 +1,7 @@
 import Image from "next/image"
 import { User } from "lucide-react"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 
 interface ProfileSectionProps {
   name: string | null
@@ -9,8 +11,8 @@ interface ProfileSectionProps {
 
 export default function ProfileSection({ name, email, image }: ProfileSectionProps) {
   return (
-    <section className="bg-white rounded-xl border border-slate-200 p-6">
-      <h2 className="text-base font-semibold text-slate-800 mb-4">프로필</h2>
+    <section className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
+      <h2 className={cn(textStyles.sectionTitle, "mb-4")}>프로필</h2>
       <div className="flex items-center gap-4">
         {image ? (
           <Image

--- a/components/settings/SettingsClient.tsx
+++ b/components/settings/SettingsClient.tsx
@@ -6,6 +6,9 @@ import GitHubConnectionSection from "@/components/settings/GitHubConnectionSecti
 import AIReviewSection from "@/components/settings/AIReviewSection"
 import NotificationSection from "@/components/settings/NotificationSection"
 import DangerZoneSection from "@/components/settings/DangerZoneSection"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { PageHeader } from "@/components/layout/PageHeader"
+import { layoutStyles } from "@/lib/styles"
 
 interface SettingsClientProps {
   user: {
@@ -20,19 +23,20 @@ interface SettingsClientProps {
 
 export default function SettingsClient({ user, githubConnected, githubScope }: SettingsClientProps) {
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <Settings className="w-6 h-6 text-slate-700" />
-        <h1 className="text-xl font-bold text-slate-900">설정</h1>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="설정"
+        description="계정 정보와 GitHub 연동 상태를 관리하세요."
+        icon={<Settings className="size-5" aria-hidden />}
+      />
 
-      <div className="space-y-4">
+      <div className={layoutStyles.listStack}>
         <ProfileSection name={user.name} email={user.email} image={user.image} />
         <GitHubConnectionSection isConnected={githubConnected} githubId={user.githubId} scope={githubScope} />
         <AIReviewSection />
         <NotificationSection />
         <DangerZoneSection />
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/components/stats/StatsClient.tsx
+++ b/components/stats/StatsClient.tsx
@@ -11,6 +11,8 @@ import type {
 } from "@/lib/stats"
 import dynamic from "next/dynamic"
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/layout/PageContainer"
+import { layoutStyles } from "@/lib/styles"
 import StatsHeader from "./StatsHeader"
 import StatsSummaryCards from "./StatsSummaryCards"
 
@@ -86,7 +88,7 @@ export default function StatsClient({
   }, [fetchAllData])
 
   return (
-    <div className="max-w-350 mx-auto space-y-4 sm:space-y-6">
+    <PageContainer size="wide">
       <StatsHeader
         range={range}
         onRangeChange={setRange}
@@ -100,13 +102,13 @@ export default function StatsClient({
       </div>
 
       {/* PR 활동 추이 + PR 상태 분포 */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 sm:gap-6">
+      <div className={`grid grid-cols-1 lg:grid-cols-5 ${layoutStyles.gridGap}`}>
         <PRTrendChart data={prTrend} loading={loading} />
         <PRStatusChart data={prTrend} loading={loading} />
       </div>
 
       {/* 코드 품질 추이 + 이슈 심각도 분포 */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 sm:gap-6">
+      <div className={`grid grid-cols-1 lg:grid-cols-5 ${layoutStyles.gridGap}`}>
         <QualityTrendChart data={qualityTrend} loading={loading} />
         <IssueSeverityChart
           data={issueDistribution.bySeverity}
@@ -122,6 +124,6 @@ export default function StatsClient({
         data={issueDistribution.byCategory}
         loading={loading}
       />
-    </div>
+    </PageContainer>
   )
 }

--- a/components/stats/StatsSummaryCards.tsx
+++ b/components/stats/StatsSummaryCards.tsx
@@ -7,6 +7,7 @@ import {
   TrendingUp,
 } from "lucide-react"
 import type { StatsOverview } from "@/lib/stats"
+import { layoutStyles, surfaceStyles } from "@/lib/styles"
 
 interface StatsSummaryCardsProps {
   overview: StatsOverview
@@ -67,11 +68,11 @@ export default function StatsSummaryCards({
   ]
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+    <div className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 ${layoutStyles.gridGap}`}>
       {cards.map((card, i) => (
         <div
           key={i}
-          className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-8 hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+          className={surfaceStyles.interactiveCard}
         >
           <div className="flex items-start justify-between mb-4 sm:mb-6">
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-linear-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center shadow-lg shadow-blue-500/30">

--- a/components/stats/charts/CodeChangesChart.tsx
+++ b/components/stats/charts/CodeChangesChart.tsx
@@ -1,17 +1,19 @@
 "use client"
 
 import {
-  BarChart,
   Bar,
+  BarChart,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
 } from "recharts"
-import { textStyles } from "@/lib/styles"
-import { Skeleton } from "@/components/ui/skeleton"
 import { BarChart3 } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type { CodeChangesItem } from "@/lib/stats"
 
 interface CodeChangesChartProps {
@@ -25,6 +27,7 @@ function CustomTooltip({
   label,
 }: {
   active?: boolean
+  // Recharts passes each bar series with library-specific metadata.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: any[]
   label?: string
@@ -32,27 +35,32 @@ function CustomTooltip({
   if (!active || !payload?.length) return null
 
   const item = payload[0]?.payload as CodeChangesItem | undefined
+
   return (
-    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3">
-      <div className="text-slate-900 font-bold text-sm mb-2">{label}</div>
+    <div className="rounded-md border border-slate-200 bg-white px-5 py-3 shadow-lg dark:border-slate-800 dark:bg-slate-950">
+      <div className="mb-2 text-sm font-bold text-slate-900 dark:text-slate-50">
+        {label}
+      </div>
       <div className="space-y-1">
         <div className="flex items-center gap-2 text-xs">
-          <div className="w-2.5 h-2.5 rounded-full bg-blue-400" />
-          <span className="text-slate-600">추가:</span>
+          <div className="size-2.5 rounded-full bg-blue-400" />
+          <span className="text-slate-600 dark:text-slate-400">추가:</span>
           <span className="font-semibold text-emerald-600">
             +{item?.additions?.toLocaleString() ?? 0}
           </span>
         </div>
         <div className="flex items-center gap-2 text-xs">
-          <div className="w-2.5 h-2.5 rounded-full bg-red-400" />
-          <span className="text-slate-600">삭제:</span>
+          <div className="size-2.5 rounded-full bg-red-400" />
+          <span className="text-slate-600 dark:text-slate-400">삭제:</span>
           <span className="font-semibold text-rose-600">
             -{item?.deletions?.toLocaleString() ?? 0}
           </span>
         </div>
         <div className="flex items-center gap-2 text-xs">
-          <span className="text-slate-600">변경 파일:</span>
-          <span className="font-semibold text-slate-900">
+          <span className="text-slate-600 dark:text-slate-400">
+            변경 파일:
+          </span>
+          <span className="font-semibold text-slate-900 dark:text-slate-50">
             {item?.files ?? 0}개
           </span>
         </div>
@@ -66,21 +74,21 @@ export default function CodeChangesChart({
   loading,
 }: CodeChangesChartProps) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         코드 변경량 추이
       </h3>
       {loading ? (
-        <div className="w-full h-70 sm:h-85">
-          <Skeleton className="w-full h-full rounded-lg" />
+        <div className="h-70 w-full sm:h-85">
+          <Skeleton className="h-full w-full rounded-md" />
         </div>
       ) : data.length === 0 ? (
-        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
-          <BarChart3 className="w-10 h-10 mb-3 text-slate-300" />
+        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
+          <BarChart3 className="mb-3 size-10 text-slate-300" />
           <p className="text-sm font-medium">데이터가 없습니다</p>
         </div>
       ) : (
-        <div className="w-full h-70 sm:h-85">
+        <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
             <BarChart
               data={data}

--- a/components/stats/charts/IssueCategoryChart.tsx
+++ b/components/stats/charts/IssueCategoryChart.tsx
@@ -1,17 +1,19 @@
 "use client"
 
 import {
-  BarChart,
   Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
 } from "recharts"
-import { textStyles } from "@/lib/styles"
-import { Skeleton } from "@/components/ui/skeleton"
 import { BarChart3 } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type { IssueCategoryItem } from "@/lib/stats"
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -46,21 +48,21 @@ export default function IssueCategoryChart({
   }))
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         이슈 카테고리 분포
       </h3>
       {loading ? (
-        <div className="w-full h-70 sm:h-85">
-          <Skeleton className="w-full h-full rounded-lg" />
+        <div className="h-70 w-full sm:h-85">
+          <Skeleton className="h-full w-full rounded-md" />
         </div>
       ) : chartData.length === 0 ? (
-        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
-          <BarChart3 className="w-10 h-10 mb-3 text-slate-300" />
+        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
+          <BarChart3 className="mb-3 size-10 text-slate-300" />
           <p className="text-sm font-medium">데이터가 없습니다</p>
         </div>
       ) : (
-        <div className="w-full h-70 sm:h-85">
+        <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
             <BarChart
               data={chartData}
@@ -86,18 +88,19 @@ export default function IssueCategoryChart({
                 content={({ active, payload }) => {
                   if (!active || !payload?.length) return null
                   const item = payload[0].payload
+
                   return (
-                    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3">
+                    <div className="rounded-md border border-slate-200 bg-white px-5 py-3 shadow-lg dark:border-slate-800 dark:bg-slate-950">
                       <div className="flex items-center gap-2">
                         <div
-                          className="w-3 h-3 rounded-full"
+                          className="size-3 rounded-full"
                           style={{ backgroundColor: item.color }}
                         />
-                        <span className="text-sm font-semibold text-slate-900">
+                        <span className="text-sm font-semibold text-slate-900 dark:text-slate-50">
                           {item.label}
                         </span>
                       </div>
-                      <p className="mt-1 text-sm text-slate-600">
+                      <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
                         {item.count}건
                       </p>
                     </div>

--- a/components/stats/charts/IssueSeverityChart.tsx
+++ b/components/stats/charts/IssueSeverityChart.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts"
-import { textStyles } from "@/lib/styles"
-import { Skeleton } from "@/components/ui/skeleton"
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts"
 import { CircleDot } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type { IssueSeverityItem } from "@/lib/stats"
 
 interface IssueSeverityChartProps {
@@ -18,33 +20,28 @@ export default function IssueSeverityChart({
   const total = data.reduce((s, d) => s + d.value, 0)
 
   return (
-    <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn("lg:col-span-2", surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         이슈 심각도 분포
       </h3>
       {loading ? (
         <div className="flex flex-col items-center gap-6">
-          <Skeleton className="w-48 h-48 rounded-full" />
-          <div className="space-y-3 w-full">
+          <Skeleton className="size-48 rounded-full" />
+          <div className="w-full space-y-3">
             {[1, 2, 3, 4].map((i) => (
               <Skeleton key={i} className="h-4 w-full rounded" />
             ))}
           </div>
         </div>
       ) : data.length === 0 ? (
-        <div className="h-70 flex flex-col items-center justify-center text-slate-400">
-          <CircleDot className="w-10 h-10 mb-3 text-slate-300" />
+        <div className="flex h-70 flex-col items-center justify-center text-slate-400">
+          <CircleDot className="mb-3 size-10 text-slate-300" />
           <p className="text-sm font-medium">데이터가 없습니다</p>
         </div>
       ) : (
         <div className="flex flex-col items-center gap-6">
-          <div className="relative w-55 h-55 sm:w-65 sm:h-65">
-            <ResponsiveContainer
-              width="100%"
-              height="100%"
-              minHeight={200}
-              minWidth={200}
-            >
+          <div className="relative h-55 w-55 sm:h-65 sm:w-65">
+            <ResponsiveContainer width="100%" height="100%" minHeight={200} minWidth={200}>
               <PieChart>
                 <Pie
                   data={data}
@@ -65,20 +62,20 @@ export default function IssueSeverityChart({
                   content={({ active, payload }) => {
                     if (!active || !payload?.length) return null
                     const { name, value, color } = payload[0].payload
+
                     return (
-                      <div className="rounded-lg border bg-white px-3 py-2 shadow-md">
+                      <div className="rounded-md border border-slate-200 bg-white px-3 py-2 shadow-md dark:border-slate-800 dark:bg-slate-950">
                         <div className="flex items-center gap-2">
                           <div
-                            className="h-3 w-3 rounded-full"
+                            className="size-3 rounded-full"
                             style={{ backgroundColor: color }}
                           />
-                          <span className="text-sm font-semibold text-slate-700">
+                          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
                             {name}
                           </span>
                         </div>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {value}건 (
-                          {Math.round((value / total) * 100)}%)
+                        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                          {value}건 ({Math.round((value / total) * 100)}%)
                         </p>
                       </div>
                     )
@@ -87,30 +84,25 @@ export default function IssueSeverityChart({
               </PieChart>
             </ResponsiveContainer>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
-              <span className="text-slate-900 text-3xl sm:text-4xl font-bold">
+              <span className="text-3xl font-bold text-slate-900 dark:text-slate-50 sm:text-4xl">
                 {total}건
               </span>
-              <span className="text-slate-400 text-xs sm:text-sm">
-                전체 이슈
-              </span>
+              <span className="text-xs text-slate-400 sm:text-sm">전체 이슈</span>
             </div>
           </div>
-          <div className="space-y-3 sm:space-y-4 w-full">
+          <div className="w-full space-y-3 sm:space-y-4">
             {data.map((item) => (
-              <div
-                key={item.name}
-                className="flex items-center justify-between"
-              >
+              <div key={item.name} className="flex items-center justify-between">
                 <div className="flex items-center gap-2 sm:gap-3">
                   <div
-                    className="w-3 h-3 sm:w-4 sm:h-4 rounded-full shadow-sm"
+                    className="size-3 rounded-full shadow-sm sm:size-4"
                     style={{ backgroundColor: item.color }}
                   />
-                  <span className="text-xs sm:text-sm font-semibold text-slate-700">
+                  <span className="text-xs font-semibold text-slate-700 dark:text-slate-300 sm:text-sm">
                     {item.name}
                   </span>
                 </div>
-                <span className="text-xs sm:text-sm font-bold text-slate-900">
+                <span className="text-xs font-bold text-slate-900 dark:text-slate-50 sm:text-sm">
                   {item.value}건
                 </span>
               </div>

--- a/components/stats/charts/PRStatusChart.tsx
+++ b/components/stats/charts/PRStatusChart.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts"
-import { textStyles } from "@/lib/styles"
-import { Skeleton } from "@/components/ui/skeleton"
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts"
 import { CircleDot } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type { PRTrendItem } from "@/lib/stats"
 
 const STATUS_COLORS: Record<string, string> = {
@@ -29,33 +31,28 @@ export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
   const total = statusData.reduce((s, d) => s + d.value, 0)
 
   return (
-    <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn("lg:col-span-2", surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         PR 상태 분포
       </h3>
       {loading ? (
         <div className="flex flex-col items-center gap-6">
-          <Skeleton className="w-48 h-48 rounded-full" />
-          <div className="space-y-3 w-full">
+          <Skeleton className="size-48 rounded-full" />
+          <div className="w-full space-y-3">
             {[1, 2, 3].map((i) => (
               <Skeleton key={i} className="h-4 w-full rounded" />
             ))}
           </div>
         </div>
       ) : statusData.length === 0 ? (
-        <div className="h-70 flex flex-col items-center justify-center text-slate-400">
-          <CircleDot className="w-10 h-10 mb-3 text-slate-300" />
+        <div className="flex h-70 flex-col items-center justify-center text-slate-400">
+          <CircleDot className="mb-3 size-10 text-slate-300" />
           <p className="text-sm font-medium">데이터가 없습니다</p>
         </div>
       ) : (
         <div className="flex flex-col items-center gap-6">
-          <div className="relative w-55 h-55 sm:w-65 sm:h-65">
-            <ResponsiveContainer
-              width="100%"
-              height="100%"
-              minHeight={200}
-              minWidth={200}
-            >
+          <div className="relative h-55 w-55 sm:h-65 sm:w-65">
+            <ResponsiveContainer width="100%" height="100%" minHeight={200} minWidth={200}>
               <PieChart>
                 <Pie
                   data={statusData}
@@ -69,32 +66,27 @@ export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
                   strokeWidth={0}
                 >
                   {statusData.map((entry) => (
-                    <Cell
-                      key={entry.name}
-                      fill={STATUS_COLORS[entry.name]}
-                    />
+                    <Cell key={entry.name} fill={STATUS_COLORS[entry.name]} />
                   ))}
                 </Pie>
                 <Tooltip
                   content={({ active, payload }) => {
                     if (!active || !payload?.length) return null
                     const { name, value } = payload[0].payload
+
                     return (
-                      <div className="rounded-lg border bg-white px-3 py-2 shadow-md">
+                      <div className="rounded-md border border-slate-200 bg-white px-3 py-2 shadow-md dark:border-slate-800 dark:bg-slate-950">
                         <div className="flex items-center gap-2">
                           <div
-                            className="h-3 w-3 rounded-full"
-                            style={{
-                              backgroundColor: STATUS_COLORS[name],
-                            }}
+                            className="size-3 rounded-full"
+                            style={{ backgroundColor: STATUS_COLORS[name] }}
                           />
-                          <span className="text-sm font-semibold text-slate-700">
+                          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
                             {name}
                           </span>
                         </div>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {value}건 ({Math.round((value / total) * 100)}
-                          %)
+                        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                          {value}건 ({Math.round((value / total) * 100)}%)
                         </p>
                       </div>
                     )
@@ -103,30 +95,25 @@ export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
               </PieChart>
             </ResponsiveContainer>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
-              <span className="text-slate-900 text-3xl sm:text-4xl font-bold">
+              <span className="text-3xl font-bold text-slate-900 dark:text-slate-50 sm:text-4xl">
                 {total}건
               </span>
-              <span className="text-slate-400 text-xs sm:text-sm">
-                전체 PR
-              </span>
+              <span className="text-xs text-slate-400 sm:text-sm">전체 PR</span>
             </div>
           </div>
-          <div className="space-y-3 sm:space-y-4 w-full">
+          <div className="w-full space-y-3 sm:space-y-4">
             {statusData.map((item) => (
-              <div
-                key={item.name}
-                className="flex items-center justify-between"
-              >
+              <div key={item.name} className="flex items-center justify-between">
                 <div className="flex items-center gap-2 sm:gap-3">
                   <div
-                    className="w-3 h-3 sm:w-4 sm:h-4 rounded-full shadow-sm"
+                    className="size-3 rounded-full shadow-sm sm:size-4"
                     style={{ backgroundColor: STATUS_COLORS[item.name] }}
                   />
-                  <span className="text-xs sm:text-sm font-semibold text-slate-700">
+                  <span className="text-xs font-semibold text-slate-700 dark:text-slate-300 sm:text-sm">
                     {item.name}
                   </span>
                 </div>
-                <span className="text-xs sm:text-sm font-bold text-slate-900">
+                <span className="text-xs font-bold text-slate-900 dark:text-slate-50 sm:text-sm">
                   {item.value}건
                 </span>
               </div>

--- a/components/stats/charts/PRTrendChart.tsx
+++ b/components/stats/charts/PRTrendChart.tsx
@@ -1,16 +1,18 @@
 "use client"
 
 import {
-  AreaChart,
   Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
 } from "recharts"
-import { textStyles } from "@/lib/styles"
-import { Skeleton } from "@/components/ui/skeleton"
 import { BarChart3 } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type { PRTrendItem } from "@/lib/stats"
 
 interface PRTrendChartProps {
@@ -28,17 +30,22 @@ function CustomTooltip({
   label?: string
 }) {
   if (!active || !payload?.length) return null
+
   return (
-    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3">
-      <div className="text-slate-900 font-bold text-sm mb-2">{label}</div>
+    <div className="rounded-md border border-slate-200 bg-white px-5 py-3 shadow-lg dark:border-slate-800 dark:bg-slate-950">
+      <div className="mb-2 text-sm font-bold text-slate-900 dark:text-slate-50">
+        {label}
+      </div>
       {payload.map((entry) => (
         <div key={entry.name} className="flex items-center gap-2 text-xs">
           <div
-            className="w-2.5 h-2.5 rounded-full"
+            className="size-2.5 rounded-full"
             style={{ backgroundColor: entry.color }}
           />
-          <span className="text-slate-600">{entry.name}:</span>
-          <span className="font-semibold text-slate-900">
+          <span className="text-slate-600 dark:text-slate-400">
+            {entry.name}:
+          </span>
+          <span className="font-semibold text-slate-900 dark:text-slate-50">
             {entry.value}건
           </span>
         </div>
@@ -49,68 +56,38 @@ function CustomTooltip({
 
 export default function PRTrendChart({ data, loading }: PRTrendChartProps) {
   return (
-    <div className="lg:col-span-3 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn("lg:col-span-3", surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         PR 활동 추이
       </h3>
       {loading ? (
-        <div className="w-full h-70 sm:h-85">
-          <Skeleton className="w-full h-full rounded-lg" />
+        <div className="h-70 w-full sm:h-85">
+          <Skeleton className="h-full w-full rounded-md" />
         </div>
       ) : data.length === 0 ? (
-        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
-          <BarChart3 className="w-10 h-10 mb-3 text-slate-300" />
+        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
+          <BarChart3 className="mb-3 size-10 text-slate-300" />
           <p className="text-sm font-medium">데이터가 없습니다</p>
         </div>
       ) : (
-        <div className="w-full h-70 sm:h-85">
+        <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
             <AreaChart
               data={data}
               margin={{ top: 5, right: 5, left: -20, bottom: 0 }}
             >
               <defs>
-                <linearGradient
-                  id="openGradient"
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
+                <linearGradient id="openGradient" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
-                  <stop
-                    offset="100%"
-                    stopColor="#3b82f6"
-                    stopOpacity={0.05}
-                  />
+                  <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
                 </linearGradient>
-                <linearGradient
-                  id="mergedGradient"
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
+                <linearGradient id="mergedGradient" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#22c55e" stopOpacity={0.3} />
-                  <stop
-                    offset="100%"
-                    stopColor="#22c55e"
-                    stopOpacity={0.05}
-                  />
+                  <stop offset="100%" stopColor="#22c55e" stopOpacity={0.05} />
                 </linearGradient>
-                <linearGradient
-                  id="closedGradient"
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
+                <linearGradient id="closedGradient" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#94a3b8" stopOpacity={0.3} />
-                  <stop
-                    offset="100%"
-                    stopColor="#94a3b8"
-                    stopOpacity={0.05}
-                  />
+                  <stop offset="100%" stopColor="#94a3b8" stopOpacity={0.05} />
                 </linearGradient>
               </defs>
               <XAxis

--- a/components/stats/charts/QualityTrendChart.tsx
+++ b/components/stats/charts/QualityTrendChart.tsx
@@ -1,16 +1,18 @@
 "use client"
 
 import {
-  AreaChart,
   Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
 } from "recharts"
-import { textStyles } from "@/lib/styles"
-import { Skeleton } from "@/components/ui/skeleton"
 import { TrendingUp } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { surfaceStyles, textStyles } from "@/lib/styles"
+import { cn } from "@/lib/utils"
 import type { QualityTrendItem } from "@/lib/stats"
 
 interface QualityTrendChartProps {
@@ -28,12 +30,13 @@ function CustomTooltip({
   label?: string
 }) {
   if (!active || !payload?.length) return null
+
   return (
-    <div className="bg-white rounded-xl shadow-lg border border-slate-200 px-5 py-3 text-center">
-      <div className="text-slate-900 font-bold text-sm">
+    <div className="rounded-md border border-slate-200 bg-white px-5 py-3 text-center shadow-lg dark:border-slate-800 dark:bg-slate-950">
+      <div className="text-sm font-bold text-slate-900 dark:text-slate-50">
         점수: {payload[0].value}점
       </div>
-      <div className="text-blue-500 text-xs mt-1">{label}</div>
+      <div className="mt-1 text-xs text-blue-500">{label}</div>
     </div>
   )
 }
@@ -43,40 +46,30 @@ export default function QualityTrendChart({
   loading,
 }: QualityTrendChartProps) {
   return (
-    <div className="lg:col-span-3 bg-white rounded-xl shadow-sm border border-slate-200 p-4 sm:p-6 md:p-8">
+    <div className={cn("lg:col-span-3", surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
         코드 품질 추이
       </h3>
       {loading ? (
-        <div className="w-full h-70 sm:h-85">
-          <Skeleton className="w-full h-full rounded-lg" />
+        <div className="h-70 w-full sm:h-85">
+          <Skeleton className="h-full w-full rounded-md" />
         </div>
       ) : data.length === 0 ? (
-        <div className="w-full h-70 sm:h-85 flex flex-col items-center justify-center text-slate-400">
-          <TrendingUp className="w-10 h-10 mb-3 text-slate-300" />
+        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
+          <TrendingUp className="mb-3 size-10 text-slate-300" />
           <p className="text-sm font-medium">데이터가 없습니다</p>
         </div>
       ) : (
-        <div className="w-full h-70 sm:h-85">
+        <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
             <AreaChart
               data={data}
               margin={{ top: 5, right: 5, left: -20, bottom: 0 }}
             >
               <defs>
-                <linearGradient
-                  id="qualityGradient"
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
+                <linearGradient id="qualityGradient" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#60a5fa" stopOpacity={0.3} />
-                  <stop
-                    offset="100%"
-                    stopColor="#60a5fa"
-                    stopOpacity={0.05}
-                  />
+                  <stop offset="100%" stopColor="#60a5fa" stopOpacity={0.05} />
                 </linearGradient>
               </defs>
               <XAxis

--- a/hooks/useConnectRepository.ts
+++ b/hooks/useConnectRepository.ts
@@ -27,6 +27,7 @@ export function useConnectRepository() {
     mutationFn: connectRepository,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["repositories"] })
+      queryClient.invalidateQueries({ queryKey: ["githubRepos"] })
     },
   })
 }


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [x] Week 9-10: 대시보드 & 배포

## 개요

보호 영역 페이지 전반의 컨테이너, 헤더, 카드, 툴바 표면 스타일을 공통 패턴으로 정리해 화면 간 일관성을 높였습니다.

## 변경 사항

- 대시보드, PR, 댓글, 알림, 저장소, 설정, 통계 화면에 `PageContainer`/`PageHeader` 기반 레이아웃을 적용했습니다.
- 카드/패널/툴바에 `surfaceStyles`, `controlStyles`, `layoutStyles` 공통 스타일을 반영했습니다.
- 각 화면의 로딩 스켈레톤도 동일한 표면 규칙에 맞춰 정리했습니다.
- 저장소 연결 성공 시 `githubRepos` 쿼리도 무효화해 즉시 목록이 갱신되도록 보완했습니다.

## 스크린샷 (선택)

- 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

추가로 아래 테스트를 실행했습니다.

- 실행하지 않음

## 참고 사항

- Markdown 문서 변경은 사용자 요청으로 이번 PR 범위에서 제외했습니다.
- Closes #137