### PR TITLE
feat: 통계 페이지 상태 세분화 및 소켓 연결 상태 UI 강화 (#148)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,12 @@ This file is the Codex-facing companion to `CLAUDE.md`.
 
 - Check for existing local changes before branching or committing.
 - Avoid mixing unrelated workspace changes into GitHub work.
+
+## Implementation Requests
+
+- When the user asks to "implement", including short Korean implementation requests, default to actually making the code changes unless they explicitly want only an explanation.
+- In the final response for implementation work, clearly list which existing files were changed.
+- Provide the full updated code for every changed file, not partial snippets.
+- Explain the reason for each file change based on the code.
+- If multiple files changed, organize the explanation and code file-by-file.
+- Prefer refactors that make the resulting structure easier to follow, and mention any folder or structure changes when they help.

--- a/app/(protected)/stats/page.tsx
+++ b/app/(protected)/stats/page.tsx
@@ -1,21 +1,32 @@
 import type { Metadata } from "next"
 import { auth } from "@/lib/auth"
-import { prisma } from "@/lib/prisma"
-import { fetchStatsOverview } from "@/lib/stats"
-import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
 import StatsClient from "@/components/stats/StatsClient"
+import { prisma } from "@/lib/prisma"
+import { buildAccessibleRepositoryWhere } from "@/lib/repository-access"
+import { fetchStatsOverview, type StatsOverview } from "@/lib/stats"
 
 export const metadata: Metadata = {
-  title: "코드 통계",
-  description: "코드 품질 지표와 리뷰 통계를 분석합니다.",
+  title: "Code Stats",
+  description: "Analyze quality trends, review insights, and pull request activity.",
+}
+
+const EMPTY_OVERVIEW: StatsOverview = {
+  totalPRs: 0,
+  mergedPRs: 0,
+  mergeRate: 0,
+  avgQualityScore: 0,
+  totalIssues: 0,
+  resolvedComments: 0,
+  totalComments: 0,
 }
 
 export default async function StatsPage() {
   const session = await auth()
   if (!session?.user?.id) return null
+
   const repositoryWhere = await buildAccessibleRepositoryWhere(session.user.id)
 
-  const [overview, repos] = await Promise.all([
+  const [overviewResult, reposResult] = await Promise.allSettled([
     fetchStatsOverview(session.user.id, "30d"),
     prisma.repository.findMany({
       where: repositoryWhere,
@@ -24,5 +35,23 @@ export default async function StatsPage() {
     }),
   ])
 
-  return <StatsClient initialOverview={overview} repos={repos} />
+  const initialOverview =
+    overviewResult.status === "fulfilled"
+      ? overviewResult.value
+      : EMPTY_OVERVIEW
+
+  const initialOverviewError =
+    overviewResult.status === "rejected"
+      ? "Failed to load overview metrics on the first render."
+      : null
+
+  const repos = reposResult.status === "fulfilled" ? reposResult.value : []
+
+  return (
+    <StatsClient
+      initialOverview={initialOverview}
+      initialOverviewError={initialOverviewError}
+      repos={repos}
+    />
+  )
 }

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,12 +1,12 @@
 import { auth } from "@/lib/auth"
 import { NextResponse } from "next/server"
 import {
-  isValidRange,
-  fetchStatsOverview,
+  fetchCodeChanges,
+  fetchIssueDistribution,
   fetchPRTrend,
   fetchQualityTrend,
-  fetchIssueDistribution,
-  fetchCodeChanges,
+  fetchStatsOverview,
+  isValidRange,
   VALID_TYPES,
   type StatsRange,
   type StatsType,
@@ -16,39 +16,10 @@ import {
  * @swagger
  * /api/stats:
  *   get:
- *     summary: 통계 데이터 조회
- *     description: PR / 코드 품질 / 이슈 등 통계 데이터를 반환합니다. type 파라미터로 조회 유형을 선택합니다.
+ *     summary: Retrieve stats data
+ *     description: Returns one stats payload at a time based on the `type` query parameter.
  *     tags:
  *       - Stats
- *     parameters:
- *       - in: query
- *         name: type
- *         schema:
- *           type: string
- *           enum: [overview, pr-trend, quality-trend, issue-distribution, code-changes]
- *           default: overview
- *         description: 조회할 통계 유형
- *       - in: query
- *         name: range
- *         schema:
- *           type: string
- *           enum: [7d, 30d, 90d, all]
- *           default: 30d
- *         description: 조회 기간
- *       - in: query
- *         name: repoId
- *         schema:
- *           type: string
- *         description: 특정 저장소 ID로 필터링 (없으면 전체 저장소 합산)
- *     responses:
- *       200:
- *         description: 통계 데이터 조회 성공
- *       400:
- *         description: 유효하지 않은 파라미터
- *       401:
- *         description: 인증되지 않은 사용자
- *       500:
- *         description: 서버 내부 오류
  */
 export async function GET(request: Request) {
   try {
@@ -58,14 +29,14 @@ export async function GET(request: Request) {
     }
 
     const { searchParams } = new URL(request.url)
-    const type = searchParams.get("type") ?? "overview"
+    const typeParam = searchParams.get("type") ?? "overview"
     const rangeParam = searchParams.get("range") ?? "30d"
     const repoId = searchParams.get("repoId") ?? undefined
 
-    if (!VALID_TYPES.includes(type as StatsType)) {
+    if (!VALID_TYPES.includes(typeParam as StatsType)) {
       return NextResponse.json(
         {
-          error: `유효하지 않은 type 값입니다. 허용값: ${VALID_TYPES.join(", ")}`,
+          error: `Invalid stats type. Supported values: ${VALID_TYPES.join(", ")}`,
         },
         { status: 400 }
       )
@@ -73,38 +44,37 @@ export async function GET(request: Request) {
 
     if (!isValidRange(rangeParam)) {
       return NextResponse.json(
-        { error: "유효하지 않은 range 값입니다. 허용값: 7d, 30d, 90d, all" },
+        {
+          error: "Invalid stats range. Supported values: 7d, 30d, 90d, all",
+        },
         { status: 400 }
       )
     }
 
-    const range = rangeParam as StatsRange
     const userId = session.user.id
+    const range = rangeParam as StatsRange
+    const type = typeParam as StatsType
 
-    switch (type as StatsType) {
-      case "overview":
-        return NextResponse.json(
-          await fetchStatsOverview(userId, range, repoId)
-        )
-      case "pr-trend":
-        return NextResponse.json({
-          data: await fetchPRTrend(userId, range, repoId),
-        })
-      case "quality-trend":
-        return NextResponse.json({
-          data: await fetchQualityTrend(userId, range, repoId),
-        })
-      case "issue-distribution":
-        return NextResponse.json(
-          await fetchIssueDistribution(userId, range, repoId)
-        )
-      case "code-changes":
-        return NextResponse.json({
-          data: await fetchCodeChanges(userId, range, repoId),
-        })
+    const handlers: Record<StatsType, () => Promise<unknown>> = {
+      overview: () => fetchStatsOverview(userId, range, repoId),
+      "pr-trend": async () => ({
+        data: await fetchPRTrend(userId, range, repoId),
+      }),
+      "quality-trend": async () => ({
+        data: await fetchQualityTrend(userId, range, repoId),
+      }),
+      "issue-distribution": () => fetchIssueDistribution(userId, range, repoId),
+      "code-changes": async () => ({
+        data: await fetchCodeChanges(userId, range, repoId),
+      }),
     }
-  } catch (err) {
-    console.error("[GET /api/stats]", err)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+
+    return NextResponse.json(await handlers[type]())
+  } catch (error) {
+    console.error("[GET /api/stats]", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
   }
 }

--- a/components/comment/CommentList.tsx
+++ b/components/comment/CommentList.tsx
@@ -11,13 +11,21 @@ import {
 } from "lucide-react"
 import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
-import { useCreateComment, useDeleteComment } from "@/hooks/useComments"
+import {
+  useCreateComment,
+  useDeleteComment,
+  useToggleReaction,
+} from "@/hooks/useComments"
 import { usePRDetail } from "@/hooks/usePRDetail"
 import { useRealtimeComments } from "@/hooks/useRealtimeComments"
 import { useTypingIndicator } from "@/hooks/useTypingIndicator"
 import { recordRender } from "@/lib/measurements/renderCounter"
 import { cn } from "@/lib/utils"
-import type { CommentWithAuthor, MentionUser } from "@/types/comment"
+import type {
+  CommentWithAuthor,
+  MentionUser,
+  ReactionEmoji,
+} from "@/types/comment"
 import {
   SocketConnectionBadge,
   SocketConnectionNotice,
@@ -309,6 +317,13 @@ export default function CommentList({
       handleSend()
     }
   }
+
+  const handleReaction = useCallback(
+    (commentId: string, emoji: ReactionEmoji) => {
+      toggleReaction.mutate({ commentId, emoji })
+    },
+    [toggleReaction]
+  )
 
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">

--- a/components/comment/CommentList.tsx
+++ b/components/comment/CommentList.tsx
@@ -3,34 +3,31 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Image from "next/image"
 import {
-  AlertCircle,
   ChevronDown,
   Loader2,
   MessageSquare,
   Send,
   Trash2,
-  Wifi,
-  WifiOff,
 } from "lucide-react"
 import { formatDistanceToNow } from "date-fns"
 import { ko } from "date-fns/locale"
-import { Badge } from "@/components/ui/badge"
 import { useCreateComment, useDeleteComment } from "@/hooks/useComments"
 import { usePRDetail } from "@/hooks/usePRDetail"
 import { useRealtimeComments } from "@/hooks/useRealtimeComments"
-import { useSocket } from "@/hooks/useSocket"
 import { useTypingIndicator } from "@/hooks/useTypingIndicator"
 import { recordRender } from "@/lib/measurements/renderCounter"
 import { cn } from "@/lib/utils"
 import type { CommentWithAuthor, MentionUser } from "@/types/comment"
+import {
+  SocketConnectionBadge,
+  SocketConnectionNotice,
+} from "@/components/realtime/SocketConnectionStatus"
 import CommentRenderMetricsPanel from "./CommentRenderMetricsPanel"
 
 interface CommentListProps {
   prId: string
   currentUserId: string
 }
-
-const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
 
 function isOptimisticComment(commentId: string) {
   return commentId.startsWith("optimistic-comment-")
@@ -57,59 +54,6 @@ function renderContent(content: string, isOwn: boolean) {
       </span>
     )
   })
-}
-
-function ConnectionBadge() {
-  const { connectionStatus, connectionError } = useSocket()
-
-  if (!isSocketMode) {
-    return (
-      <Badge
-        variant="outline"
-        className="gap-1 border-slate-200 bg-white/80 text-slate-500 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300"
-      >
-        <span className="size-1.5 rounded-full bg-slate-400" />
-        폴링 모드
-      </Badge>
-    )
-  }
-
-  if (connectionStatus === "connected") {
-    return (
-      <Badge className="gap-1 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/10 dark:bg-emerald-500/15 dark:text-emerald-300">
-        <Wifi size={12} />
-        실시간 연결
-      </Badge>
-    )
-  }
-
-  if (connectionStatus === "connecting" || connectionStatus === "reconnecting") {
-    return (
-      <Badge className="gap-1 bg-blue-500/10 text-blue-700 hover:bg-blue-500/10 dark:bg-blue-500/15 dark:text-blue-300">
-        <Loader2 size={12} className="animate-spin" />
-        {connectionStatus === "connecting" ? "연결 중" : "재연결 중"}
-      </Badge>
-    )
-  }
-
-  if (connectionStatus === "error") {
-    return (
-      <Badge
-        className="gap-1 bg-rose-500/10 text-rose-700 hover:bg-rose-500/10 dark:bg-rose-500/15 dark:text-rose-300"
-        title={connectionError ?? "소켓 연결 오류"}
-      >
-        <AlertCircle size={12} />
-        연결 오류
-      </Badge>
-    )
-  }
-
-  return (
-    <Badge className="gap-1 bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300">
-      <WifiOff size={12} />
-      연결 끊김
-    </Badge>
-  )
 }
 
 function ChatBubble({
@@ -168,7 +112,7 @@ function ChatBubble({
         <div className={cn("flex items-end gap-1", isOwn ? "flex-row-reverse" : "flex-row")}>
           <div
             className={cn(
-              "relative px-3.5 py-2 text-sm leading-relaxed break-words shadow-sm transition-opacity",
+              "relative break-words px-3.5 py-2 text-sm leading-relaxed shadow-sm transition-opacity",
               isOwn
                 ? "rounded-[18px] rounded-br-[4px] bg-blue-500 text-white"
                 : "rounded-[18px] rounded-bl-[4px] border border-slate-100 bg-white text-slate-800 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100",
@@ -278,7 +222,6 @@ export default function CommentList({
   const { data: allComments = [], isLoading } = useRealtimeComments(prId)
   const createComment = useCreateComment(prId)
   const { names: typingNames, onTyping, onTypingStop } = useTypingIndicator(prId)
-  const { connectionStatus, connectionError } = useSocket()
   const { data: pr } = usePRDetail(prId)
   const [open, setOpen] = useState(true)
   const [input, setInput] = useState("")
@@ -343,12 +286,6 @@ export default function CommentList({
     }
   }
 
-  const shouldShowSocketWarning =
-    isSocketMode &&
-    (connectionStatus === "error" ||
-      connectionStatus === "disconnected" ||
-      connectionStatus === "reconnecting")
-
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <button
@@ -364,7 +301,7 @@ export default function CommentList({
               {generalComments.length}
             </span>
           )}
-          <ConnectionBadge />
+          <SocketConnectionBadge />
         </div>
         <ChevronDown
           size={15}
@@ -377,17 +314,7 @@ export default function CommentList({
 
       {open && (
         <>
-          {shouldShowSocketWarning && (
-            <div className="flex items-center gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300">
-              <AlertCircle size={14} className="shrink-0" />
-              <span>
-                {connectionStatus === "reconnecting"
-                  ? "실시간 연결을 다시 시도하고 있습니다."
-                  : "실시간 동기화가 지연될 수 있습니다."}
-                {connectionError ? ` ${connectionError}` : ""}
-              </span>
-            </div>
-          )}
+          <SocketConnectionNotice />
 
           <div
             onScroll={handleScroll}

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth"
 import { SidebarTrigger } from "@/components/ui/sidebar"
 import NotificationBell from "@/components/notification/NotificationBell"
+import { SocketConnectionBadge } from "@/components/realtime/SocketConnectionStatus"
 import HeaderSearch from "./HeaderSearch"
 import HeaderProfile from "./HeaderProfile"
 
@@ -17,6 +18,7 @@ export default async function AppHeader() {
         </div>
       </div>
       <div className="flex items-center gap-2 md:gap-4">
+        <SocketConnectionBadge className="hidden lg:inline-flex" />
         <HeaderSearch />
         <NotificationBell />
         <HeaderProfile

--- a/components/pulls/detail/PRDetailHeader.tsx
+++ b/components/pulls/detail/PRDetailHeader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { ChevronLeft, FileText, Clock } from "lucide-react";
 import { timeAgo } from "@/lib/date";
 import { PR_STATUS_STYLE } from "@/constants/pulls";
+import { SocketConnectionBadge } from "@/components/realtime/SocketConnectionStatus";
 import BranchChip from "./BranchChip";
 import type { PullRequest } from "@/types/pulls";
 
@@ -35,6 +36,8 @@ export default function PRDetailHeader({ pr, scrolled = false }: PRDetailHeaderP
           <span className={`px-2 py-0.5 rounded-full border text-[9px] font-black uppercase tracking-wider shrink-0 ${PR_STATUS_STYLE[pr.status]}`}>
             {pr.status}
           </span>
+
+          <SocketConnectionBadge className="hidden md:inline-flex" />
 
           <h1 className="text-xs md:text-sm font-bold text-slate-900 dark:text-white truncate flex-1 min-w-0">
             {pr.title}
@@ -94,6 +97,7 @@ export default function PRDetailHeader({ pr, scrolled = false }: PRDetailHeaderP
           {/* 우측: 통계 + 시간 */}
           <div className="flex flex-row md:flex-col items-center md:items-end justify-between md:justify-start gap-3 border-t md:border-t-0 pt-3 md:pt-0 border-slate-100 dark:border-slate-800">
             <div className="flex items-center gap-2 text-[10px] md:text-xs font-bold">
+              <SocketConnectionBadge className="hidden md:inline-flex" />
               <span className="px-2 py-1 bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 rounded-full border border-emerald-100 dark:border-emerald-500/20">
                 +{pr.additions}
               </span>

--- a/components/realtime/SocketConnectionStatus.tsx
+++ b/components/realtime/SocketConnectionStatus.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { AlertCircle, Loader2, Wifi, WifiOff } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { useSocket } from "@/hooks/useSocket"
+import { cn } from "@/lib/utils"
+
+interface SocketConnectionBadgeProps {
+  className?: string
+}
+
+interface SocketConnectionNoticeProps {
+  className?: string
+}
+
+function getSocketStatusPresentation(params: {
+  realtimeEnabled: boolean
+  connectionStatus: ReturnType<typeof useSocket>["connectionStatus"]
+  fallbackActive: boolean
+  connectionError: string | null
+}) {
+  const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } = params
+
+  if (!realtimeEnabled) {
+    return {
+      badgeLabel: "Polling",
+      badgeClassName:
+        "border-slate-200 bg-white/80 text-slate-500 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300",
+      BadgeIcon: WifiOff,
+      notice: null,
+    }
+  }
+
+  if (connectionStatus === "connected") {
+    return {
+      badgeLabel: fallbackActive ? "Recovering" : "Realtime",
+      badgeClassName:
+        "bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/10 dark:bg-emerald-500/15 dark:text-emerald-300",
+      BadgeIcon: Wifi,
+      notice: null,
+    }
+  }
+
+  if (fallbackActive) {
+    return {
+      badgeLabel: "Polling Fallback",
+      badgeClassName:
+        "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300",
+      BadgeIcon: WifiOff,
+      notice: connectionError
+        ? `Realtime sync is unavailable, so polling fallback is active. ${connectionError}`
+        : "Realtime sync is unavailable, so polling fallback is active.",
+    }
+  }
+
+  if (connectionStatus === "connecting" || connectionStatus === "reconnecting") {
+    return {
+      badgeLabel: connectionStatus === "connecting" ? "Connecting" : "Reconnecting",
+      badgeClassName:
+        "bg-blue-500/10 text-blue-700 hover:bg-blue-500/10 dark:bg-blue-500/15 dark:text-blue-300",
+      BadgeIcon: Loader2,
+      notice:
+        connectionStatus === "reconnecting"
+          ? "Realtime connection is reconnecting."
+          : null,
+    }
+  }
+
+  if (connectionStatus === "error") {
+    return {
+      badgeLabel: "Socket Error",
+      badgeClassName:
+        "bg-rose-500/10 text-rose-700 hover:bg-rose-500/10 dark:bg-rose-500/15 dark:text-rose-300",
+      BadgeIcon: AlertCircle,
+      notice: connectionError
+        ? `Socket connection failed. ${connectionError}`
+        : "Socket connection failed.",
+    }
+  }
+
+  return {
+    badgeLabel: "Offline",
+    badgeClassName:
+      "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300",
+    BadgeIcon: WifiOff,
+    notice: "Realtime connection was lost. Waiting to reconnect.",
+  }
+}
+
+export function SocketConnectionBadge({
+  className,
+}: SocketConnectionBadgeProps) {
+  const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } =
+    useSocket()
+
+  const presentation = getSocketStatusPresentation({
+    realtimeEnabled,
+    connectionStatus,
+    fallbackActive,
+    connectionError,
+  })
+
+  return (
+    <Badge className={cn("gap-1", presentation.badgeClassName, className)}>
+      <presentation.BadgeIcon
+        size={12}
+        className={presentation.BadgeIcon === Loader2 ? "animate-spin" : undefined}
+      />
+      {presentation.badgeLabel}
+    </Badge>
+  )
+}
+
+export function SocketConnectionNotice({
+  className,
+}: SocketConnectionNoticeProps) {
+  const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } =
+    useSocket()
+
+  const presentation = getSocketStatusPresentation({
+    realtimeEnabled,
+    connectionStatus,
+    fallbackActive,
+    connectionError,
+  })
+
+  if (!presentation.notice) return null
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300",
+        className
+      )}
+    >
+      <AlertCircle size={14} className="shrink-0" />
+      <span>{presentation.notice}</span>
+    </div>
+  )
+}

--- a/components/stats/StatsClient.tsx
+++ b/components/stats/StatsClient.tsx
@@ -1,29 +1,38 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
-import type {
-  StatsRange,
-  StatsOverview,
-  PRTrendItem,
-  QualityTrendItem,
-  IssueDistribution,
-  CodeChangesItem,
-} from "@/lib/stats"
+import { useCallback, useEffect, useRef, useState } from "react"
 import dynamic from "next/dynamic"
-import { Skeleton } from "@/components/ui/skeleton"
 import { PageContainer } from "@/components/layout/PageContainer"
 import { layoutStyles } from "@/lib/styles"
+import type {
+  CodeChangesItem,
+  IssueDistribution,
+  PRTrendItem,
+  QualityTrendItem,
+  StatsOverview,
+  StatsRange,
+} from "@/lib/stats"
 import StatsHeader from "./StatsHeader"
 import StatsSummaryCards from "./StatsSummaryCards"
 
-const ChartSkeleton = () => <Skeleton className="h-64 w-full rounded-lg" />
-
-const PRTrendChart       = dynamic(() => import("./charts/PRTrendChart"),       { ssr: false, loading: ChartSkeleton })
-const PRStatusChart      = dynamic(() => import("./charts/PRStatusChart"),      { ssr: false, loading: ChartSkeleton })
-const QualityTrendChart  = dynamic(() => import("./charts/QualityTrendChart"),  { ssr: false, loading: ChartSkeleton })
-const IssueSeverityChart = dynamic(() => import("./charts/IssueSeverityChart"), { ssr: false, loading: ChartSkeleton })
-const CodeChangesChart   = dynamic(() => import("./charts/CodeChangesChart"),   { ssr: false, loading: ChartSkeleton })
-const IssueCategoryChart = dynamic(() => import("./charts/IssueCategoryChart"), { ssr: false, loading: ChartSkeleton })
+const PRTrendChart = dynamic(() => import("./charts/PRTrendChart"), {
+  ssr: false,
+})
+const PRStatusChart = dynamic(() => import("./charts/PRStatusChart"), {
+  ssr: false,
+})
+const QualityTrendChart = dynamic(() => import("./charts/QualityTrendChart"), {
+  ssr: false,
+})
+const IssueSeverityChart = dynamic(() => import("./charts/IssueSeverityChart"), {
+  ssr: false,
+})
+const CodeChangesChart = dynamic(() => import("./charts/CodeChangesChart"), {
+  ssr: false,
+})
+const IssueCategoryChart = dynamic(() => import("./charts/IssueCategoryChart"), {
+  ssr: false,
+})
 
 interface Repo {
   id: string
@@ -33,59 +42,432 @@ interface Repo {
 
 interface StatsClientProps {
   initialOverview: StatsOverview
+  initialOverviewError?: string | null
   repos: Repo[]
+}
+
+type StatsSectionKey =
+  | "overview"
+  | "prTrend"
+  | "qualityTrend"
+  | "issueDistribution"
+  | "codeChanges"
+
+interface StatsSectionState<T> {
+  data: T
+  loading: boolean
+  error: string | null
+}
+
+interface StatsSectionsState {
+  overview: StatsSectionState<StatsOverview>
+  prTrend: StatsSectionState<PRTrendItem[]>
+  qualityTrend: StatsSectionState<QualityTrendItem[]>
+  issueDistribution: StatsSectionState<IssueDistribution>
+  codeChanges: StatsSectionState<CodeChangesItem[]>
+}
+
+const ALL_SECTION_KEYS: StatsSectionKey[] = [
+  "overview",
+  "prTrend",
+  "qualityTrend",
+  "issueDistribution",
+  "codeChanges",
+]
+
+const INITIAL_LOAD_KEYS: StatsSectionKey[] = [
+  "prTrend",
+  "qualityTrend",
+  "issueDistribution",
+  "codeChanges",
+]
+
+const SECTION_ERROR_LABELS: Record<StatsSectionKey, string> = {
+  overview: "overview metrics",
+  prTrend: "PR trend",
+  qualityTrend: "quality trend",
+  issueDistribution: "issue distribution",
+  codeChanges: "code changes",
+}
+
+function setSectionLoadingState(
+  previous: StatsSectionsState,
+  key: StatsSectionKey
+): StatsSectionsState {
+  switch (key) {
+    case "overview":
+      return {
+        ...previous,
+        overview: {
+          ...previous.overview,
+          loading: true,
+          error: null,
+        },
+      }
+    case "prTrend":
+      return {
+        ...previous,
+        prTrend: {
+          ...previous.prTrend,
+          loading: true,
+          error: null,
+        },
+      }
+    case "qualityTrend":
+      return {
+        ...previous,
+        qualityTrend: {
+          ...previous.qualityTrend,
+          loading: true,
+          error: null,
+        },
+      }
+    case "issueDistribution":
+      return {
+        ...previous,
+        issueDistribution: {
+          ...previous.issueDistribution,
+          loading: true,
+          error: null,
+        },
+      }
+    case "codeChanges":
+      return {
+        ...previous,
+        codeChanges: {
+          ...previous.codeChanges,
+          loading: true,
+          error: null,
+        },
+      }
+  }
+}
+
+function setSectionSuccessState(
+  previous: StatsSectionsState,
+  key: "overview",
+  data: StatsOverview
+): StatsSectionsState
+function setSectionSuccessState(
+  previous: StatsSectionsState,
+  key: "prTrend",
+  data: PRTrendItem[]
+): StatsSectionsState
+function setSectionSuccessState(
+  previous: StatsSectionsState,
+  key: "qualityTrend",
+  data: QualityTrendItem[]
+): StatsSectionsState
+function setSectionSuccessState(
+  previous: StatsSectionsState,
+  key: "issueDistribution",
+  data: IssueDistribution
+): StatsSectionsState
+function setSectionSuccessState(
+  previous: StatsSectionsState,
+  key: "codeChanges",
+  data: CodeChangesItem[]
+): StatsSectionsState
+function setSectionSuccessState(
+  previous: StatsSectionsState,
+  key: StatsSectionKey,
+  data:
+    | StatsOverview
+    | PRTrendItem[]
+    | QualityTrendItem[]
+    | IssueDistribution
+    | CodeChangesItem[]
+): StatsSectionsState {
+  switch (key) {
+    case "overview":
+      return {
+        ...previous,
+        overview: {
+          data: data as StatsOverview,
+          loading: false,
+          error: null,
+        },
+      }
+    case "prTrend":
+      return {
+        ...previous,
+        prTrend: {
+          data: data as PRTrendItem[],
+          loading: false,
+          error: null,
+        },
+      }
+    case "qualityTrend":
+      return {
+        ...previous,
+        qualityTrend: {
+          data: data as QualityTrendItem[],
+          loading: false,
+          error: null,
+        },
+      }
+    case "issueDistribution":
+      return {
+        ...previous,
+        issueDistribution: {
+          data: data as IssueDistribution,
+          loading: false,
+          error: null,
+        },
+      }
+    case "codeChanges":
+      return {
+        ...previous,
+        codeChanges: {
+          data: data as CodeChangesItem[],
+          loading: false,
+          error: null,
+        },
+      }
+  }
+}
+
+function setSectionErrorState(
+  previous: StatsSectionsState,
+  key: StatsSectionKey,
+  error: string
+): StatsSectionsState {
+  switch (key) {
+    case "overview":
+      return {
+        ...previous,
+        overview: {
+          ...previous.overview,
+          loading: false,
+          error,
+        },
+      }
+    case "prTrend":
+      return {
+        ...previous,
+        prTrend: {
+          ...previous.prTrend,
+          loading: false,
+          error,
+        },
+      }
+    case "qualityTrend":
+      return {
+        ...previous,
+        qualityTrend: {
+          ...previous.qualityTrend,
+          loading: false,
+          error,
+        },
+      }
+    case "issueDistribution":
+      return {
+        ...previous,
+        issueDistribution: {
+          ...previous.issueDistribution,
+          loading: false,
+          error,
+        },
+      }
+    case "codeChanges":
+      return {
+        ...previous,
+        codeChanges: {
+          ...previous.codeChanges,
+          loading: false,
+          error,
+        },
+      }
+  }
+}
+
+function createInitialState(
+  initialOverview: StatsOverview,
+  initialOverviewError: string | null
+): StatsSectionsState {
+  return {
+    overview: {
+      data: initialOverview,
+      loading: false,
+      error: initialOverviewError,
+    },
+    prTrend: {
+      data: [],
+      loading: true,
+      error: null,
+    },
+    qualityTrend: {
+      data: [],
+      loading: true,
+      error: null,
+    },
+    issueDistribution: {
+      data: { bySeverity: [], byCategory: [] },
+      loading: true,
+      error: null,
+    },
+    codeChanges: {
+      data: [],
+      loading: true,
+      error: null,
+    },
+  }
+}
+
+function getSectionErrorMessage(
+  key: StatsSectionKey,
+  error: unknown
+): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return `Failed to load ${SECTION_ERROR_LABELS[key]}.`
+}
+
+async function fetchSectionData<T>(
+  queryString: string,
+  type: string,
+  select: (payload: unknown) => T
+): Promise<T> {
+  const response = await fetch(`/api/stats?type=${type}&${queryString}`)
+  const payload = (await response.json().catch(() => null)) as
+    | Record<string, unknown>
+    | null
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string"
+        ? payload.error
+        : `Failed to load ${type}.`
+    throw new Error(message)
+  }
+
+  return select(payload)
 }
 
 export default function StatsClient({
   initialOverview,
+  initialOverviewError = null,
   repos,
 }: StatsClientProps) {
   const [range, setRange] = useState<StatsRange>("30d")
   const [repoId, setRepoId] = useState("")
-  const [overview, setOverview] = useState(initialOverview)
-  const [prTrend, setPRTrend] = useState<PRTrendItem[]>([])
-  const [qualityTrend, setQualityTrend] = useState<QualityTrendItem[]>([])
-  const [issueDistribution, setIssueDistribution] =
-    useState<IssueDistribution>({ bySeverity: [], byCategory: [] })
-  const [codeChanges, setCodeChanges] = useState<CodeChangesItem[]>([])
-  const [loading, setLoading] = useState(true)
+  const [sections, setSections] = useState<StatsSectionsState>(
+    createInitialState(initialOverview, initialOverviewError)
+  )
+  const initialLoadRef = useRef(true)
 
-  const fetchAllData = useCallback(async () => {
-    setLoading(true)
-    const params = new URLSearchParams({ range })
-    if (repoId) params.set("repoId", repoId)
+  const fetchSections = useCallback(
+    async (targetKeys: StatsSectionKey[]) => {
+      const params = new URLSearchParams({ range })
+      if (repoId) params.set("repoId", repoId)
+      const queryString = params.toString()
 
-    try {
-      const [overviewRes, prTrendRes, qualityRes, issueRes, codeRes] =
-        await Promise.all([
-          fetch(`/api/stats?type=overview&${params}`).then((r) => r.json()),
-          fetch(`/api/stats?type=pr-trend&${params}`).then((r) => r.json()),
-          fetch(`/api/stats?type=quality-trend&${params}`).then((r) =>
-            r.json()
-          ),
-          fetch(`/api/stats?type=issue-distribution&${params}`).then((r) =>
-            r.json()
-          ),
-          fetch(`/api/stats?type=code-changes&${params}`).then((r) =>
-            r.json()
-          ),
-        ])
+      setSections((previous) => {
+        return targetKeys.reduce(
+          (current, key) => setSectionLoadingState(current, key),
+          previous
+        )
+      })
 
-      setOverview(overviewRes)
-      setPRTrend(prTrendRes.data ?? [])
-      setQualityTrend(qualityRes.data ?? [])
-      setIssueDistribution(issueRes)
-      setCodeChanges(codeRes.data ?? [])
-    } catch (err) {
-      console.error("Failed to fetch stats:", err)
-    } finally {
-      setLoading(false)
-    }
-  }, [range, repoId])
+      const requests: Record<StatsSectionKey, () => Promise<unknown>> = {
+        overview: () =>
+          fetchSectionData(queryString, "overview", (payload) => payload as StatsOverview),
+        prTrend: () =>
+          fetchSectionData(queryString, "pr-trend", (payload) => {
+            const body = payload as { data?: PRTrendItem[] }
+            return body.data ?? []
+          }),
+        qualityTrend: () =>
+          fetchSectionData(queryString, "quality-trend", (payload) => {
+            const body = payload as { data?: QualityTrendItem[] }
+            return body.data ?? []
+          }),
+        issueDistribution: () =>
+          fetchSectionData(queryString, "issue-distribution", (payload) => {
+            return payload as IssueDistribution
+          }),
+        codeChanges: () =>
+          fetchSectionData(queryString, "code-changes", (payload) => {
+            const body = payload as { data?: CodeChangesItem[] }
+            return body.data ?? []
+          }),
+      }
+
+      const results = await Promise.allSettled(
+        targetKeys.map((key) => requests[key]())
+      )
+
+      setSections((previous) => {
+        return targetKeys.reduce((current, key, index) => {
+          const result = results[index]
+
+          if (result.status === "fulfilled") {
+            switch (key) {
+              case "overview":
+                return setSectionSuccessState(
+                  current,
+                  "overview",
+                  result.value as StatsOverview
+                )
+              case "prTrend":
+                return setSectionSuccessState(
+                  current,
+                  "prTrend",
+                  result.value as PRTrendItem[]
+                )
+              case "qualityTrend":
+                return setSectionSuccessState(
+                  current,
+                  "qualityTrend",
+                  result.value as QualityTrendItem[]
+                )
+              case "issueDistribution":
+                return setSectionSuccessState(
+                  current,
+                  "issueDistribution",
+                  result.value as IssueDistribution
+                )
+              case "codeChanges":
+                return setSectionSuccessState(
+                  current,
+                  "codeChanges",
+                  result.value as CodeChangesItem[]
+                )
+            }
+          }
+
+          return setSectionErrorState(
+            current,
+            key,
+            getSectionErrorMessage(key, result.reason)
+          )
+        }, previous)
+      })
+    },
+    [range, repoId]
+  )
 
   useEffect(() => {
-    fetchAllData()
-  }, [fetchAllData])
+    const keys = initialLoadRef.current ? INITIAL_LOAD_KEYS : ALL_SECTION_KEYS
+    initialLoadRef.current = false
+
+    const timeoutId = window.setTimeout(() => {
+      void fetchSections(keys)
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [fetchSections])
+
+  const retrySection = useCallback(
+    (key: StatsSectionKey) => {
+      void fetchSections([key])
+    },
+    [fetchSections]
+  )
 
   return (
     <PageContainer size="wide">
@@ -97,32 +479,59 @@ export default function StatsClient({
         repos={repos}
       />
 
-      <div className={loading ? "opacity-60 transition-opacity" : "transition-opacity"}>
-        <StatsSummaryCards overview={overview} />
-      </div>
+      <StatsSummaryCards
+        overview={sections.overview.data}
+        loading={sections.overview.loading}
+        error={sections.overview.error}
+        onRetry={() => retrySection("overview")}
+      />
 
-      {/* PR 활동 추이 + PR 상태 분포 */}
-      <div className={`grid grid-cols-1 lg:grid-cols-5 ${layoutStyles.gridGap}`}>
-        <PRTrendChart data={prTrend} loading={loading} />
-        <PRStatusChart data={prTrend} loading={loading} />
-      </div>
-
-      {/* 코드 품질 추이 + 이슈 심각도 분포 */}
-      <div className={`grid grid-cols-1 lg:grid-cols-5 ${layoutStyles.gridGap}`}>
-        <QualityTrendChart data={qualityTrend} loading={loading} />
-        <IssueSeverityChart
-          data={issueDistribution.bySeverity}
-          loading={loading}
+      <div
+        className={`grid grid-cols-1 lg:grid-cols-5 ${layoutStyles.gridGap}`}
+      >
+        <PRTrendChart
+          data={sections.prTrend.data}
+          loading={sections.prTrend.loading}
+          error={sections.prTrend.error}
+          onRetry={() => retrySection("prTrend")}
+        />
+        <PRStatusChart
+          data={sections.prTrend.data}
+          loading={sections.prTrend.loading}
+          error={sections.prTrend.error}
+          onRetry={() => retrySection("prTrend")}
         />
       </div>
 
-      {/* 코드 변경량 추이 */}
-      <CodeChangesChart data={codeChanges} loading={loading} />
+      <div
+        className={`grid grid-cols-1 lg:grid-cols-5 ${layoutStyles.gridGap}`}
+      >
+        <QualityTrendChart
+          data={sections.qualityTrend.data}
+          loading={sections.qualityTrend.loading}
+          error={sections.qualityTrend.error}
+          onRetry={() => retrySection("qualityTrend")}
+        />
+        <IssueSeverityChart
+          data={sections.issueDistribution.data.bySeverity}
+          loading={sections.issueDistribution.loading}
+          error={sections.issueDistribution.error}
+          onRetry={() => retrySection("issueDistribution")}
+        />
+      </div>
 
-      {/* 이슈 카테고리 분포 */}
+      <CodeChangesChart
+        data={sections.codeChanges.data}
+        loading={sections.codeChanges.loading}
+        error={sections.codeChanges.error}
+        onRetry={() => retrySection("codeChanges")}
+      />
+
       <IssueCategoryChart
-        data={issueDistribution.byCategory}
-        loading={loading}
+        data={sections.issueDistribution.data.byCategory}
+        loading={sections.issueDistribution.loading}
+        error={sections.issueDistribution.error}
+        onRetry={() => retrySection("issueDistribution")}
       />
     </PageContainer>
   )

--- a/components/stats/StatsSummaryCards.tsx
+++ b/components/stats/StatsSummaryCards.tsx
@@ -1,91 +1,140 @@
 import {
-  GitPullRequest,
-  Star,
   AlertTriangle,
   GitMerge,
+  GitPullRequest,
   MessageSquare,
+  RefreshCw,
+  Star,
   TrendingUp,
 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import type { StatsOverview } from "@/lib/stats"
 import { layoutStyles, surfaceStyles } from "@/lib/styles"
 
 interface StatsSummaryCardsProps {
   overview: StatsOverview
+  loading?: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
 export default function StatsSummaryCards({
   overview,
+  loading = false,
+  error,
+  onRetry,
 }: StatsSummaryCardsProps) {
-  const commentResRate =
+  const commentResolutionRate =
     overview.totalComments > 0
-      ? Math.round(
-          (overview.resolvedComments / overview.totalComments) * 1000
-        ) / 10
+      ? Math.round((overview.resolvedComments / overview.totalComments) * 1000) / 10
       : 0
 
   const cards = [
     {
       icon: GitPullRequest,
       value: `${overview.totalPRs}`,
-      label: "총 PR 수",
+      label: "Total PRs",
       badge: (
-        <span className="text-purple-600 text-xs font-semibold">
-          MERGED {overview.mergedPRs}건
+        <span className="text-xs font-semibold text-purple-600">
+          MERGED {overview.mergedPRs}
         </span>
       ),
     },
     {
       icon: Star,
-      value: `${overview.avgQualityScore}점`,
-      label: "평균 품질 점수",
+      value: `${overview.avgQualityScore}`,
+      label: "Average quality score",
       badge: (
-        <span className="text-blue-600 text-xs font-semibold flex items-center gap-1">
-          <TrendingUp className="w-3 h-3" /> 품질 지표
+        <span className="flex items-center gap-1 text-xs font-semibold text-blue-600">
+          <TrendingUp className="h-3 w-3" /> Quality signal
         </span>
       ),
     },
     {
       icon: AlertTriangle,
       value: `${overview.totalIssues}`,
-      label: "총 이슈 수",
+      label: "Total issues",
       badge: (
-        <span className="text-amber-600 text-xs font-semibold">
-          발견된 이슈
+        <span className="text-xs font-semibold text-amber-600">
+          Review findings
         </span>
       ),
     },
     {
       icon: GitMerge,
       value: `${overview.mergeRate}%`,
-      label: "머지율",
+      label: "Merge rate",
       badge: (
-        <span className="text-emerald-600 text-xs font-semibold flex items-center gap-1">
-          <MessageSquare className="w-3 h-3" />
-          댓글 해결률 {commentResRate}%
+        <span className="flex items-center gap-1 text-xs font-semibold text-emerald-600">
+          <MessageSquare className="h-3 w-3" />
+          Resolved comments {commentResolutionRate}%
         </span>
       ),
     },
   ]
 
+  if (loading) {
+    return (
+      <div
+        className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 ${layoutStyles.gridGap}`}
+      >
+        {cards.map((card) => (
+          <div key={card.label} className={surfaceStyles.interactiveCard}>
+            <div className="mb-4 flex items-start justify-between sm:mb-6">
+              <Skeleton className="h-10 w-10 rounded-full sm:h-12 sm:w-12" />
+            </div>
+            <div className="space-y-3">
+              <Skeleton className="h-10 w-24 rounded sm:h-12 sm:w-28" />
+              <Skeleton className="h-4 w-32 rounded" />
+              <Skeleton className="h-4 w-24 rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className={surfaceStyles.panel}>
+        <div className="flex flex-col gap-4 px-6 py-8 text-center sm:items-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-rose-50 text-rose-500 dark:bg-rose-950/40 dark:text-rose-300">
+            <AlertTriangle size={20} />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+              Failed to load overview metrics
+            </p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">{error}</p>
+          </div>
+          {onRetry && (
+            <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+              <RefreshCw size={14} />
+              Retry overview
+            </Button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <div className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 ${layoutStyles.gridGap}`}>
-      {cards.map((card, i) => (
-        <div
-          key={i}
-          className={surfaceStyles.interactiveCard}
-        >
-          <div className="flex items-start justify-between mb-4 sm:mb-6">
-            <div className="w-10 h-10 sm:w-12 sm:h-12 bg-linear-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center shadow-lg shadow-blue-500/30">
-              <card.icon className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
+    <div
+      className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 ${layoutStyles.gridGap}`}
+    >
+      {cards.map((card) => (
+        <div key={card.label} className={surfaceStyles.interactiveCard}>
+          <div className="mb-4 flex items-start justify-between sm:mb-6">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-blue-600 shadow-lg shadow-blue-500/30 sm:h-12 sm:w-12">
+              <card.icon className="h-5 w-5 text-white sm:h-6 sm:w-6" />
             </div>
           </div>
           <div className="space-y-2">
-            <div className="text-slate-900 text-3xl sm:text-4xl md:text-5xl font-bold leading-none">
+            <div className="text-3xl font-bold leading-none text-slate-900 sm:text-4xl md:text-5xl">
               {card.value}
             </div>
-            <div className="text-slate-500 text-sm font-medium">
-              {card.label}
-            </div>
+            <div className="text-sm font-medium text-slate-500">{card.label}</div>
             <div className="mt-3">{card.badge}</div>
           </div>
         </div>

--- a/components/stats/charts/CodeChangesChart.tsx
+++ b/components/stats/charts/CodeChangesChart.tsx
@@ -10,15 +10,20 @@ import {
   YAxis,
 } from "recharts"
 import { BarChart3 } from "lucide-react"
-
-import { Skeleton } from "@/components/ui/skeleton"
 import { surfaceStyles, textStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { CodeChangesItem } from "@/lib/stats"
+import {
+  StatsChartEmpty,
+  StatsChartError,
+  StatsChartLoading,
+} from "./StatsChartState"
 
 interface CodeChangesChartProps {
   data: CodeChangesItem[]
   loading: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
 function CustomTooltip({
@@ -44,24 +49,22 @@ function CustomTooltip({
       <div className="space-y-1">
         <div className="flex items-center gap-2 text-xs">
           <div className="size-2.5 rounded-full bg-blue-400" />
-          <span className="text-slate-600 dark:text-slate-400">추가:</span>
+          <span className="text-slate-600 dark:text-slate-400">Additions:</span>
           <span className="font-semibold text-emerald-600">
             +{item?.additions?.toLocaleString() ?? 0}
           </span>
         </div>
         <div className="flex items-center gap-2 text-xs">
           <div className="size-2.5 rounded-full bg-red-400" />
-          <span className="text-slate-600 dark:text-slate-400">삭제:</span>
+          <span className="text-slate-600 dark:text-slate-400">Deletions:</span>
           <span className="font-semibold text-rose-600">
             -{item?.deletions?.toLocaleString() ?? 0}
           </span>
         </div>
         <div className="flex items-center gap-2 text-xs">
-          <span className="text-slate-600 dark:text-slate-400">
-            변경 파일:
-          </span>
+          <span className="text-slate-600 dark:text-slate-400">Changed files:</span>
           <span className="font-semibold text-slate-900 dark:text-slate-50">
-            {item?.files ?? 0}개
+            {item?.files ?? 0}
           </span>
         </div>
       </div>
@@ -72,21 +75,20 @@ function CustomTooltip({
 export default function CodeChangesChart({
   data,
   loading,
+  error,
+  onRetry,
 }: CodeChangesChartProps) {
   return (
     <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
-        코드 변경량 추이
+        Code Changes
       </h3>
       {loading ? (
-        <div className="h-70 w-full sm:h-85">
-          <Skeleton className="h-full w-full rounded-md" />
-        </div>
+        <StatsChartLoading />
+      ) : error ? (
+        <StatsChartError message={error} onRetry={onRetry} />
       ) : data.length === 0 ? (
-        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
-          <BarChart3 className="mb-3 size-10 text-slate-300" />
-          <p className="text-sm font-medium">데이터가 없습니다</p>
-        </div>
+        <StatsChartEmpty icon={BarChart3} message="No code change data yet." />
       ) : (
         <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
@@ -116,14 +118,14 @@ export default function CodeChangesChart({
               />
               <Bar
                 dataKey="additions"
-                name="추가"
+                name="Additions"
                 fill="#60a5fa"
                 radius={[4, 4, 0, 0]}
                 maxBarSize={40}
               />
               <Bar
                 dataKey="deletions"
-                name="삭제"
+                name="Deletions"
                 fill="#f87171"
                 radius={[4, 4, 0, 0]}
                 maxBarSize={40}

--- a/components/stats/charts/IssueCategoryChart.tsx
+++ b/components/stats/charts/IssueCategoryChart.tsx
@@ -10,11 +10,14 @@ import {
   YAxis,
 } from "recharts"
 import { BarChart3 } from "lucide-react"
-
-import { Skeleton } from "@/components/ui/skeleton"
 import { surfaceStyles, textStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { IssueCategoryItem } from "@/lib/stats"
+import {
+  StatsChartEmpty,
+  StatsChartError,
+  StatsChartLoading,
+} from "./StatsChartState"
 
 const CATEGORY_COLORS: Record<string, string> = {
   BUG: "#ef4444",
@@ -35,11 +38,15 @@ const CATEGORY_LABELS: Record<string, string> = {
 interface IssueCategoryChartProps {
   data: IssueCategoryItem[]
   loading: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
 export default function IssueCategoryChart({
   data,
   loading,
+  error,
+  onRetry,
 }: IssueCategoryChartProps) {
   const chartData = data.map((item) => ({
     ...item,
@@ -50,17 +57,14 @@ export default function IssueCategoryChart({
   return (
     <div className={cn(surfaceStyles.panel, surfaceStyles.panelPadding)}>
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
-        이슈 카테고리 분포
+        Issue Categories
       </h3>
       {loading ? (
-        <div className="h-70 w-full sm:h-85">
-          <Skeleton className="h-full w-full rounded-md" />
-        </div>
+        <StatsChartLoading />
+      ) : error ? (
+        <StatsChartError message={error} onRetry={onRetry} />
       ) : chartData.length === 0 ? (
-        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
-          <BarChart3 className="mb-3 size-10 text-slate-300" />
-          <p className="text-sm font-medium">데이터가 없습니다</p>
-        </div>
+        <StatsChartEmpty icon={BarChart3} message="No issue category data yet." />
       ) : (
         <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
@@ -101,7 +105,7 @@ export default function IssueCategoryChart({
                         </span>
                       </div>
                       <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-                        {item.count}건
+                        {item.count} items
                       </p>
                     </div>
                   )

--- a/components/stats/charts/IssueSeverityChart.tsx
+++ b/components/stats/charts/IssueSeverityChart.tsx
@@ -2,46 +2,56 @@
 
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts"
 import { CircleDot } from "lucide-react"
-
-import { Skeleton } from "@/components/ui/skeleton"
 import { surfaceStyles, textStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { IssueSeverityItem } from "@/lib/stats"
+import {
+  StatsChartEmpty,
+  StatsChartError,
+  StatsChartLoading,
+} from "./StatsChartState"
 
 interface IssueSeverityChartProps {
   data: IssueSeverityItem[]
   loading: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
 export default function IssueSeverityChart({
   data,
   loading,
+  error,
+  onRetry,
 }: IssueSeverityChartProps) {
-  const total = data.reduce((s, d) => s + d.value, 0)
+  const total = data.reduce((sum, item) => sum + item.value, 0)
 
   return (
-    <div className={cn("lg:col-span-2", surfaceStyles.panel, surfaceStyles.panelPadding)}>
+    <div
+      className={cn(
+        "lg:col-span-2",
+        surfaceStyles.panel,
+        surfaceStyles.panelPadding
+      )}
+    >
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
-        이슈 심각도 분포
+        Issue Severity
       </h3>
       {loading ? (
-        <div className="flex flex-col items-center gap-6">
-          <Skeleton className="size-48 rounded-full" />
-          <div className="w-full space-y-3">
-            {[1, 2, 3, 4].map((i) => (
-              <Skeleton key={i} className="h-4 w-full rounded" />
-            ))}
-          </div>
-        </div>
+        <StatsChartLoading variant="pie" />
+      ) : error ? (
+        <StatsChartError message={error} onRetry={onRetry} />
       ) : data.length === 0 ? (
-        <div className="flex h-70 flex-col items-center justify-center text-slate-400">
-          <CircleDot className="mb-3 size-10 text-slate-300" />
-          <p className="text-sm font-medium">데이터가 없습니다</p>
-        </div>
+        <StatsChartEmpty icon={CircleDot} message="No issue severity data yet." />
       ) : (
         <div className="flex flex-col items-center gap-6">
           <div className="relative h-55 w-55 sm:h-65 sm:w-65">
-            <ResponsiveContainer width="100%" height="100%" minHeight={200} minWidth={200}>
+            <ResponsiveContainer
+              width="100%"
+              height="100%"
+              minHeight={200}
+              minWidth={200}
+            >
               <PieChart>
                 <Pie
                   data={data}
@@ -75,7 +85,7 @@ export default function IssueSeverityChart({
                           </span>
                         </div>
                         <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-                          {value}건 ({Math.round((value / total) * 100)}%)
+                          {value} items ({Math.round((value / total) * 100)}%)
                         </p>
                       </div>
                     )
@@ -85,9 +95,9 @@ export default function IssueSeverityChart({
             </ResponsiveContainer>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
               <span className="text-3xl font-bold text-slate-900 dark:text-slate-50 sm:text-4xl">
-                {total}건
+                {total}
               </span>
-              <span className="text-xs text-slate-400 sm:text-sm">전체 이슈</span>
+              <span className="text-xs text-slate-400 sm:text-sm">Total Issues</span>
             </div>
           </div>
           <div className="w-full space-y-3 sm:space-y-4">
@@ -103,7 +113,7 @@ export default function IssueSeverityChart({
                   </span>
                 </div>
                 <span className="text-xs font-bold text-slate-900 dark:text-slate-50 sm:text-sm">
-                  {item.value}건
+                  {item.value} items
                 </span>
               </div>
             ))}

--- a/components/stats/charts/PRStatusChart.tsx
+++ b/components/stats/charts/PRStatusChart.tsx
@@ -2,11 +2,14 @@
 
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts"
 import { CircleDot } from "lucide-react"
-
-import { Skeleton } from "@/components/ui/skeleton"
 import { surfaceStyles, textStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { PRTrendItem } from "@/lib/stats"
+import {
+  StatsChartEmpty,
+  StatsChartError,
+  StatsChartLoading,
+} from "./StatsChartState"
 
 const STATUS_COLORS: Record<string, string> = {
   Open: "#22c55e",
@@ -18,41 +21,49 @@ const STATUS_COLORS: Record<string, string> = {
 interface PRStatusChartProps {
   data: PRTrendItem[]
   loading: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
-export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
+export default function PRStatusChart({
+  data,
+  loading,
+  error,
+  onRetry,
+}: PRStatusChartProps) {
   const statusData = [
-    { name: "Open", value: data.reduce((s, w) => s + w.open, 0) },
-    { name: "Merged", value: data.reduce((s, w) => s + w.merged, 0) },
-    { name: "Closed", value: data.reduce((s, w) => s + w.closed, 0) },
-    { name: "Draft", value: data.reduce((s, w) => s + w.draft, 0) },
-  ].filter((d) => d.value > 0)
+    { name: "Open", value: data.reduce((sum, week) => sum + week.open, 0) },
+    { name: "Merged", value: data.reduce((sum, week) => sum + week.merged, 0) },
+    { name: "Closed", value: data.reduce((sum, week) => sum + week.closed, 0) },
+    { name: "Draft", value: data.reduce((sum, week) => sum + week.draft, 0) },
+  ].filter((item) => item.value > 0)
 
-  const total = statusData.reduce((s, d) => s + d.value, 0)
+  const total = statusData.reduce((sum, item) => sum + item.value, 0)
 
   return (
-    <div className={cn("lg:col-span-2", surfaceStyles.panel, surfaceStyles.panelPadding)}>
-      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
-        PR 상태 분포
-      </h3>
+    <div
+      className={cn(
+        "lg:col-span-2",
+        surfaceStyles.panel,
+        surfaceStyles.panelPadding
+      )}
+    >
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>PR Status</h3>
       {loading ? (
-        <div className="flex flex-col items-center gap-6">
-          <Skeleton className="size-48 rounded-full" />
-          <div className="w-full space-y-3">
-            {[1, 2, 3].map((i) => (
-              <Skeleton key={i} className="h-4 w-full rounded" />
-            ))}
-          </div>
-        </div>
+        <StatsChartLoading variant="pie" />
+      ) : error ? (
+        <StatsChartError message={error} onRetry={onRetry} />
       ) : statusData.length === 0 ? (
-        <div className="flex h-70 flex-col items-center justify-center text-slate-400">
-          <CircleDot className="mb-3 size-10 text-slate-300" />
-          <p className="text-sm font-medium">데이터가 없습니다</p>
-        </div>
+        <StatsChartEmpty icon={CircleDot} message="No PR status data yet." />
       ) : (
         <div className="flex flex-col items-center gap-6">
           <div className="relative h-55 w-55 sm:h-65 sm:w-65">
-            <ResponsiveContainer width="100%" height="100%" minHeight={200} minWidth={200}>
+            <ResponsiveContainer
+              width="100%"
+              height="100%"
+              minHeight={200}
+              minWidth={200}
+            >
               <PieChart>
                 <Pie
                   data={statusData}
@@ -86,7 +97,7 @@ export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
                           </span>
                         </div>
                         <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-                          {value}건 ({Math.round((value / total) * 100)}%)
+                          {value} items ({Math.round((value / total) * 100)}%)
                         </p>
                       </div>
                     )
@@ -96,9 +107,9 @@ export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
             </ResponsiveContainer>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
               <span className="text-3xl font-bold text-slate-900 dark:text-slate-50 sm:text-4xl">
-                {total}건
+                {total}
               </span>
-              <span className="text-xs text-slate-400 sm:text-sm">전체 PR</span>
+              <span className="text-xs text-slate-400 sm:text-sm">Total PRs</span>
             </div>
           </div>
           <div className="w-full space-y-3 sm:space-y-4">
@@ -114,7 +125,7 @@ export default function PRStatusChart({ data, loading }: PRStatusChartProps) {
                   </span>
                 </div>
                 <span className="text-xs font-bold text-slate-900 dark:text-slate-50 sm:text-sm">
-                  {item.value}건
+                  {item.value} items
                 </span>
               </div>
             ))}

--- a/components/stats/charts/PRTrendChart.tsx
+++ b/components/stats/charts/PRTrendChart.tsx
@@ -9,15 +9,20 @@ import {
   YAxis,
 } from "recharts"
 import { BarChart3 } from "lucide-react"
-
-import { Skeleton } from "@/components/ui/skeleton"
 import { surfaceStyles, textStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { PRTrendItem } from "@/lib/stats"
+import {
+  StatsChartEmpty,
+  StatsChartError,
+  StatsChartLoading,
+} from "./StatsChartState"
 
 interface PRTrendChartProps {
   data: PRTrendItem[]
   loading: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
 function CustomTooltip({
@@ -46,7 +51,7 @@ function CustomTooltip({
             {entry.name}:
           </span>
           <span className="font-semibold text-slate-900 dark:text-slate-50">
-            {entry.value}건
+            {entry.value} items
           </span>
         </div>
       ))}
@@ -54,21 +59,27 @@ function CustomTooltip({
   )
 }
 
-export default function PRTrendChart({ data, loading }: PRTrendChartProps) {
+export default function PRTrendChart({
+  data,
+  loading,
+  error,
+  onRetry,
+}: PRTrendChartProps) {
   return (
-    <div className={cn("lg:col-span-3", surfaceStyles.panel, surfaceStyles.panelPadding)}>
-      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
-        PR 활동 추이
-      </h3>
+    <div
+      className={cn(
+        "lg:col-span-3",
+        surfaceStyles.panel,
+        surfaceStyles.panelPadding
+      )}
+    >
+      <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>PR Trend</h3>
       {loading ? (
-        <div className="h-70 w-full sm:h-85">
-          <Skeleton className="h-full w-full rounded-md" />
-        </div>
+        <StatsChartLoading />
+      ) : error ? (
+        <StatsChartError message={error} onRetry={onRetry} />
       ) : data.length === 0 ? (
-        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
-          <BarChart3 className="mb-3 size-10 text-slate-300" />
-          <p className="text-sm font-medium">데이터가 없습니다</p>
-        </div>
+        <StatsChartEmpty icon={BarChart3} message="No PR activity yet." />
       ) : (
         <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>
@@ -81,11 +92,23 @@ export default function PRTrendChart({ data, loading }: PRTrendChartProps) {
                   <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
                   <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
                 </linearGradient>
-                <linearGradient id="mergedGradient" x1="0" y1="0" x2="0" y2="1">
+                <linearGradient
+                  id="mergedGradient"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
                   <stop offset="0%" stopColor="#22c55e" stopOpacity={0.3} />
                   <stop offset="100%" stopColor="#22c55e" stopOpacity={0.05} />
                 </linearGradient>
-                <linearGradient id="closedGradient" x1="0" y1="0" x2="0" y2="1">
+                <linearGradient
+                  id="closedGradient"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
                   <stop offset="0%" stopColor="#94a3b8" stopOpacity={0.3} />
                   <stop offset="100%" stopColor="#94a3b8" stopOpacity={0.05} />
                 </linearGradient>

--- a/components/stats/charts/QualityTrendChart.tsx
+++ b/components/stats/charts/QualityTrendChart.tsx
@@ -9,15 +9,20 @@ import {
   YAxis,
 } from "recharts"
 import { TrendingUp } from "lucide-react"
-
-import { Skeleton } from "@/components/ui/skeleton"
 import { surfaceStyles, textStyles } from "@/lib/styles"
 import { cn } from "@/lib/utils"
 import type { QualityTrendItem } from "@/lib/stats"
+import {
+  StatsChartEmpty,
+  StatsChartError,
+  StatsChartLoading,
+} from "./StatsChartState"
 
 interface QualityTrendChartProps {
   data: QualityTrendItem[]
   loading: boolean
+  error?: string | null
+  onRetry?: () => void
 }
 
 function CustomTooltip({
@@ -34,7 +39,7 @@ function CustomTooltip({
   return (
     <div className="rounded-md border border-slate-200 bg-white px-5 py-3 text-center shadow-lg dark:border-slate-800 dark:bg-slate-950">
       <div className="text-sm font-bold text-slate-900 dark:text-slate-50">
-        점수: {payload[0].value}점
+        Score: {payload[0].value}
       </div>
       <div className="mt-1 text-xs text-blue-500">{label}</div>
     </div>
@@ -44,21 +49,26 @@ function CustomTooltip({
 export default function QualityTrendChart({
   data,
   loading,
+  error,
+  onRetry,
 }: QualityTrendChartProps) {
   return (
-    <div className={cn("lg:col-span-3", surfaceStyles.panel, surfaceStyles.panelPadding)}>
+    <div
+      className={cn(
+        "lg:col-span-3",
+        surfaceStyles.panel,
+        surfaceStyles.panelPadding
+      )}
+    >
       <h3 className={`${textStyles.sectionTitle} mb-4 sm:mb-6`}>
-        코드 품질 추이
+        Quality Trend
       </h3>
       {loading ? (
-        <div className="h-70 w-full sm:h-85">
-          <Skeleton className="h-full w-full rounded-md" />
-        </div>
+        <StatsChartLoading />
+      ) : error ? (
+        <StatsChartError message={error} onRetry={onRetry} />
       ) : data.length === 0 ? (
-        <div className="flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85">
-          <TrendingUp className="mb-3 size-10 text-slate-300" />
-          <p className="text-sm font-medium">데이터가 없습니다</p>
-        </div>
+        <StatsChartEmpty icon={TrendingUp} message="No quality review data yet." />
       ) : (
         <div className="h-70 w-full sm:h-85">
           <ResponsiveContainer width="100%" height="100%" minHeight={200}>

--- a/components/stats/charts/StatsChartState.tsx
+++ b/components/stats/charts/StatsChartState.tsx
@@ -1,0 +1,87 @@
+import { AlertCircle, RefreshCw, type LucideIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+
+interface StatsChartLoadingProps {
+  variant?: "chart" | "pie"
+}
+
+interface StatsChartEmptyProps {
+  icon: LucideIcon
+  message: string
+  className?: string
+}
+
+interface StatsChartErrorProps {
+  message: string
+  onRetry?: () => void
+  className?: string
+}
+
+export function StatsChartLoading({
+  variant = "chart",
+}: StatsChartLoadingProps) {
+  if (variant === "pie") {
+    return (
+      <div className="flex flex-col items-center gap-6">
+        <Skeleton className="size-48 rounded-full" />
+        <div className="w-full space-y-3">
+          {[1, 2, 3, 4].map((item) => (
+            <Skeleton key={item} className="h-4 w-full rounded" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-70 w-full sm:h-85">
+      <Skeleton className="h-full w-full rounded-md" />
+    </div>
+  )
+}
+
+export function StatsChartEmpty({
+  icon: Icon,
+  message,
+  className,
+}: StatsChartEmptyProps) {
+  return (
+    <div
+      className={`flex h-70 w-full flex-col items-center justify-center text-slate-400 sm:h-85 ${className ?? ""}`}
+    >
+      <Icon className="mb-3 size-10 text-slate-300" />
+      <p className="text-sm font-medium">{message}</p>
+    </div>
+  )
+}
+
+export function StatsChartError({
+  message,
+  onRetry,
+  className,
+}: StatsChartErrorProps) {
+  return (
+    <div
+      className={`flex h-70 w-full flex-col items-center justify-center gap-3 text-center sm:h-85 ${className ?? ""}`}
+    >
+      <div className="flex size-12 items-center justify-center rounded-full bg-rose-50 text-rose-500 dark:bg-rose-950/40 dark:text-rose-300">
+        <AlertCircle size={20} />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+          Failed to load this section
+        </p>
+        <p className="max-w-xs text-xs text-slate-500 dark:text-slate-400">
+          {message}
+        </p>
+      </div>
+      {onRetry && (
+        <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+          <RefreshCw size={14} />
+          Retry
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useCallback, useMemo } from "react"
+import { useEffect, useCallback, useMemo, useRef } from "react"
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { useSocket } from "./useSocket"
@@ -17,8 +17,7 @@ import {
   recordHandlerRemoved,
 } from "@/lib/measurements/socketMetrics"
 
-const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
-const toastedNotificationKeys = new Set<string>()
+const toastedNotificationIds = new Set<string>()
 
 async function fetchNotifications(
   type?: NotificationFilterType,
@@ -53,19 +52,6 @@ function getToastMessage(notification: BaseNotification) {
       : null
 
   if (notification.type === "NEW_REVIEW") {
-    if (notification.reviewStatus === "PENDING") {
-      return null
-    }
-
-    if (notification.reviewStatus === "FAILED") {
-      return {
-        title: "AI review failed",
-        description:
-          notification.message ?? "The review process hit an error.",
-        kind: "error" as const,
-      }
-    }
-
     return {
       title: prTitle ? `AI review is ready for "${prTitle}"` : "AI review is ready",
       description: notification.message ?? "Open the PR to review the result.",
@@ -90,10 +76,6 @@ function getToastMessage(notification: BaseNotification) {
 
 function showNotificationToast(notification: BaseNotification) {
   const toastContent = getToastMessage(notification)
-  if (!toastContent) {
-    return
-  }
-
   const action =
     notification.prId &&
     (notification.type === "NEW_REVIEW" ||
@@ -135,13 +117,14 @@ export function useNotifications(
   typeFilter?: NotificationFilterType,
   readFilter?: NotificationFilterRead
 ) {
-  const { socket } = useSocket()
+  const { socket, fallbackActive, realtimeEnabled } = useSocket()
   const queryClient = useQueryClient()
+  const previousFallbackRef = useRef(fallbackActive)
 
   const { data, isLoading } = useQuery({
     queryKey: ["notifications", typeFilter, readFilter],
     queryFn: () => fetchNotifications(typeFilter, readFilter),
-    refetchInterval: isSocketMode ? false : 10_000,
+    refetchInterval: realtimeEnabled && !fallbackActive ? false : 10_000,
   })
 
   const notifications = useMemo(() => data?.notifications ?? [], [data])
@@ -151,58 +134,26 @@ export function useNotifications(
     (base: BaseNotification) => {
       recordHandlerInvocation("notification:new")
 
-      const toastKey = `${base.id}:${base.reviewStatus ?? "none"}`
-      if (!toastedNotificationKeys.has(toastKey)) {
-        toastedNotificationKeys.add(toastKey)
+      if (!toastedNotificationIds.has(base.id)) {
+        toastedNotificationIds.add(base.id)
         showNotificationToast(base)
       }
 
       const notification: Notification = {
         ...base,
-        prTitle: base.prTitle ?? null,
-        prNumber: base.prNumber ?? null,
-        repoFullName: base.repoFullName ?? null,
+        prTitle: null,
+        prNumber: null,
+        repoFullName: null,
       }
 
       queryClient.setQueryData<NotificationsResponse>(
         ["notifications", typeFilter, readFilter],
         (old) => {
-          if (!old) {
-            return {
-              notifications: [notification],
-              unreadCount: notification.isRead ? 0 : 1,
-              total: 1,
-            }
-          }
-
-          const existingIndex = old.notifications.findIndex((n) => n.id === notification.id)
-
-          if (existingIndex === -1) {
-            return {
-              notifications: [notification, ...old.notifications],
-              unreadCount: old.unreadCount + (notification.isRead ? 0 : 1),
-              total: old.total + 1,
-            }
-          }
-
-          const existing = old.notifications[existingIndex]
-          const nextNotifications = [...old.notifications]
-          nextNotifications[existingIndex] = notification
-
-          const unreadDelta =
-            existing.isRead === notification.isRead
-              ? 0
-              : notification.isRead
-                ? -1
-                : 1
-
+          if (!old) return { notifications: [notification], unreadCount: 1, total: 1 }
           return {
-            notifications: [
-              notification,
-              ...nextNotifications.filter((item) => item.id !== notification.id),
-            ],
-            unreadCount: old.unreadCount + unreadDelta,
-            total: old.total,
+            notifications: [notification, ...old.notifications],
+            unreadCount: old.unreadCount + 1,
+            total: old.total + 1,
           }
         }
       )
@@ -222,6 +173,14 @@ export function useNotifications(
       recordHandlerRemoved("notification:new")
     }
   }, [socket, handleNew])
+
+  useEffect(() => {
+    if (previousFallbackRef.current && !fallbackActive) {
+      void queryClient.invalidateQueries({ queryKey: ["notifications"] })
+    }
+
+    previousFallbackRef.current = fallbackActive
+  }, [fallbackActive, queryClient])
 
   const { mutate: markAsRead } = useMutation({
     mutationFn: markAsReadApi,

--- a/hooks/useRealtimeComments.ts
+++ b/hooks/useRealtimeComments.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { CommentWithAuthor } from "@/types/comment"
 import {
@@ -8,6 +8,7 @@ import {
   recordHandlerRegistered,
   recordHandlerRemoved,
 } from "@/lib/measurements/socketMetrics"
+import { useSocket } from "./useSocket"
 import { useSocketRoom } from "./useSocketRoom"
 
 function normalizeComment(comment: CommentWithAuthor): CommentWithAuthor {
@@ -28,8 +29,6 @@ async function fetchComments(prId: string): Promise<CommentWithAuthor[]> {
   const data = await res.json()
   return (data.comments as CommentWithAuthor[]).map(normalizeComment)
 }
-
-const isSocketMode = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
 
 function appendComment(
   comments: CommentWithAuthor[],
@@ -57,12 +56,14 @@ function appendComment(
 
 export function useRealtimeComments(prId: string) {
   const socket = useSocketRoom(prId)
+  const { fallbackActive, realtimeEnabled } = useSocket()
   const queryClient = useQueryClient()
+  const previousFallbackRef = useRef(fallbackActive)
 
   const query = useQuery({
     queryKey: ["comments", prId],
     queryFn: () => fetchComments(prId),
-    refetchInterval: isSocketMode ? false : 10_000,
+    refetchInterval: realtimeEnabled && !fallbackActive ? false : 10_000,
   })
 
   const handleNew = useCallback(
@@ -136,6 +137,14 @@ export function useRealtimeComments(prId: string) {
       recordHandlerRemoved("comment:deleted")
     }
   }, [socket, handleDeleted, handleNew, handleUpdated])
+
+  useEffect(() => {
+    if (previousFallbackRef.current && !fallbackActive) {
+      void query.refetch()
+    }
+
+    previousFallbackRef.current = fallbackActive
+  }, [fallbackActive, query])
 
   return query
 }

--- a/hooks/useSocket.ts
+++ b/hooks/useSocket.ts
@@ -3,6 +3,13 @@
 import { useEffect, useSyncExternalStore } from "react"
 import { io } from "socket.io-client"
 import type { TypedClientSocket } from "@/lib/socket/types"
+import {
+  recordSocketConnectCall,
+  recordSocketConnectError,
+  recordSocketConnected,
+  recordSocketCreate,
+  recordSocketDisconnected,
+} from "@/lib/measurements/socketMetrics"
 
 export type SocketConnectionStatus =
   | "idle"
@@ -12,11 +19,17 @@ export type SocketConnectionStatus =
   | "disconnected"
   | "error"
 
+export const SOCKET_FALLBACK_GRACE_MS = 8_000
+
+const realtimeEnabled = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
+
 let socket: TypedClientSocket | null = null
 let connected = false
 let connecting = false
+let fallbackActive = !realtimeEnabled
 let status: SocketConnectionStatus = "idle"
 let lastError: string | null = null
+let fallbackTimer: number | null = null
 const listeners = new Set<() => void>()
 
 function notify() {
@@ -46,6 +59,14 @@ function getErrorSnapshot() {
   return lastError
 }
 
+function getFallbackSnapshot() {
+  return fallbackActive
+}
+
+function getRealtimeEnabledSnapshot() {
+  return realtimeEnabled
+}
+
 function getServerSocketSnapshot(): null {
   return null
 }
@@ -60,6 +81,51 @@ function getServerStatusSnapshot(): SocketConnectionStatus {
 
 function getServerErrorSnapshot(): null {
   return null
+}
+
+function getServerFallbackSnapshot() {
+  return !realtimeEnabled
+}
+
+function getServerRealtimeEnabledSnapshot() {
+  return realtimeEnabled
+}
+
+function clearFallbackTimer() {
+  if (fallbackTimer == null) return
+
+  window.clearTimeout(fallbackTimer)
+  fallbackTimer = null
+}
+
+function scheduleFallbackActivation() {
+  if (!realtimeEnabled || fallbackActive || fallbackTimer != null) return
+
+  fallbackTimer = window.setTimeout(() => {
+    fallbackTimer = null
+    fallbackActive = true
+    notify()
+  }, SOCKET_FALLBACK_GRACE_MS)
+}
+
+function syncFallbackState(nextStatus: SocketConnectionStatus) {
+  if (!realtimeEnabled) {
+    clearFallbackTimer()
+    fallbackActive = true
+    return
+  }
+
+  if (
+    nextStatus === "connected" ||
+    nextStatus === "connecting" ||
+    nextStatus === "idle"
+  ) {
+    clearFallbackTimer()
+    fallbackActive = false
+    return
+  }
+
+  scheduleFallbackActivation()
 }
 
 function setConnectionState(
@@ -84,11 +150,14 @@ function setConnectionState(
     lastError = options?.error ?? null
   }
 
+  syncFallbackState(nextStatus)
   notify()
 }
 
 async function connect() {
-  if (process.env.NEXT_PUBLIC_REALTIME_MODE !== "socket") {
+  recordSocketConnectCall()
+
+  if (!realtimeEnabled) {
     setConnectionState("idle", {
       connected: false,
       connecting: false,
@@ -123,13 +192,14 @@ async function connect() {
       setConnectionState("error", {
         connected: false,
         connecting: false,
-        error: "소켓 인증 토큰을 가져오지 못했습니다.",
+        error: "Failed to fetch a socket auth token.",
       })
       return
     }
 
     const { token } = await res.json()
 
+    recordSocketCreate()
     socket = io(process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:4000", {
       path: "/socket.io",
       transports: ["websocket"],
@@ -141,6 +211,7 @@ async function connect() {
     })
 
     socket.on("connect", () => {
+      recordSocketConnected()
       setConnectionState("connected", {
         connected: true,
         connecting: false,
@@ -149,6 +220,7 @@ async function connect() {
     })
 
     socket.on("disconnect", (reason) => {
+      recordSocketDisconnected()
       const nextStatus =
         reason === "io client disconnect" ? "disconnected" : "reconnecting"
 
@@ -160,6 +232,7 @@ async function connect() {
     })
 
     socket.on("connect_error", (error) => {
+      recordSocketConnectError(error.message)
       const shouldRetry = socket?.active ?? false
 
       setConnectionState(shouldRetry ? "reconnecting" : "error", {
@@ -174,14 +247,14 @@ async function connect() {
     setConnectionState("error", {
       connected: false,
       connecting: false,
-      error: "소켓 연결 초기화 중 오류가 발생했습니다.",
+      error: "Failed to initialize the socket connection.",
     })
   }
 }
 
 export function useSocket() {
   useEffect(() => {
-    connect()
+    void connect()
   }, [])
 
   const currentSocket = useSyncExternalStore(
@@ -204,11 +277,24 @@ export function useSocket() {
     getErrorSnapshot,
     getServerErrorSnapshot
   )
+  const currentFallbackActive = useSyncExternalStore(
+    subscribe,
+    getFallbackSnapshot,
+    getServerFallbackSnapshot
+  )
+  const currentRealtimeEnabled = useSyncExternalStore(
+    subscribe,
+    getRealtimeEnabledSnapshot,
+    getServerRealtimeEnabledSnapshot
+  )
 
   return {
     socket: currentSocket,
     isConnected,
     connectionStatus,
     connectionError,
+    fallbackActive: currentFallbackActive,
+    realtimeEnabled: currentRealtimeEnabled,
+    degraded: currentRealtimeEnabled && currentFallbackActive,
   }
 }


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 협업
- [x] Week 9-10: 대시보드 & 배포

## 개요

통계 페이지에서 각 섹션의 로딩/에러 상태를 독립적으로 처리하도록 개선하고, 소켓 연결 상태를 공통 UI로 정리했습니다. 실시간 연결이 불안정할 때는 fallback polling으로 동작하도록 보완해 사용자에게 현재 업데이트 방식을 더 명확하게 보여줍니다.

## 변경 사항

- 통계 페이지 데이터를 `overview`, `prTrend`, `qualityTrend`, `issueDistribution`, `codeChanges` 단위로 분리해 섹션별 로딩/에러/재시도 처리 추가
- 통계 차트 공통 상태 UI(`loading`, `empty`, `error`)를 `StatsChartState`로 분리
- 최초 통계 페이지 렌더에서 일부 데이터가 실패해도 전체 페이지가 깨지지 않도록 fallback overview 처리 추가
- 소켓 연결 상태를 `SocketConnectionStatus` 공용 컴포넌트로 분리해 배지와 안내 배너 공통화
- 소켓 연결이 불안정할 때 comments / notifications 쿼리가 polling fallback으로 동작하도록 보완
- 앱 헤더, PR 상세 헤더, 댓글 영역에서 공통 연결 상태 UI 사용
- 댓글 목록에서 반응 토글 연결이 빠져 CI typecheck를 깨던 부분을 복구
- 구현 요청 응답 형식을 `AGENTS.md`에 기록

## 스크린샷 (선택)

- N/A

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

## 참고 사항

- 실행 결과
  - `npx.cmd eslint . --no-error-on-unmatched-pattern` 통과
  - `npx.cmd tsc --noEmit --pretty false` 통과
  - `npx.cmd jest --runInBand` 통과 (`19` suites, `116` tests)
  - `npm.cmd run build` 통과
- CI 실패 원인은 `components/comment/CommentList.tsx`에서 반응 토글 관련 import / handler 연결이 빠져 있던 문제였습니다.
- UI 문구 추가 조정이나 저장소 `401` 자동 로그아웃 흐름은 이 PR에 포함되지 않았습니다.