### PR TITLE
fix: 저장소 PR 동기화 최신화 (#144)

### DIFF
--- a/__tests__/api/repositories/[id]/sync/route.test.ts
+++ b/__tests__/api/repositories/[id]/sync/route.test.ts
@@ -1,0 +1,145 @@
+import { POST } from "@/app/api/repositories/[id]/sync/route"
+import { auth } from "@/lib/auth"
+import { getOctokit } from "@/lib/github"
+import { prisma } from "@/lib/prisma"
+import { syncRepositoryPullRequests } from "@/lib/pull-request-sync"
+import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
+
+jest.mock("@/lib/auth", () => ({
+  auth: jest.fn(),
+}))
+
+jest.mock("@/lib/github", () => ({
+  getOctokit: jest.fn(),
+}))
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    repository: {
+      findFirst: jest.fn(),
+    },
+  },
+}))
+
+jest.mock("@/lib/pull-request-sync", () => ({
+  syncRepositoryPullRequests: jest.fn(),
+}))
+
+jest.mock("@/lib/repository-access", () => ({
+  buildAccessibleRepositoryWhere: jest.fn(),
+}))
+
+const mockedAuth = auth as jest.Mock
+const mockedGetOctokit = getOctokit as jest.Mock
+const mockedFindFirst = prisma.repository.findFirst as jest.Mock
+const mockedSyncRepositoryPullRequests = syncRepositoryPullRequests as jest.Mock
+const mockedBuildAccessibleRepositoryWhere =
+  buildAccessibleRepositoryWhere as jest.Mock
+
+describe("POST /api/repositories/[id]/sync", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns 401 for anonymous users", async () => {
+    mockedAuth.mockResolvedValue(null)
+
+    const response = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "repo-1" }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error).toBe("Unauthorized")
+  })
+
+  it("syncs the latest PR list for the repository", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
+    mockedFindFirst.mockResolvedValue({
+      id: "repo-1",
+      fullName: "owner/sample-repo",
+    })
+    mockedGetOctokit.mockResolvedValue({ rest: { pulls: {} } })
+    mockedSyncRepositoryPullRequests.mockResolvedValue({
+      syncedCount: 18,
+      detailHydratedCount: 4,
+    })
+
+    const response = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "repo-1" }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      updated: 18,
+      total: 18,
+      detailHydrated: 4,
+    })
+    expect(mockedBuildAccessibleRepositoryWhere).toHaveBeenCalledWith(
+      "user-1",
+      "repo-1"
+    )
+    expect(mockedSyncRepositoryPullRequests).toHaveBeenCalledWith({
+      octokit: expect.any(Object),
+      owner: "owner",
+      repo: "sample-repo",
+      repositoryId: "repo-1",
+    })
+  })
+
+  it("returns 404 when the repository is not accessible", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
+    mockedFindFirst.mockResolvedValue(null)
+
+    const response = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "repo-1" }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body.error).toBe("Repository not found")
+  })
+
+  it("returns a reconnect message when the GitHub token is missing", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
+    mockedFindFirst.mockResolvedValue({
+      id: "repo-1",
+      fullName: "owner/sample-repo",
+    })
+    mockedGetOctokit.mockRejectedValue(
+      new Error("GitHub 토큰이 없습니다. GitHub 계정을 다시 연결해 주세요.")
+    )
+
+    const response = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "repo-1" }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error).toContain("GitHub")
+    expect(body.error).toContain("다시 연결")
+  })
+
+  it("returns a permission message for GitHub 403 errors", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedBuildAccessibleRepositoryWhere.mockResolvedValue({ id: { in: ["repo-1"] } })
+    mockedFindFirst.mockResolvedValue({
+      id: "repo-1",
+      fullName: "owner/sample-repo",
+    })
+    mockedGetOctokit.mockResolvedValue({ rest: { pulls: {} } })
+    mockedSyncRepositoryPullRequests.mockRejectedValue({ status: 403 })
+
+    const response = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "repo-1" }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toContain("접근 권한")
+  })
+})

