### PR TITLE
feat: 댓글 반응 변경 실시간 동기화 (#146)

### DIFF
--- a/__tests__/api/comments/[id]/reactions/route.test.ts
+++ b/__tests__/api/comments/[id]/reactions/route.test.ts
@@ -1,0 +1,158 @@
+import { POST } from "@/app/api/comments/[id]/reactions/route"
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+import { emitCommentReactionUpdated } from "@/lib/socket/emitter"
+
+jest.mock("@/lib/auth", () => ({
+  auth: jest.fn(),
+}))
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    comment: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock("@/lib/socket/emitter", () => ({
+  emitCommentReactionUpdated: jest.fn(),
+}))
+
+const mockedAuth = auth as jest.Mock
+const mockedFindUnique = prisma.comment.findUnique as jest.Mock
+const mockedUpdate = prisma.comment.update as jest.Mock
+const mockedEmitCommentReactionUpdated = emitCommentReactionUpdated as jest.Mock
+
+function createRequest(body: object) {
+  return new Request("http://localhost/api/comments/comment-1/reactions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+function createParams(id = "comment-1") {
+  return Promise.resolve({ id })
+}
+
+describe("POST /api/comments/[id]/reactions", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns 401 for anonymous users", async () => {
+    mockedAuth.mockResolvedValue(null)
+
+    const response = await POST(createRequest({ emoji: "👍" }), {
+      params: createParams(),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error).toBe("Unauthorized")
+  })
+
+  it("returns 404 when the comment does not exist", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue(null)
+
+    const response = await POST(createRequest({ emoji: "👍" }), {
+      params: createParams(),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body.error).toBeDefined()
+  })
+
+  it("returns 400 for unsupported emoji", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue({
+      id: "comment-1",
+      pullRequestId: "pr-1",
+      reactions: {},
+    })
+
+    const response = await POST(createRequest({ emoji: "🔥" }), {
+      params: createParams(),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBeDefined()
+    expect(mockedUpdate).not.toHaveBeenCalled()
+    expect(mockedEmitCommentReactionUpdated).not.toHaveBeenCalled()
+  })
+
+  it("adds a reaction and emits a realtime update", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue({
+      id: "comment-1",
+      pullRequestId: "pr-1",
+      reactions: { "👍": ["user-2"] },
+    })
+    mockedUpdate.mockResolvedValue({
+      id: "comment-1",
+      pullRequestId: "pr-1",
+      reactions: { "👍": ["user-2", "user-1"] },
+      author: { id: "user-1", name: "Tester", image: null },
+    })
+
+    const response = await POST(createRequest({ emoji: "👍" }), {
+      params: createParams(),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockedUpdate).toHaveBeenCalledWith({
+      where: { id: "comment-1" },
+      data: { reactions: { "👍": ["user-2", "user-1"] } },
+      include: {
+        author: { select: { id: true, name: true, image: true } },
+      },
+    })
+    expect(mockedEmitCommentReactionUpdated).toHaveBeenCalledWith(
+      "pr-1",
+      "comment-1",
+      { "👍": ["user-2", "user-1"] }
+    )
+    expect(body.comment.reactions["👍"]).toEqual(["user-2", "user-1"])
+  })
+
+  it("removes the user's existing reaction and emits the trimmed payload", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue({
+      id: "comment-1",
+      pullRequestId: "pr-1",
+      reactions: { "👍": ["user-1", "user-2"] },
+    })
+    mockedUpdate.mockResolvedValue({
+      id: "comment-1",
+      pullRequestId: "pr-1",
+      reactions: { "👍": ["user-2"] },
+      author: { id: "user-1", name: "Tester", image: null },
+    })
+
+    const response = await POST(createRequest({ emoji: "👍" }), {
+      params: createParams(),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockedUpdate).toHaveBeenCalledWith({
+      where: { id: "comment-1" },
+      data: { reactions: { "👍": ["user-2"] } },
+      include: {
+        author: { select: { id: true, name: true, image: true } },
+      },
+    })
+    expect(mockedEmitCommentReactionUpdated).toHaveBeenCalledWith(
+      "pr-1",
+      "comment-1",
+      { "👍": ["user-2"] }
+    )
+    expect(body.comment.reactions["👍"]).toEqual(["user-2"])
+  })
+})

--- a/__tests__/lib/comments/cache.test.ts
+++ b/__tests__/lib/comments/cache.test.ts
@@ -1,0 +1,115 @@
+import {
+  findCommentInThread,
+  normalizeComment,
+  toggleReactionForUser,
+  updateCommentReactionsInThread,
+} from "@/lib/comments/cache"
+import type { CommentWithAuthor } from "@/types/comment"
+
+function makeComment(
+  overrides: Partial<CommentWithAuthor> = {}
+): CommentWithAuthor {
+  return {
+    id: overrides.id ?? "comment-1",
+    content: overrides.content ?? "hello",
+    lineNumber: overrides.lineNumber ?? null,
+    filePath: overrides.filePath ?? null,
+    isResolved: overrides.isResolved ?? false,
+    pullRequestId: overrides.pullRequestId ?? "pr-1",
+    authorId: overrides.authorId ?? "user-1",
+    parentId: overrides.parentId ?? null,
+    mentions: overrides.mentions ?? [],
+    reactions: overrides.reactions ?? {},
+    createdAt: overrides.createdAt ?? "2024-01-01T00:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2024-01-01T00:00:00.000Z",
+    author: overrides.author ?? {
+      id: overrides.authorId ?? "user-1",
+      name: "Tester",
+      image: null,
+    },
+    replies: overrides.replies ?? [],
+  }
+}
+
+describe("lib/comments/cache", () => {
+  it("normalizes missing author fields recursively", () => {
+    const normalized = normalizeComment(
+      makeComment({
+        author: {
+          id: "",
+          name: null,
+          image: null,
+        },
+        replies: [
+          makeComment({
+            id: "reply-1",
+            parentId: "comment-1",
+            authorId: "user-2",
+            author: {
+              id: "",
+              name: null,
+              image: null,
+            },
+          }),
+        ],
+      })
+    )
+
+    expect(normalized.author.id).toBe("user-1")
+    expect(normalized.replies[0].author.id).toBe("user-2")
+  })
+
+  it("finds nested comments in the thread", () => {
+    const comments = [
+      makeComment({
+        id: "comment-1",
+        replies: [
+          makeComment({
+            id: "reply-1",
+            parentId: "comment-1",
+          }),
+        ],
+      }),
+    ]
+
+    expect(findCommentInThread(comments, "reply-1")?.id).toBe("reply-1")
+    expect(findCommentInThread(comments, "missing")).toBeNull()
+  })
+
+  it("toggles reaction membership for the current user", () => {
+    const added = toggleReactionForUser({ "👍": ["user-2"] }, "👍", "user-1")
+    expect(added["👍"]).toEqual(["user-2", "user-1"])
+
+    const removed = toggleReactionForUser(added, "👍", "user-1")
+    expect(removed["👍"]).toEqual(["user-2"])
+  })
+
+  it("patches reactions for nested replies without touching siblings", () => {
+    const comments = [
+      makeComment({
+        id: "comment-1",
+        reactions: { "👍": ["user-1"] },
+        replies: [
+          makeComment({
+            id: "reply-1",
+            parentId: "comment-1",
+            reactions: { "👀": ["user-2"] },
+          }),
+          makeComment({
+            id: "reply-2",
+            parentId: "comment-1",
+            reactions: { "🚀": ["user-3"] },
+          }),
+        ],
+      }),
+    ]
+
+    const updated = updateCommentReactionsInThread(comments, "reply-1", {
+      "👀": ["user-2", "user-1"],
+    })
+
+    expect(updated[0].reactions).toEqual({ "👍": ["user-1"] })
+    expect(updated[0].replies[0].reactions).toEqual({ "👀": ["user-2", "user-1"] })
+    expect(updated[0].replies[1].reactions).toEqual({ "🚀": ["user-3"] })
+  })
+})

--- a/app/api/comments/[id]/reactions/route.ts
+++ b/app/api/comments/[id]/reactions/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { emitCommentReactionUpdated } from "@/lib/socket/emitter"
 import { NextResponse } from "next/server"
 import type { ReactionEmoji, Reactions } from "@/types/comment"
 
@@ -75,6 +76,8 @@ export async function POST(
         author: { select: { id: true, name: true, image: true } },
       },
     })
+
+    emitCommentReactionUpdated(comment.pullRequestId, id, updatedReactions)
 
     return NextResponse.json({ comment: updated })
   } catch {

--- a/components/comment/CommentList.tsx
+++ b/components/comment/CommentList.tsx
@@ -15,15 +15,24 @@ import {
 import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
 import { Badge } from "@/components/ui/badge"
-import { useCreateComment, useDeleteComment } from "@/hooks/useComments"
+import {
+  useCreateComment,
+  useDeleteComment,
+  useToggleReaction,
+} from "@/hooks/useComments"
 import { usePRDetail } from "@/hooks/usePRDetail"
 import { useRealtimeComments } from "@/hooks/useRealtimeComments"
 import { useSocket } from "@/hooks/useSocket"
 import { useTypingIndicator } from "@/hooks/useTypingIndicator"
 import { recordRender } from "@/lib/measurements/renderCounter"
 import { cn } from "@/lib/utils"
-import type { CommentWithAuthor, MentionUser } from "@/types/comment"
+import type {
+  CommentWithAuthor,
+  MentionUser,
+  ReactionEmoji,
+} from "@/types/comment"
 import CommentRenderMetricsPanel from "./CommentRenderMetricsPanel"
+import ReactionBar from "./ReactionBar"
 
 interface CommentListProps {
   prId: string
@@ -69,7 +78,7 @@ function ConnectionBadge() {
         className="gap-1 border-slate-200 bg-white/80 text-slate-500 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300"
       >
         <span className="size-1.5 rounded-full bg-slate-400" />
-        폴링 모드
+        Polling
       </Badge>
     )
   }
@@ -78,7 +87,7 @@ function ConnectionBadge() {
     return (
       <Badge className="gap-1 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/10 dark:bg-emerald-500/15 dark:text-emerald-300">
         <Wifi size={12} />
-        실시간 연결
+        Realtime
       </Badge>
     )
   }
@@ -87,7 +96,7 @@ function ConnectionBadge() {
     return (
       <Badge className="gap-1 bg-blue-500/10 text-blue-700 hover:bg-blue-500/10 dark:bg-blue-500/15 dark:text-blue-300">
         <Loader2 size={12} className="animate-spin" />
-        {connectionStatus === "connecting" ? "연결 중" : "재연결 중"}
+        {connectionStatus === "connecting" ? "Connecting" : "Reconnecting"}
       </Badge>
     )
   }
@@ -96,10 +105,10 @@ function ConnectionBadge() {
     return (
       <Badge
         className="gap-1 bg-rose-500/10 text-rose-700 hover:bg-rose-500/10 dark:bg-rose-500/15 dark:text-rose-300"
-        title={connectionError ?? "소켓 연결 오류"}
+        title={connectionError ?? "Socket connection error"}
       >
         <AlertCircle size={12} />
-        연결 오류
+        Error
       </Badge>
     )
   }
@@ -107,7 +116,7 @@ function ConnectionBadge() {
   return (
     <Badge className="gap-1 bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300">
       <WifiOff size={12} />
-      연결 끊김
+      Offline
     </Badge>
   )
 }
@@ -118,12 +127,14 @@ function ChatBubble({
   currentUserId,
   prId,
   showName,
+  onReaction,
 }: {
   comment: CommentWithAuthor
   isOwn: boolean
   currentUserId: string
   prId: string
   showName: boolean
+  onReaction: (commentId: string, emoji: ReactionEmoji) => void
 }) {
   const deleteComment = useDeleteComment(prId)
   const isPendingComment = isOptimisticComment(comment.id)
@@ -168,7 +179,7 @@ function ChatBubble({
         <div className={cn("flex items-end gap-1", isOwn ? "flex-row-reverse" : "flex-row")}>
           <div
             className={cn(
-              "relative px-3.5 py-2 text-sm leading-relaxed break-words shadow-sm transition-opacity",
+              "relative break-words px-3.5 py-2 text-sm leading-relaxed shadow-sm transition-opacity",
               isOwn
                 ? "rounded-[18px] rounded-br-[4px] bg-blue-500 text-white"
                 : "rounded-[18px] rounded-bl-[4px] border border-slate-100 bg-white text-slate-800 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100",
@@ -185,7 +196,7 @@ function ChatBubble({
                 )}
               >
                 <Loader2 size={10} className="animate-spin" />
-                전송 중
+                Sending...
               </div>
             )}
           </div>
@@ -198,16 +209,17 @@ function ChatBubble({
               )}
             >
               <Loader2 size={10} className="animate-spin" />
-              삭제 중입니다...
+              Deleting...
             </span>
           )}
 
           {isOwn && !isPendingComment && (
             <button
+              type="button"
               className="mb-1 shrink-0 text-slate-300 opacity-0 transition-opacity hover:text-rose-400 group-hover:opacity-100"
               onClick={() => deleteComment.mutate(comment.id)}
               disabled={deleteComment.isPending}
-              title="댓글 삭제"
+              title="Delete comment"
             >
               <Trash2 size={12} />
             </button>
@@ -215,8 +227,18 @@ function ChatBubble({
         </div>
 
         <span className={cn("px-2 text-[9px] text-slate-400", isOwn && "text-right")}>
-          {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
+          {formatDistanceToNow(new Date(comment.createdAt), {
+            addSuffix: true,
+            locale: ko,
+          })}
         </span>
+
+        <ReactionBar
+          reactions={comment.reactions ?? {}}
+          currentUserId={currentUserId}
+          onToggle={(emoji) => onReaction(comment.id, emoji)}
+          className={cn("px-2", isOwn && "justify-end")}
+        />
 
         {(comment.replies?.length ?? 0) > 0 && (
           <div
@@ -245,7 +267,7 @@ function ChatBubble({
                       {reply.author.name}
                     </span>
                   )}
-                  {renderContent(reply.content, isOwnReply)}
+                  <div>{renderContent(reply.content, isOwnReply)}</div>
                   {isPendingReply && (
                     <div
                       className={cn(
@@ -254,9 +276,15 @@ function ChatBubble({
                       )}
                     >
                       <Loader2 size={10} className="animate-spin" />
-                      전송 중
+                      Sending...
                     </div>
                   )}
+                  <ReactionBar
+                    reactions={reply.reactions ?? {}}
+                    currentUserId={currentUserId}
+                    onToggle={(emoji) => onReaction(reply.id, emoji)}
+                    className={cn("mt-2", isOwnReply && "justify-end")}
+                  />
                 </div>
               )
             })}
@@ -277,6 +305,7 @@ export default function CommentList({
 
   const { data: allComments = [], isLoading } = useRealtimeComments(prId)
   const createComment = useCreateComment(prId)
+  const toggleReaction = useToggleReaction(prId, currentUserId)
   const { names: typingNames, onTyping, onTypingStop } = useTypingIndicator(prId)
   const { connectionStatus, connectionError } = useSocket()
   const { data: pr } = usePRDetail(prId)
@@ -298,7 +327,9 @@ export default function CommentList({
       pr?.repo.owner,
       ...allComments.flatMap((comment) => [
         comment.author,
-        ...(Array.isArray(comment.replies) ? comment.replies : []).map((reply) => reply.author),
+        ...(Array.isArray(comment.replies) ? comment.replies : []).map(
+          (reply) => reply.author
+        ),
       ]),
     ]
 
@@ -320,7 +351,8 @@ export default function CommentList({
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const element = e.currentTarget
-    isAtBottomRef.current = element.scrollHeight - element.scrollTop <= element.clientHeight + 60
+    isAtBottomRef.current =
+      element.scrollHeight - element.scrollTop <= element.clientHeight + 60
   }
 
   const handleSend = useCallback(() => {
@@ -343,6 +375,13 @@ export default function CommentList({
     }
   }
 
+  const handleReaction = useCallback(
+    (commentId: string, emoji: ReactionEmoji) => {
+      toggleReaction.mutate({ commentId, emoji })
+    },
+    [toggleReaction]
+  )
+
   const shouldShowSocketWarning =
     isSocketMode &&
     (connectionStatus === "error" ||
@@ -358,7 +397,9 @@ export default function CommentList({
       >
         <div className="flex items-center gap-2">
           <MessageSquare size={15} className="text-blue-500" />
-          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">댓글</span>
+          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+            Comments
+          </span>
           {generalComments.length > 0 && (
             <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-600 dark:bg-blue-900/40 dark:text-blue-400">
               {generalComments.length}
@@ -382,8 +423,8 @@ export default function CommentList({
               <AlertCircle size={14} className="shrink-0" />
               <span>
                 {connectionStatus === "reconnecting"
-                  ? "실시간 연결을 다시 시도하고 있습니다."
-                  : "실시간 동기화가 지연될 수 있습니다."}
+                  ? "Realtime connection is reconnecting."
+                  : "Realtime sync may be delayed."}
                 {connectionError ? ` ${connectionError}` : ""}
               </span>
             </div>
@@ -396,12 +437,12 @@ export default function CommentList({
           >
             {isLoading ? (
               <div className="flex h-40 items-center justify-center text-sm text-slate-400">
-                댓글을 불러오는 중입니다...
+                Loading comments...
               </div>
             ) : generalComments.length === 0 ? (
               <div className="flex h-40 flex-col items-center justify-center gap-2 text-slate-400">
                 <MessageSquare size={30} className="opacity-20" />
-                <span className="text-sm">첫 번째 댓글을 남겨보세요.</span>
+                <span className="text-sm">Start the conversation</span>
               </div>
             ) : (
               generalComments.map((comment, index) => {
@@ -417,6 +458,7 @@ export default function CommentList({
                       currentUserId={currentUserId}
                       prId={prId}
                       showName={showName}
+                      onReaction={handleReaction}
                     />
                   </div>
                 )
@@ -429,13 +471,13 @@ export default function CommentList({
             <div className="flex items-center gap-1.5 border-t border-slate-100 bg-slate-50 px-4 py-1.5 text-[11px] text-slate-400 dark:border-slate-800 dark:bg-slate-950">
               <span>
                 {typingNames.length === 1
-                  ? `${typingNames[0]}님이 입력 중입니다`
-                  : `${typingNames[0]} 외 ${typingNames.length - 1}명이 입력 중입니다`}
+                  ? `${typingNames[0]} is typing`
+                  : `${typingNames[0]} and ${typingNames.length - 1} more are typing`}
               </span>
               <span className="flex items-end gap-0.5">
-                <span className="h-1 w-1 rounded-full bg-slate-400 animate-bounce [animation-delay:0ms]" />
-                <span className="h-1 w-1 rounded-full bg-slate-400 animate-bounce [animation-delay:150ms]" />
-                <span className="h-1 w-1 rounded-full bg-slate-400 animate-bounce [animation-delay:300ms]" />
+                <span className="h-1 w-1 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
+                <span className="h-1 w-1 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
+                <span className="h-1 w-1 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
               </span>
             </div>
           )}
@@ -452,9 +494,9 @@ export default function CommentList({
                 }}
                 onBlur={onTypingStop}
                 onKeyDown={handleKeyDown}
-                placeholder="댓글을 입력하세요. Enter 전송, Shift+Enter 줄바꿈"
+                placeholder="Write a comment. Enter to send, Shift+Enter for newline"
                 rows={1}
-                className="flex-1 resize-none overflow-hidden rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 transition focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                className="flex-1 resize-none overflow-hidden rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 transition placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
                 style={{ lineHeight: "1.5", minHeight: 38 }}
               />
               <button
@@ -462,7 +504,7 @@ export default function CommentList({
                 onClick={handleSend}
                 disabled={!input.trim() || createComment.isPending}
                 className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-blue-500 text-white shadow-sm transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
-                title="댓글 전송"
+                title="Send comment"
               >
                 {createComment.isPending ? (
                   <Loader2 size={15} className="animate-spin" />
@@ -475,7 +517,7 @@ export default function CommentList({
             {createComment.isPending && (
               <div className="mt-2 flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
                 <Loader2 size={12} className="animate-spin" />
-                댓글을 반영하는 중입니다...
+                Saving comment...
               </div>
             )}
           </div>

--- a/components/comment/CommentThread.tsx
+++ b/components/comment/CommentThread.tsx
@@ -26,7 +26,7 @@ export default function CommentThread({ comment, prId, currentUserId, mentionUse
   const createComment = useCreateComment(prId)
   const updateComment = useUpdateComment(prId)
   const deleteComment = useDeleteComment(prId)
-  const toggleReaction = useToggleReaction(prId)
+  const toggleReaction = useToggleReaction(prId, currentUserId)
   const toggleResolve = useToggleResolve(prId)
 
   const handleUpdate = (commentId: string, content: string) => {

--- a/components/comment/InlineCommentThread.tsx
+++ b/components/comment/InlineCommentThread.tsx
@@ -5,8 +5,12 @@ import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
 import { Loader2, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { useDeleteComment } from "@/hooks/useComments"
-import type { CommentWithAuthor } from "@/types/comment"
+import {
+  useDeleteComment,
+  useToggleReaction,
+} from "@/hooks/useComments"
+import type { CommentWithAuthor, ReactionEmoji } from "@/types/comment"
+import ReactionBar from "./ReactionBar"
 
 interface InlineCommentThreadProps {
   comments: CommentWithAuthor[]
@@ -20,64 +24,79 @@ export default function InlineCommentThread({
   prId,
 }: InlineCommentThreadProps) {
   const deleteComment = useDeleteComment(prId)
+  const toggleReaction = useToggleReaction(prId, currentUserId)
+
+  const handleReaction = (commentId: string, emoji: ReactionEmoji) => {
+    toggleReaction.mutate({ commentId, emoji })
+  }
 
   return (
-    <div className="bg-slate-50 dark:bg-slate-800/50 border-y border-slate-200 dark:border-slate-700 divide-y divide-slate-200 dark:divide-slate-700">
+    <div className="divide-y divide-slate-200 border-y border-slate-200 bg-slate-50 dark:divide-slate-700 dark:border-slate-700 dark:bg-slate-800/50">
       {comments.map((comment) => {
         const isDeletingComment =
           deleteComment.isPending && deleteComment.variables === comment.id
 
         return (
-        <div key={comment.id} id={`comment-${comment.id}`} className="px-4 py-3 flex gap-3">
-          <div className="shrink-0">
-            {comment.author.image ? (
-              <Image
-                src={comment.author.image}
-                alt={comment.author.name ?? ""}
-                width={24}
-                height={24}
-                className="rounded-full"
-              />
-            ) : (
-              <div className="w-6 h-6 rounded-full bg-slate-300 dark:bg-slate-600 flex items-center justify-center text-[10px] font-bold text-slate-600 dark:text-slate-300">
-                {comment.author.name?.[0]?.toUpperCase() ?? "?"}
-              </div>
-            )}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-semibold text-slate-800 dark:text-slate-200">
-                  {comment.author.name ?? "알 수 없음"}
-                </span>
-                <span className="text-[11px] text-slate-400">
-                  {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
-                </span>
-              </div>
-              {comment.authorId === currentUserId && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-5 px-1 text-rose-500 hover:text-rose-600 shrink-0"
-                  onClick={() => deleteComment.mutate(comment.id)}
-                  disabled={deleteComment.isPending}
-                >
-                  <Trash2 size={11} />
-                </Button>
+          <div key={comment.id} id={`comment-${comment.id}`} className="flex gap-3 px-4 py-3">
+            <div className="shrink-0">
+              {comment.author.image ? (
+                <Image
+                  src={comment.author.image}
+                  alt={comment.author.name ?? ""}
+                  width={24}
+                  height={24}
+                  className="rounded-full"
+                />
+              ) : (
+                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-slate-300 text-[10px] font-bold text-slate-600 dark:bg-slate-600 dark:text-slate-300">
+                  {comment.author.name?.[0]?.toUpperCase() ?? "?"}
+                </div>
               )}
             </div>
-            <p className="mt-0.5 text-xs text-slate-700 dark:text-slate-300 whitespace-pre-wrap">
-              {comment.content}
-            </p>
-            {isDeletingComment && (
-              <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 dark:text-slate-300">
-                <Loader2 size={11} className="animate-spin" />
-                삭제 중입니다...
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold text-slate-800 dark:text-slate-200">
+                    {comment.author.name ?? "이름 없음"}
+                  </span>
+                  <span className="text-[11px] text-slate-400">
+                    {formatDistanceToNow(new Date(comment.createdAt), {
+                      addSuffix: true,
+                      locale: ko,
+                    })}
+                  </span>
+                </div>
+                {comment.authorId === currentUserId && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-5 shrink-0 px-1 text-rose-500 hover:text-rose-600"
+                    onClick={() => deleteComment.mutate(comment.id)}
+                    disabled={deleteComment.isPending}
+                  >
+                    <Trash2 size={11} />
+                  </Button>
+                )}
               </div>
-            )}
+              <p className="mt-0.5 whitespace-pre-wrap text-xs text-slate-700 dark:text-slate-300">
+                {comment.content}
+              </p>
+              <ReactionBar
+                reactions={comment.reactions ?? {}}
+                currentUserId={currentUserId}
+                onToggle={(emoji) => handleReaction(comment.id, emoji)}
+                className="mt-2"
+              />
+              {isDeletingComment && (
+                <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 dark:text-slate-300">
+                  <Loader2 size={11} className="animate-spin" />
+                  삭제 중입니다...
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )})}
+        )
+      })}
     </div>
   )
 }

--- a/components/comment/ReactionBar.tsx
+++ b/components/comment/ReactionBar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { cn } from "@/lib/utils"
 import type { ReactionEmoji, Reactions } from "@/types/comment"
 
 const EMOJIS: ReactionEmoji[] = ["👍", "❤️", "🎉", "🚀", "👀"]
@@ -8,11 +9,19 @@ interface ReactionBarProps {
   reactions: Reactions
   currentUserId: string
   onToggle: (emoji: ReactionEmoji) => void
+  className?: string
+  disabled?: boolean
 }
 
-export default function ReactionBar({ reactions, currentUserId, onToggle }: ReactionBarProps) {
+export default function ReactionBar({
+  reactions,
+  currentUserId,
+  onToggle,
+  className,
+  disabled = false,
+}: ReactionBarProps) {
   return (
-    <div className="flex items-center gap-1 flex-wrap mt-1">
+    <div className={cn("mt-1 flex flex-wrap items-center gap-1", className)}>
       {EMOJIS.map((emoji) => {
         const users = reactions[emoji] ?? []
         const count = users.length
@@ -23,12 +32,16 @@ export default function ReactionBar({ reactions, currentUserId, onToggle }: Reac
         return (
           <button
             key={emoji}
+            type="button"
             onClick={() => onToggle(emoji)}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border transition-colors ${
+            disabled={disabled}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors",
               active
-                ? "bg-blue-50 border-blue-300 text-blue-700 dark:bg-blue-900/30 dark:border-blue-600 dark:text-blue-300"
-                : "bg-slate-50 border-slate-200 text-slate-600 hover:bg-slate-100 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700"
-            }`}
+                ? "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-600 dark:bg-blue-900/30 dark:text-blue-300"
+                : "border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700",
+              disabled && "cursor-not-allowed opacity-60"
+            )}
           >
             <span>{emoji}</span>
             {count > 0 && <span className="font-medium">{count}</span>}
@@ -36,18 +49,23 @@ export default function ReactionBar({ reactions, currentUserId, onToggle }: Reac
         )
       })}
 
-      {/* 이모지 추가 버튼 */}
-      <div className="relative group">
-        <button className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border border-dashed border-slate-300 text-slate-400 hover:border-slate-400 hover:text-slate-500 dark:border-slate-600 dark:text-slate-500 dark:hover:border-slate-500 transition-colors">
+      <div className="group relative">
+        <button
+          type="button"
+          disabled={disabled}
+          className="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 px-2 py-0.5 text-xs text-slate-400 transition-colors hover:border-slate-400 hover:text-slate-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:text-slate-500 dark:hover:border-slate-500"
+        >
           <span>+</span>
-          <span>😊</span>
+          <span>추가</span>
         </button>
-        <div className="absolute bottom-full left-0 mb-1 hidden group-focus-within:flex group-hover:flex bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg p-1.5 gap-1 z-10">
+        <div className="absolute bottom-full left-0 z-10 mb-1 hidden gap-1 rounded-xl border border-slate-200 bg-white p-1.5 shadow-lg group-hover:flex group-focus-within:flex dark:border-slate-700 dark:bg-slate-800">
           {EMOJIS.map((emoji) => (
             <button
               key={emoji}
+              type="button"
               onClick={() => onToggle(emoji)}
-              className="text-lg hover:scale-125 transition-transform p-0.5 rounded"
+              disabled={disabled}
+              className="rounded p-0.5 text-lg transition-transform hover:scale-125 disabled:cursor-not-allowed"
               title={emoji}
             >
               {emoji}

--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -1,4 +1,10 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  findCommentInThread,
+  normalizeComment,
+  toggleReactionForUser,
+  updateCommentReactionsInThread,
+} from "@/lib/comments/cache"
 import type {
   CommentWithAuthor,
   CommentsListResponse,
@@ -11,18 +17,6 @@ export interface CommentsFilter {
   repoId?: string
   prId?: string
   authorId?: string
-}
-
-function normalizeComment(comment: CommentWithAuthor): CommentWithAuthor {
-  return {
-    ...comment,
-    author: {
-      id: comment.author?.id ?? comment.authorId,
-      name: comment.author?.name ?? null,
-      image: comment.author?.image ?? null,
-    },
-    replies: Array.isArray(comment.replies) ? comment.replies.map(normalizeComment) : [],
-  }
 }
 
 async function fetchAllCommentsPage(
@@ -119,8 +113,9 @@ export function useDeleteComment(prId: string) {
   })
 }
 
-export function useToggleReaction(prId: string) {
+export function useToggleReaction(prId: string, currentUserId: string) {
   const queryClient = useQueryClient()
+
   return useMutation({
     mutationFn: async ({ commentId, emoji }: { commentId: string; emoji: ReactionEmoji }) => {
       const res = await fetch(`/api/comments/${commentId}/reactions`, {
@@ -130,10 +125,48 @@ export function useToggleReaction(prId: string) {
       })
       if (!res.ok) throw new Error("Failed to toggle reaction.")
       const data = await res.json()
-      return data.comment as CommentWithAuthor
+      return normalizeComment(data.comment as CommentWithAuthor)
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["comments", prId] })
+    onMutate: async ({ commentId, emoji }) => {
+      await queryClient.cancelQueries({ queryKey: ["comments", prId] })
+
+      const previousComments = queryClient.getQueryData<CommentWithAuthor[]>([
+        "comments",
+        prId,
+      ])
+
+      if (!previousComments) {
+        return { previousComments }
+      }
+
+      const targetComment = findCommentInThread(previousComments, commentId)
+      if (!targetComment) {
+        return { previousComments }
+      }
+
+      const nextReactions = toggleReactionForUser(
+        targetComment.reactions ?? {},
+        emoji,
+        currentUserId
+      )
+
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old ? updateCommentReactionsInThread(old, commentId, nextReactions) : old
+      )
+
+      return { previousComments }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousComments) {
+        queryClient.setQueryData(["comments", prId], context.previousComments)
+      }
+    },
+    onSuccess: (comment) => {
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old
+          ? updateCommentReactionsInThread(old, comment.id, comment.reactions ?? {})
+          : old
+      )
     },
   })
 }

--- a/hooks/useRealtimeComments.ts
+++ b/hooks/useRealtimeComments.ts
@@ -2,6 +2,13 @@
 
 import { useCallback, useEffect } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  appendCommentToThread,
+  normalizeComment,
+  removeCommentFromThread,
+  replaceCommentInThread,
+  updateCommentReactionsInThread,
+} from "@/lib/comments/cache"
 import type { CommentWithAuthor } from "@/types/comment"
 import {
   recordHandlerInvocation,
@@ -9,18 +16,6 @@ import {
   recordHandlerRemoved,
 } from "@/lib/measurements/socketMetrics"
 import { useSocketRoom } from "./useSocketRoom"
-
-function normalizeComment(comment: CommentWithAuthor): CommentWithAuthor {
-  return {
-    ...comment,
-    author: {
-      id: comment.author?.id ?? comment.authorId,
-      name: comment.author?.name ?? null,
-      image: comment.author?.image ?? null,
-    },
-    replies: Array.isArray(comment.replies) ? comment.replies.map(normalizeComment) : [],
-  }
-}
 
 async function fetchComments(prId: string): Promise<CommentWithAuthor[]> {
   const res = await fetch(`/api/pulls/${prId}/comments`)
@@ -30,30 +25,6 @@ async function fetchComments(prId: string): Promise<CommentWithAuthor[]> {
 }
 
 const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
-
-function appendComment(
-  comments: CommentWithAuthor[],
-  comment: CommentWithAuthor
-): CommentWithAuthor[] {
-  const normalizedComment = normalizeComment(comment)
-
-  if (normalizedComment.parentId == null) {
-    if (comments.some((item) => item.id === normalizedComment.id)) return comments
-    return [...comments, normalizedComment]
-  }
-
-  return comments.map((item) => {
-    const replies = Array.isArray(item.replies) ? item.replies : []
-
-    if (item.id === normalizedComment.parentId) {
-      if (replies.some((reply) => reply.id === normalizedComment.id)) return item
-      return { ...item, replies: [...replies, normalizedComment] }
-    }
-
-    if (replies.length === 0) return item
-    return { ...item, replies: appendComment(replies, normalizedComment) }
-  })
-}
 
 export function useRealtimeComments(prId: string) {
   const socket = useSocketRoom(prId)
@@ -69,7 +40,7 @@ export function useRealtimeComments(prId: string) {
     (comment: CommentWithAuthor) => {
       recordHandlerInvocation("comment:new")
       queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
-        old ? appendComment(old, comment) : [normalizeComment(comment)]
+        old ? appendCommentToThread(old, comment) : [normalizeComment(comment)]
       )
     },
     [queryClient, prId]
@@ -82,19 +53,7 @@ export function useRealtimeComments(prId: string) {
         const normalizedComment = normalizeComment(comment)
         if (!old) return [normalizedComment]
 
-        return old.map((item) => {
-          if (item.id === normalizedComment.id) return normalizedComment
-
-          const replies = Array.isArray(item.replies) ? item.replies : []
-          if (replies.length === 0) return item
-
-          return {
-            ...item,
-            replies: replies.map((reply) =>
-              reply.id === normalizedComment.id ? normalizedComment : reply
-            ),
-          }
-        })
+        return replaceCommentInThread(old, normalizedComment)
       })
     },
     [queryClient, prId]
@@ -104,14 +63,24 @@ export function useRealtimeComments(prId: string) {
     ({ commentId }: { commentId: string; prId: string }) => {
       recordHandlerInvocation("comment:deleted")
       queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
-        old
-          ? old
-              .filter((item) => item.id !== commentId)
-              .map((item) => ({
-                ...item,
-                replies: (item.replies ?? []).filter((reply) => reply.id !== commentId),
-              }))
-          : []
+        old ? removeCommentFromThread(old, commentId) : []
+      )
+    },
+    [queryClient, prId]
+  )
+
+  const handleReactionUpdated = useCallback(
+    ({
+      commentId,
+      reactions,
+    }: {
+      commentId: string
+      prId: string
+      reactions: CommentWithAuthor["reactions"]
+    }) => {
+      recordHandlerInvocation("comment:reaction-updated")
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old ? updateCommentReactionsInThread(old, commentId, reactions) : old
       )
     },
     [queryClient, prId]
@@ -123,19 +92,23 @@ export function useRealtimeComments(prId: string) {
     recordHandlerRegistered("comment:new")
     recordHandlerRegistered("comment:updated")
     recordHandlerRegistered("comment:deleted")
+    recordHandlerRegistered("comment:reaction-updated")
     socket.on("comment:new", handleNew)
     socket.on("comment:updated", handleUpdated)
     socket.on("comment:deleted", handleDeleted)
+    socket.on("comment:reaction-updated", handleReactionUpdated)
 
     return () => {
       socket.off("comment:new", handleNew)
       socket.off("comment:updated", handleUpdated)
       socket.off("comment:deleted", handleDeleted)
+      socket.off("comment:reaction-updated", handleReactionUpdated)
       recordHandlerRemoved("comment:new")
       recordHandlerRemoved("comment:updated")
       recordHandlerRemoved("comment:deleted")
+      recordHandlerRemoved("comment:reaction-updated")
     }
-  }, [socket, handleDeleted, handleNew, handleUpdated])
+  }, [socket, handleDeleted, handleNew, handleReactionUpdated, handleUpdated])
 
   return query
 }

--- a/lib/comments/cache.ts
+++ b/lib/comments/cache.ts
@@ -1,0 +1,144 @@
+import type {
+  CommentWithAuthor,
+  ReactionEmoji,
+  Reactions,
+} from "@/types/comment"
+
+export function normalizeComment(comment: CommentWithAuthor): CommentWithAuthor {
+  return {
+    ...comment,
+    author: {
+      id: comment.author?.id || comment.authorId,
+      name: comment.author?.name ?? null,
+      image: comment.author?.image ?? null,
+    },
+    replies: Array.isArray(comment.replies)
+      ? comment.replies.map(normalizeComment)
+      : [],
+  }
+}
+
+function mapCommentTree(
+  comments: CommentWithAuthor[],
+  updater: (comment: CommentWithAuthor) => CommentWithAuthor
+): CommentWithAuthor[] {
+  return comments.map((comment) => {
+    const nextComment = updater(comment)
+    const replies = Array.isArray(nextComment.replies) ? nextComment.replies : []
+
+    if (replies.length === 0) return nextComment
+
+    return {
+      ...nextComment,
+      replies: mapCommentTree(replies, updater),
+    }
+  })
+}
+
+export function appendCommentToThread(
+  comments: CommentWithAuthor[],
+  comment: CommentWithAuthor
+): CommentWithAuthor[] {
+  const normalizedComment = normalizeComment(comment)
+
+  if (normalizedComment.parentId == null) {
+    if (comments.some((item) => item.id === normalizedComment.id)) {
+      return comments
+    }
+
+    return [...comments, normalizedComment]
+  }
+
+  return mapCommentTree(comments, (item) => {
+    if (item.id !== normalizedComment.parentId) return item
+
+    const replies = Array.isArray(item.replies) ? item.replies : []
+    if (replies.some((reply) => reply.id === normalizedComment.id)) {
+      return item
+    }
+
+    return {
+      ...item,
+      replies: [...replies, normalizedComment],
+    }
+  })
+}
+
+export function replaceCommentInThread(
+  comments: CommentWithAuthor[],
+  comment: CommentWithAuthor
+): CommentWithAuthor[] {
+  const normalizedComment = normalizeComment(comment)
+
+  return mapCommentTree(comments, (item) =>
+    item.id === normalizedComment.id
+      ? {
+          ...normalizedComment,
+          replies:
+            normalizedComment.replies.length > 0
+              ? normalizedComment.replies
+              : item.replies,
+        }
+      : item
+  )
+}
+
+export function removeCommentFromThread(
+  comments: CommentWithAuthor[],
+  commentId: string
+): CommentWithAuthor[] {
+  return comments
+    .filter((comment) => comment.id !== commentId)
+    .map((comment) => ({
+      ...comment,
+      replies: removeCommentFromThread(comment.replies ?? [], commentId),
+    }))
+}
+
+export function updateCommentReactionsInThread(
+  comments: CommentWithAuthor[],
+  commentId: string,
+  reactions: Reactions
+): CommentWithAuthor[] {
+  return mapCommentTree(comments, (comment) =>
+    comment.id === commentId
+      ? {
+          ...comment,
+          reactions,
+        }
+      : comment
+  )
+}
+
+export function findCommentInThread(
+  comments: CommentWithAuthor[],
+  commentId: string
+): CommentWithAuthor | null {
+  for (const comment of comments) {
+    if (comment.id === commentId) return comment
+
+    const replies = Array.isArray(comment.replies) ? comment.replies : []
+    if (replies.length === 0) continue
+
+    const nested = findCommentInThread(replies, commentId)
+    if (nested) return nested
+  }
+
+  return null
+}
+
+export function toggleReactionForUser(
+  reactions: Reactions,
+  emoji: ReactionEmoji,
+  userId: string
+): Reactions {
+  const currentUsers = reactions[emoji] ?? []
+  const nextUsers = currentUsers.includes(userId)
+    ? currentUsers.filter((id) => id !== userId)
+    : [...currentUsers, userId]
+
+  return {
+    ...reactions,
+    [emoji]: nextUsers,
+  }
+}

--- a/lib/measurements/socketMetrics.ts
+++ b/lib/measurements/socketMetrics.ts
@@ -4,6 +4,7 @@ export const SOCKET_METRIC_EVENTS = [
   "comment:new",
   "comment:updated",
   "comment:deleted",
+  "comment:reaction-updated",
   "notification:new",
   "typing:start",
   "typing:stop",

--- a/lib/socket/emitter.ts
+++ b/lib/socket/emitter.ts
@@ -1,4 +1,4 @@
-import type { CommentWithAuthor } from "@/types/comment"
+import type { CommentWithAuthor, Reactions } from "@/types/comment"
 import type { BaseNotification } from "@/types/notification"
 
 function serialize<T>(data: unknown): T {
@@ -36,6 +36,18 @@ export function emitCommentUpdated(prId: string, comment: unknown) {
 
 export function emitCommentDeleted(prId: string, commentId: string) {
   emitToSocket(`pr:${prId}`, "comment:deleted", { commentId, prId })
+}
+
+export function emitCommentReactionUpdated(
+  prId: string,
+  commentId: string,
+  reactions: Reactions
+) {
+  emitToSocket(`pr:${prId}`, "comment:reaction-updated", {
+    commentId,
+    prId,
+    reactions: serialize<Reactions>(reactions),
+  })
 }
 
 export function emitNotification(userId: string, notification: BaseNotification) {

--- a/lib/socket/types.ts
+++ b/lib/socket/types.ts
@@ -1,12 +1,17 @@
 import type { Server, Socket } from "socket.io"
 import type { Socket as ClientSocket } from "socket.io-client"
-import type { CommentWithAuthor } from "@/types/comment"
+import type { CommentWithAuthor, Reactions } from "@/types/comment"
 import type { BaseNotification } from "@/types/notification"
 
 export interface ServerToClientEvents {
   "comment:new": (comment: CommentWithAuthor) => void
   "comment:updated": (comment: CommentWithAuthor) => void
   "comment:deleted": (data: { commentId: string; prId: string }) => void
+  "comment:reaction-updated": (data: {
+    commentId: string
+    prId: string
+    reactions: Reactions
+  }) => void
   "typing:start": (data: { userId: string; userName: string }) => void
   "typing:stop": (data: { userId: string }) => void
   "inline:typing:start": (data: { userId: string; userName: string; filePath: string; lineNumber: number }) => void


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

댓글 반응(이모지) 추가/제거가 같은 PR을 보고 있는 다른 사용자 화면에도 즉시 반영되도록 실시간 동기화를 구현했습니다.

## 변경 사항

- 댓글 반응 변경 전용 socket event `comment:reaction-updated` 추가
- 반응 API에서 DB 업데이트 후 realtime emit 수행
- `useRealtimeComments`에서 반응 이벤트 수신 후 해당 댓글의 `reactions`만 patch 하도록 변경
- `useToggleReaction`에 optimistic update와 rollback 추가
- 실제 사용 중인 일반 댓글 UI `CommentList`에 반응 바 연결
- 인라인 댓글 UI `InlineCommentThread`에도 동일한 반응 UX 연결
- 댓글 트리 캐시 조작 로직을 `lib/comments/cache.ts`로 공통화
- 반응 API route 테스트와 댓글 캐시 유틸 테스트 추가

## 스크린샷 (선택)

UI 스크린샷은 생략했습니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

추가 실행:
- `npx.cmd jest --runInBand --runTestsByPath '__tests__/api/comments/[id]/reactions/route.test.ts' '__tests__/lib/comments/cache.test.ts'`
- `npx.cmd eslint lib/comments/cache.ts hooks/useComments.ts hooks/useRealtimeComments.ts components/comment/ReactionBar.tsx components/comment/CommentList.tsx components/comment/InlineCommentThread.tsx components/comment/CommentThread.tsx lib/socket/types.ts lib/socket/emitter.ts lib/measurements/socketMetrics.ts '__tests__/api/comments/[id]/reactions/route.test.ts' '__tests__/lib/comments/cache.test.ts' --no-error-on-unmatched-pattern`

참고:
- `npx.cmd tsc --noEmit --pretty false` 는 저장소의 기존 타입 오류들 때문에 전체 통과하지 못했습니다.

## 참고 사항

- 관련 이슈: #146
- 이번 PR은 댓글 반응 동기화 범위만 분리해 커밋했습니다.