--- a/__tests__/api/repositories/route.test.ts
+++ b/__tests__/api/repositories/route.test.ts
@@ -2,6 +2,7 @@ import { POST } from "@/app/api/repositories/route"
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import { syncRepositoryPullRequests } from "@/lib/pull-request-sync"
 import {
   connectRepositoryToUser,
   isRepositoryMembershipMigrationError,
@@ -22,11 +23,11 @@ jest.mock("@/lib/prisma", () => ({
       create: jest.fn(),
       update: jest.fn(),
     },
-    pullRequest: {
-      count: jest.fn(),
-      createMany: jest.fn(),
-    },
   },
+}))
+
+jest.mock("@/lib/pull-request-sync", () => ({
+  syncRepositoryPullRequests: jest.fn(),
 }))
 
 jest.mock("@/lib/repository-access", () => ({
@@ -39,8 +40,7 @@ const mockedGetOctokit = getOctokit as jest.Mock
 const mockedFindUnique = prisma.repository.findUnique as jest.Mock
 const mockedCreate = prisma.repository.create as jest.Mock
 const mockedUpdate = prisma.repository.update as jest.Mock
-const mockedCount = prisma.pullRequest.count as jest.Mock
-const mockedCreateMany = prisma.pullRequest.createMany as jest.Mock
+const mockedSyncRepositoryPullRequests = syncRepositoryPullRequests as jest.Mock
 const mockedConnectRepositoryToUser = connectRepositoryToUser as jest.Mock
 const mockedIsRepositoryMembershipMigrationError =
   isRepositoryMembershipMigrationError as jest.Mock
@@ -62,15 +62,14 @@ describe("POST /api/repositories", () => {
   it("creates a repository connection", async () => {
     mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
     mockedFindUnique.mockResolvedValue(null)
-    mockedCount.mockResolvedValue(0)
-    mockedCreateMany.mockResolvedValue({ count: 0 })
+    mockedSyncRepositoryPullRequests.mockResolvedValue({
+      syncedCount: 0,
+      detailHydratedCount: 0,
+    })
     mockedGetOctokit.mockResolvedValue({
       rest: {
         repos: {
           createWebhook: jest.fn().mockResolvedValue({ data: { id: 9999 } }),
-        },
-        pulls: {
-          list: jest.fn().mockResolvedValue({ data: [] }),
         },
       },
     })
@@ -127,6 +126,12 @@ describe("POST /api/repositories", () => {
       },
       select: expect.any(Object),
     })
+    expect(mockedSyncRepositoryPullRequests).toHaveBeenCalledWith({
+      octokit: expect.any(Object),
+      owner: "user",
+      repo: "my-repo",
+      repositoryId: "repo-1",
+    })
   })
 
   it("returns 401 for anonymous users", async () => {
@@ -171,6 +176,37 @@ describe("POST /api/repositories", () => {
 
     expect(response.status).toBe(409)
     expect(body.error).toContain("already connected")
+  })
+
+  it("syncs PRs when connecting an existing shared repository", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue({
+      id: "existing-repo",
+      githubId: BigInt(12345),
+      name: "repo",
+      fullName: "user/repo",
+      description: null,
+      language: null,
+      webhookId: 9999,
+    })
+    mockedConnectRepositoryToUser.mockResolvedValue("created")
+    mockedGetOctokit.mockResolvedValue({ rest: { repos: {} } })
+    mockedSyncRepositoryPullRequests.mockResolvedValue({
+      syncedCount: 12,
+      detailHydratedCount: 3,
+    })
+
+    const response = await POST(
+      createRequest({ githubId: 12345, name: "repo", fullName: "user/repo" })
+    )
+
+    expect(response.status).toBe(201)
+    expect(mockedSyncRepositoryPullRequests).toHaveBeenCalledWith({
+      octokit: expect.any(Object),
+      owner: "user",
+      repo: "repo",
+      repositoryId: "existing-repo",
+    })
   })
 
   it("returns 500 on unexpected errors", async () => {

--- a/app/api/pulls/route.ts
+++ b/app/api/pulls/route.ts
@@ -58,6 +58,7 @@ export async function GET(request: Request) {
           },
         },
         orderBy: [
+          { githubUpdatedAt: { sort: "desc", nulls: "last" } },
           { githubCreatedAt: { sort: "desc", nulls: "last" } },
           { number: "desc" },
         ],

--- a/app/api/repositories/[id]/sync/route.ts
+++ b/app/api/repositories/[id]/sync/route.ts
@@ -1,8 +1,58 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import { syncRepositoryPullRequests } from "@/lib/pull-request-sync"
 import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
 import { NextResponse } from "next/server"
+
+function getSyncErrorResponse(error: unknown) {
+  if (
+    error instanceof Error &&
+    error.message.includes("GitHub") &&
+    error.message.includes("다시")
+  ) {
+    return NextResponse.json(
+      { error: "GitHub 연동이 만료되었습니다. GitHub를 다시 연결해 주세요." },
+      { status: 401 }
+    )
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof error.status === "number"
+  ) {
+    if (error.status === 401) {
+      return NextResponse.json(
+        { error: "GitHub 인증이 만료되었습니다. GitHub를 다시 연결해 주세요." },
+        { status: 401 }
+      )
+    }
+
+    if (error.status === 403) {
+      return NextResponse.json(
+        {
+          error:
+            "GitHub 저장소 접근 권한이 없거나 API 요청 한도에 도달했습니다. 잠시 후 다시 시도해 주세요.",
+        },
+        { status: 403 }
+      )
+    }
+
+    if (error.status === 404) {
+      return NextResponse.json(
+        { error: "GitHub에서 해당 저장소를 찾지 못했습니다." },
+        { status: 404 }
+      )
+    }
+  }
+
+  return NextResponse.json(
+    { error: "저장소 동기화 중 서버 오류가 발생했습니다." },
+    { status: 500 }
+  )
+}
 
 export async function POST(
   _request: Request,
@@ -26,74 +76,23 @@ export async function POST(
       return NextResponse.json({ error: "Repository not found" }, { status: 404 })
     }
 
-    const unsynced = await prisma.pullRequest.findMany({
-      where: {
-        repoId: id,
-        additions: 0,
-        deletions: 0,
-        changedFiles: 0,
-      },
-      select: { id: true, number: true },
-    })
-
-    if (unsynced.length === 0) {
-      return NextResponse.json({ updated: 0, total: 0 })
-    }
-
     const [owner, repo] = repository.fullName.split("/")
     const octokit = await getOctokit(session.user.id)
 
-    const results: {
-      id: string
-      additions: number
-      deletions: number
-      changedFiles: number
-    }[] = []
+    const result = await syncRepositoryPullRequests({
+      octokit,
+      owner,
+      repo,
+      repositoryId: repository.id,
+    })
 
-    for (const pr of unsynced) {
-      try {
-        const { data } = await octokit.pulls.get({
-          owner,
-          repo,
-          pull_number: pr.number,
-        })
-
-        if (
-          data.additions === 0 &&
-          data.deletions === 0 &&
-          data.changed_files === 0
-        ) {
-          continue
-        }
-
-        results.push({
-          id: pr.id,
-          additions: data.additions,
-          deletions: data.deletions,
-          changedFiles: data.changed_files,
-        })
-      } catch {
-        // Skip PRs that fail detail hydration and continue.
-      }
-    }
-
-    if (results.length > 0) {
-      await prisma.$transaction(
-        results.map((result) =>
-          prisma.pullRequest.update({
-            where: { id: result.id },
-            data: {
-              additions: result.additions,
-              deletions: result.deletions,
-              changedFiles: result.changedFiles,
-            },
-          })
-        )
-      )
-    }
-
-    return NextResponse.json({ updated: results.length, total: unsynced.length })
-  } catch {
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    return NextResponse.json({
+      updated: result.syncedCount,
+      total: result.syncedCount,
+      detailHydrated: result.detailHydratedCount,
+    })
+  } catch (error) {
+    console.error("[POST /api/repositories/[id]/sync] failed:", error)
+    return getSyncErrorResponse(error)
   }
 }

--- a/app/api/repositories/route.ts
+++ b/app/api/repositories/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth"
 import { getOctokit } from "@/lib/github"
 import { prisma } from "@/lib/prisma"
+import { syncRepositoryPullRequests } from "@/lib/pull-request-sync"
 import {
   buildAccessibleRepositoryWhere,
   connectRepositoryToUser,
@@ -149,53 +150,17 @@ export async function POST(request: Request) {
       }
     }
 
-    const existingPullRequestCount = await prisma.pullRequest.count({
-      where: { repoId: repository.id },
-    })
+    try {
+      const octokit = await getOctokit(session.user.id)
 
-    if (existingPullRequestCount === 0) {
-      try {
-        const octokit = await getOctokit(session.user.id)
-        const { data: prs } = await octokit.rest.pulls.list({
-          owner,
-          repo,
-          state: "all",
-          per_page: 100,
-          sort: "updated",
-          direction: "desc",
-        })
-
-        if (prs.length > 0) {
-          await prisma.pullRequest.createMany({
-            data: prs.map((pr) => ({
-              githubId: BigInt(pr.id),
-              number: pr.number,
-              title: pr.title,
-              description: pr.body ?? null,
-              status: pr.draft
-                ? "DRAFT"
-                : pr.state === "closed"
-                  ? pr.merged_at
-                    ? "MERGED"
-                    : "CLOSED"
-                  : "OPEN",
-              baseBranch: pr.base.ref,
-              headBranch: pr.head.ref,
-              additions: 0,
-              deletions: 0,
-              changedFiles: 0,
-              mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
-              closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
-              githubCreatedAt: pr.created_at ? new Date(pr.created_at) : null,
-              githubUpdatedAt: pr.updated_at ? new Date(pr.updated_at) : null,
-              repoId: repository.id,
-            })),
-            skipDuplicates: true,
-          })
-        }
-      } catch (error) {
-        console.error("[Backfill] failed:", error)
-      }
+      await syncRepositoryPullRequests({
+        octokit,
+        owner,
+        repo,
+        repositoryId: repository.id,
+      })
+    } catch (error) {
+      console.error("[Repository PR sync] failed:", error)
     }
 
     return NextResponse.json(

--- a/components/github/RepoCard.tsx
+++ b/components/github/RepoCard.tsx
@@ -11,8 +11,9 @@ import {
   RefreshCw,
   Trash2,
 } from "lucide-react"
-import { Button } from "@/components/ui/button"
+
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { useSyncRepository } from "@/hooks/useSyncRepository"
 import { controlStyles, surfaceStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
@@ -53,6 +54,7 @@ export default function RepoCard({
   connectError = null,
 }: RepoCardProps) {
   const [syncMessage, setSyncMessage] = useState<string | null>(null)
+  const [syncError, setSyncError] = useState<string | null>(null)
   const { mutate: sync, isPending: isSyncing } = useSyncRepository()
   const dotColor = language ? (LANGUAGE_COLORS[language] ?? "bg-slate-400") : null
 
@@ -60,7 +62,7 @@ export default function RepoCard({
     <div className={cn("group relative", surfaceStyles.interactiveCard)}>
       <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div className="flex items-start gap-4">
-          <div className="h-12 w-12 shrink-0 rounded-2xl border border-slate-100 bg-slate-50 text-slate-400 transition-colors group-hover:bg-blue-50 group-hover:text-blue-600 flex items-center justify-center">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-slate-100 bg-slate-50 text-slate-400 transition-colors group-hover:bg-blue-50 group-hover:text-blue-600">
             <FolderGit2 size={22} aria-hidden />
           </div>
 
@@ -89,7 +91,7 @@ export default function RepoCard({
             <>
               <Badge className="gap-1.5 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-1.5 text-xs font-bold text-emerald-600">
                 <Check size={12} aria-hidden />
-                연동됨
+                연결됨
               </Badge>
               {syncMessage && (
                 <span className="text-xs font-medium text-slate-500">{syncMessage}</span>
@@ -101,32 +103,47 @@ export default function RepoCard({
                 onClick={() => {
                   if (!repositoryId) return
 
+                  setSyncError(null)
+                  setSyncMessage("동기화 중...")
+
                   sync(repositoryId, {
-                    onSuccess: ({ updated, total }) => {
+                    onSuccess: ({ updated, total, detailHydrated }) => {
                       setSyncMessage(
-                        total === 0 ? "보정할 PR 없음" : `${updated}/${total}건 보정 완료`
+                        total === 0
+                          ? "동기화할 PR이 없습니다."
+                          : detailHydrated && detailHydrated > 0
+                            ? `PR ${updated}건 동기화, 상세 ${detailHydrated}건 보정 완료`
+                            : `PR ${updated}건 동기화 완료`
                       )
                       setTimeout(() => setSyncMessage(null), 3000)
                     },
-                    onError: () => {
-                      setSyncMessage("동기화 실패")
-                      setTimeout(() => setSyncMessage(null), 3000)
+                    onError: (error) => {
+                      setSyncMessage(null)
+                      setSyncError(
+                        error instanceof Error
+                          ? error.message
+                          : "저장소 동기화에 실패했습니다."
+                      )
                     },
                   })
                 }}
-                title="코드 변경량 동기화"
+                title="GitHub에서 최신 PR 목록 동기화"
                 className={cn(
                   controlStyles.iconButton,
                   "text-slate-400 hover:border-blue-100 hover:bg-blue-50 hover:text-blue-500 disabled:opacity-40"
                 )}
               >
-                <RefreshCw size={18} className={isSyncing ? "animate-spin" : ""} aria-hidden />
+                <RefreshCw
+                  size={18}
+                  className={isSyncing ? "animate-spin" : ""}
+                  aria-hidden
+                />
               </Button>
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={onDisconnect}
-                title="연동 해제"
+                title="저장소 연결 해제"
                 className={cn(
                   controlStyles.iconButton,
                   "text-slate-400 hover:border-rose-100 hover:bg-rose-50 hover:text-rose-500"
@@ -145,12 +162,12 @@ export default function RepoCard({
               {isConnecting ? (
                 <>
                   <Loader2 size={14} className="animate-spin" aria-hidden />
-                  연동 중...
+                  연결 중...
                 </>
               ) : (
                 <>
                   <Plus size={14} aria-hidden />
-                  연동
+                  연결
                 </>
               )}
             </Button>
@@ -162,6 +179,13 @@ export default function RepoCard({
         <div className="mt-3 inline-flex items-center gap-1.5 rounded-xl border border-rose-100 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-600">
           <AlertCircle size={13} aria-hidden />
           {connectError}
+        </div>
+      )}
+
+      {syncError && isConnected && (
+        <div className="mt-3 inline-flex items-center gap-1.5 rounded-xl border border-rose-100 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-600">
+          <AlertCircle size={13} aria-hidden />
+          {syncError}
         </div>
       )}
 

--- a/hooks/useConnectRepository.ts
+++ b/hooks/useConnectRepository.ts
@@ -28,6 +28,7 @@ export function useConnectRepository() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["repositories"] })
       queryClient.invalidateQueries({ queryKey: ["githubRepos"] })
+      queryClient.invalidateQueries({ queryKey: ["pullRequests"] })
     },
   })
 }

--- a/hooks/useSyncRepository.ts
+++ b/hooks/useSyncRepository.ts
@@ -1,8 +1,9 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 interface SyncResult {
   updated: number
   total: number
+  detailHydrated?: number
 }
 
 async function syncRepository(repositoryId: string): Promise<SyncResult> {
@@ -17,7 +18,12 @@ async function syncRepository(repositoryId: string): Promise<SyncResult> {
 }
 
 export function useSyncRepository() {
+  const queryClient = useQueryClient()
+
   return useMutation({
     mutationFn: syncRepository,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["pullRequests"] })
+    },
   })
 }

--- a/lib/pull-request-sync.ts
+++ b/lib/pull-request-sync.ts
@@ -1,0 +1,228 @@
+import type { Octokit } from "@octokit/rest"
+
+import { prisma } from "@/lib/prisma"
+
+type GitHubPullRequestSummary =
+  Awaited<ReturnType<Octokit["rest"]["pulls"]["list"]>>["data"][number]
+type GitHubPullRequestDetail =
+  Awaited<ReturnType<Octokit["rest"]["pulls"]["get"]>>["data"]
+
+interface SyncRepositoryPullRequestsParams {
+  octokit: Octokit
+  owner: string
+  repo: string
+  repositoryId: string
+}
+
+export interface SyncRepositoryPullRequestsResult {
+  syncedCount: number
+  detailHydratedCount: number
+}
+
+export function getPullRequestStatus(pr: {
+  state: string
+  draft?: boolean | null
+  merged?: boolean | null
+  merged_at?: string | null
+}): "OPEN" | "CLOSED" | "MERGED" | "DRAFT" {
+  if (pr.draft) return "DRAFT"
+
+  if (pr.state === "closed") {
+    return pr.merged || Boolean(pr.merged_at) ? "MERGED" : "CLOSED"
+  }
+
+  return "OPEN"
+}
+
+function getNeedsDetailHydration(
+  localPullRequest:
+    | {
+        additions: number
+        deletions: number
+        changedFiles: number
+        githubUpdatedAt: Date | null
+      }
+    | undefined,
+  remotePullRequest: GitHubPullRequestSummary
+): boolean {
+  if (!localPullRequest) {
+    return true
+  }
+
+  if (
+    localPullRequest.additions === 0 &&
+    localPullRequest.deletions === 0 &&
+    localPullRequest.changedFiles === 0
+  ) {
+    return true
+  }
+
+  if (!remotePullRequest.updated_at) {
+    return false
+  }
+
+  if (!localPullRequest.githubUpdatedAt) {
+    return true
+  }
+
+  return (
+    new Date(remotePullRequest.updated_at).getTime() >
+    localPullRequest.githubUpdatedAt.getTime()
+  )
+}
+
+function toUpsertPayload(
+  pullRequest: GitHubPullRequestSummary | GitHubPullRequestDetail,
+  repositoryId: string
+) {
+  return {
+    githubId: BigInt(pullRequest.id),
+    number: pullRequest.number,
+    title: pullRequest.title,
+    description: pullRequest.body ?? null,
+    status: getPullRequestStatus(pullRequest),
+    baseBranch: pullRequest.base.ref,
+    headBranch: pullRequest.head.ref,
+    additions: "additions" in pullRequest ? (pullRequest.additions ?? 0) : 0,
+    deletions: "deletions" in pullRequest ? (pullRequest.deletions ?? 0) : 0,
+    changedFiles:
+      "changed_files" in pullRequest ? (pullRequest.changed_files ?? 0) : 0,
+    mergedAt: pullRequest.merged_at ? new Date(pullRequest.merged_at) : null,
+    closedAt: pullRequest.closed_at ? new Date(pullRequest.closed_at) : null,
+    githubCreatedAt: pullRequest.created_at
+      ? new Date(pullRequest.created_at)
+      : null,
+    githubUpdatedAt: pullRequest.updated_at
+      ? new Date(pullRequest.updated_at)
+      : null,
+    repoId: repositoryId,
+  }
+}
+
+export async function syncRepositoryPullRequests({
+  octokit,
+  owner,
+  repo,
+  repositoryId,
+}: SyncRepositoryPullRequestsParams): Promise<SyncRepositoryPullRequestsResult> {
+  const remotePullRequests = await octokit.paginate(octokit.rest.pulls.list, {
+    owner,
+    repo,
+    state: "all",
+    per_page: 100,
+    sort: "updated",
+    direction: "desc",
+  })
+
+  if (remotePullRequests.length === 0) {
+    return {
+      syncedCount: 0,
+      detailHydratedCount: 0,
+    }
+  }
+
+  const existingPullRequests = await prisma.pullRequest.findMany({
+    where: {
+      repoId: repositoryId,
+      number: {
+        in: remotePullRequests.map((pullRequest) => pullRequest.number),
+      },
+    },
+    select: {
+      id: true,
+      number: true,
+      additions: true,
+      deletions: true,
+      changedFiles: true,
+      githubUpdatedAt: true,
+    },
+  })
+
+  const existingByNumber = new Map(
+    existingPullRequests.map((pullRequest) => [pullRequest.number, pullRequest])
+  )
+
+  const pullRequestsToHydrate = remotePullRequests.filter((pullRequest) =>
+    getNeedsDetailHydration(existingByNumber.get(pullRequest.number), pullRequest)
+  )
+
+  const syncedPullRequests = await prisma.$transaction(
+    remotePullRequests.map((pullRequest) =>
+      prisma.pullRequest.upsert({
+        where: { githubId: BigInt(pullRequest.id) },
+        update: {
+          title: pullRequest.title,
+          description: pullRequest.body ?? null,
+          status: getPullRequestStatus(pullRequest),
+          baseBranch: pullRequest.base.ref,
+          headBranch: pullRequest.head.ref,
+          mergedAt: pullRequest.merged_at ? new Date(pullRequest.merged_at) : null,
+          closedAt: pullRequest.closed_at ? new Date(pullRequest.closed_at) : null,
+          githubCreatedAt: pullRequest.created_at
+            ? new Date(pullRequest.created_at)
+            : null,
+          githubUpdatedAt: pullRequest.updated_at
+            ? new Date(pullRequest.updated_at)
+            : null,
+        },
+        create: toUpsertPayload(pullRequest, repositoryId),
+      })
+    )
+  )
+
+  const syncedByNumber = new Map(
+    syncedPullRequests.map((pullRequest) => [pullRequest.number, pullRequest.id])
+  )
+
+  const hydratedResults: {
+    id: string
+    additions: number
+    deletions: number
+    changedFiles: number
+  }[] = []
+
+  for (const pullRequest of pullRequestsToHydrate) {
+    try {
+      const { data } = await octokit.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: pullRequest.number,
+      })
+
+      const localId = syncedByNumber.get(pullRequest.number)
+
+      if (!localId) {
+        continue
+      }
+
+      hydratedResults.push({
+        id: localId,
+        additions: data.additions ?? 0,
+        deletions: data.deletions ?? 0,
+        changedFiles: data.changed_files ?? 0,
+      })
+    } catch {
+      // Continue syncing other PRs when one detail request fails.
+    }
+  }
+
+  if (hydratedResults.length > 0) {
+    await prisma.$transaction(
+      hydratedResults.map((result) =>
+        prisma.pullRequest.update({
+          where: { id: result.id },
+          data: {
+            additions: result.additions,
+            deletions: result.deletions,
+            changedFiles: result.changedFiles,
+          },
+        })
+      )
+    )
+  }
+
+  return {
+    syncedCount: remotePullRequests.length,
+    detailHydratedCount: hydratedResults.length,
+  }
+}


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [x] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

저장소 재연동 또는 수동 동기화 후에도 PR 목록이 최신 상태로 반영되지 않던 문제를 수정했습니다. Closes #144.

## 변경 사항

- 저장소 연결과 수동 동기화 모두 GitHub PR 목록을 다시 조회해 upsert 하도록 공통 sync 로직 추가
- 수동 sync API가 원인별 에러 메시지를 반환하도록 보강
- 저장소 페이지에서 동기화 성공/실패 피드백을 명확히 표시
- PR 목록 정렬을 `githubUpdatedAt` 기준으로 보정
- 관련 API 회귀 테스트 추가

## 스크린샷 (선택)

없음

## 테스트

- [x] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

추가 실행:
- `npm.cmd test -- --runInBand --runTestsByPath "__tests__/api/repositories/route.test.ts" "__tests__/api/repositories/[id]/sync/route.test.ts" "__tests__/api/pulls/route.test.ts"`
- `npx.cmd eslint app/api/repositories/route.ts "app/api/repositories/[id]/sync/route.ts" app/api/pulls/route.ts hooks/useConnectRepository.ts hooks/useSyncRepository.ts components/github/RepoCard.tsx lib/pull-request-sync.ts "__tests__/api/repositories/route.test.ts" "__tests__/api/repositories/[id]/sync/route.test.ts"`

## 참고 사항

- 로컬 작업 트리에 unrelated 변경이 많아 `main` 기준 분리 worktree에서 이번 수정만 별도 브랜치로 분리해 커밋했습니다.
- 로컬 `git push`는 일반 권한에서는 자격 증명 오류가 있었고, 승인 후 권한 상승으로 원격 브랜치 푸시를 완료했습니다.