### PR TITLE
feat: implement PR repository dropdown filter

### DIFF
--- a/components/pulls/PRList.tsx
+++ b/components/pulls/PRList.tsx
@@ -2,10 +2,10 @@
 
 import { useSearchParams } from "next/navigation";
 
-import { InfiniteScrollTrigger } from "@/components/ui/InfiniteScrollTrigger";
 import { FILTER_TAB_TO_STATUS, type PRFilterTab } from "@/constants";
 import { usePullRequests } from "@/hooks/usePullRequests";
 import { layoutStyles, surfaceStyles } from "@/lib/styles";
+import { InfiniteScrollTrigger } from "@/components/ui/InfiniteScrollTrigger";
 import PRCard from "./PRCard";
 import PRCardSkeleton from "./PRCardSkeleton";
 import PREmptyState from "./PREmptyState";
@@ -14,6 +14,7 @@ import PRListFooter from "./PRListFooter";
 export default function PRList() {
   const searchParams = useSearchParams();
   const statusTab = (searchParams.get("status") as PRFilterTab) ?? "All";
+  const repoId = searchParams.get("repoId") ?? undefined;
   const apiStatus = FILTER_TAB_TO_STATUS[statusTab];
 
   const {
@@ -23,7 +24,7 @@ export default function PRList() {
     isFetchingNextPage,
     isLoading,
     isError,
-  } = usePullRequests(apiStatus);
+  } = usePullRequests({ status: apiStatus, repoId });
 
   if (isLoading) {
     return (
@@ -38,7 +39,7 @@ export default function PRList() {
   if (isError) {
     return (
       <div className={surfaceStyles.emptyState}>
-        PR 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        PR 목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
       </div>
     );
   }
@@ -51,23 +52,23 @@ export default function PRList() {
 
   return (
     <div className={layoutStyles.listStack}>
-        {pullRequests.map((pr, index) => (
-          <PRCard key={pr.id} {...pr} animationDelay={index * 75} />
-        ))}
+      {pullRequests.map((pr, index) => (
+        <PRCard key={pr.id} {...pr} animationDelay={index * 75} />
+      ))}
 
-        <InfiniteScrollTrigger
-          onLoadMore={fetchNextPage}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          loadingFallback={
-            <div className={layoutStyles.listStack}>
-              <PRCardSkeleton />
-              <PRCardSkeleton />
-            </div>
-          }
-        />
+      <InfiniteScrollTrigger
+        onLoadMore={fetchNextPage}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        loadingFallback={
+          <div className={layoutStyles.listStack}>
+            <PRCardSkeleton />
+            <PRCardSkeleton />
+          </div>
+        }
+      />
 
-        {!hasNextPage && <PRListFooter />}
+      {!hasNextPage && <PRListFooter />}
     </div>
   );
 }

--- a/components/pulls/PRPageHeader.tsx
+++ b/components/pulls/PRPageHeader.tsx
@@ -1,30 +1,12 @@
-import { ChevronDown, GitPullRequest } from "lucide-react";
-
-import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layout/PageHeader";
-import { controlStyles } from "@/lib/styles";
-import { cn } from "@/lib/utils";
+import PRRepositoryFilter from "@/components/pulls/PRRepositoryFilter";
 
 export default function PRPageHeader() {
   return (
     <PageHeader
       title="Pull Requests"
-      description="저장소의 코드 변경 사항을 검토하고 병합을 관리하세요."
-      actions={
-        <>
-        <Button
-          variant="outline"
-          className={cn("gap-2 px-4 py-2.5 text-sm", controlStyles.secondaryAction)}
-        >
-          <span>모든 저장소</span>
-          <ChevronDown className="text-slate-400" size={16} aria-hidden />
-        </Button>
-        <Button className={cn("gap-2", controlStyles.primaryAction)}>
-          <GitPullRequest size={18} aria-hidden />
-          <span>새 PR 생성</span>
-        </Button>
-        </>
-      }
+      description="저장소별 코드 변경 사항을 확인하고 병합 흐름을 관리해요."
+      actions={<PRRepositoryFilter />}
     />
   );
 }

--- a/components/pulls/PRRepositoryFilter.tsx
+++ b/components/pulls/PRRepositoryFilter.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useConnectedRepositories } from "@/hooks/useConnectedRepositories";
+import { controlStyles } from "@/lib/styles";
+import { cn } from "@/lib/utils";
+
+const ALL_REPOSITORIES_VALUE = "__all__";
+
+export default function PRRepositoryFilter() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selectedRepoId = searchParams.get("repoId") ?? "";
+  const { data, isLoading } = useConnectedRepositories();
+
+  const repositories = data?.repositories ?? [];
+  const selectedRepository = repositories.find((repo) => repo.id === selectedRepoId);
+  const label = selectedRepository?.fullName ?? "모든 저장소";
+
+  const handleValueChange = (repoId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (repoId === ALL_REPOSITORIES_VALUE) {
+      params.delete("repoId");
+    } else {
+      params.set("repoId", repoId);
+    }
+
+    const nextUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+    router.push(nextUrl);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn("gap-2 px-4 py-2.5 text-sm", controlStyles.secondaryAction)}
+        >
+          <span className="max-w-52 truncate">
+            {isLoading ? "저장소 불러오는 중..." : label}
+          </span>
+          <ChevronDown className="text-slate-400" size={16} aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuItem onSelect={() => handleValueChange(ALL_REPOSITORIES_VALUE)}>
+          모든 저장소
+        </DropdownMenuItem>
+        {repositories.map((repo) => (
+          <DropdownMenuItem key={repo.id} onSelect={() => handleValueChange(repo.id)}>
+            {repo.fullName}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/hooks/useConnectedRepositories.ts
+++ b/hooks/useConnectedRepositories.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { ConnectedRepositoryListResponse } from "@/types/repos";
+
+async function fetchConnectedRepositories(): Promise<ConnectedRepositoryListResponse> {
+  const res = await fetch("/api/repositories");
+
+  if (!res.ok) {
+    throw new Error("Failed to load connected repositories.");
+  }
+
+  return res.json();
+}
+
+export function useConnectedRepositories() {
+  return useQuery({
+    queryKey: ["connectedRepositories"],
+    queryFn: fetchConnectedRepositories,
+  });
+}

--- a/hooks/usePullRequests.ts
+++ b/hooks/usePullRequests.ts
@@ -2,27 +2,38 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { PRStatus, PullRequestListResponse } from "@/types/pulls";
 
+interface PullRequestFilter {
+  status?: PRStatus;
+  repoId?: string;
+}
+
 async function fetchPullRequestsPage({
   status,
+  repoId,
   page,
-}: {
-  status?: PRStatus;
+}: PullRequestFilter & {
   page: number;
 }): Promise<PullRequestListResponse> {
   const params = new URLSearchParams();
+
   if (status) params.set("status", status);
+  if (repoId) params.set("repoId", repoId);
   params.set("page", String(page));
 
   const res = await fetch(`/api/pulls?${params}`);
-  if (!res.ok) throw new Error("PR 목록을 불러오는 데 실패했습니다.");
+
+  if (!res.ok) {
+    throw new Error("Failed to load pull requests.");
+  }
+
   return res.json();
 }
 
-export function usePullRequests(status?: PRStatus) {
+export function usePullRequests(filter: PullRequestFilter) {
   return useInfiniteQuery({
-    queryKey: ["pullRequests", status],
+    queryKey: ["pullRequests", filter.status, filter.repoId],
     queryFn: ({ pageParam }) =>
-      fetchPullRequestsPage({ status, page: pageParam }),
+      fetchPullRequestsPage({ ...filter, page: pageParam }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {
       const { page, totalPages } = lastPage.pagination;

--- a/types/repos.ts
+++ b/types/repos.ts
@@ -17,3 +17,13 @@ export interface RepoListResponse {
   repos: GitHubRepo[];
   pagination: RepoPagination;
 }
+
+export interface ConnectedRepository {
+  id: string;
+  name: string;
+  fullName: string;
+}
+
+export interface ConnectedRepositoryListResponse {
+  repositories: ConnectedRepository[];
+}


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [x] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

PR 목록 페이지 상단의 저장소 버튼을 실제 드롭다운 필터로 연결했습니다. 접근 가능한 저장소 목록을 불러와 선택할 수 있고, 선택한 저장소가 URL 쿼리와 PR 목록 조회에 반영됩니다. Closes #150.

## 변경 사항

- PR 목록 헤더의 정적 저장소 버튼을 실제 드롭다운 필터 컴포넌트로 교체
- 연결된 저장소 목록 조회용 `useConnectedRepositories` 훅 추가
- PR 목록 조회 훅에 `repoId` 필터 및 query key 반영
- PR 목록 컴포넌트가 `repoId` 쿼리를 읽어 목록 조회에 전달하도록 연결
- 저장소 관련 응답 타입 추가
- 미구현 상태였던 `새 PR 생성` 버튼 제거

## 스크린샷 (선택)

해당 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

실행 결과:
- `npm.cmd run lint -- components/pulls/PRPageHeader.tsx components/pulls/PRRepositoryFilter.tsx components/pulls/PRList.tsx hooks/usePullRequests.ts hooks/useConnectedRepositories.ts types/repos.ts` 통과
- 브라우저 수동 확인과 `tsc --noEmit` 는 이번 PR에서 실행하지 못했습니다

## 참고 사항

- `/api/pulls` 는 이미 `repoId` 필터를 지원하고 있어서, 이번 PR은 주로 UI와 클라이언트 데이터 흐름 연결에 집중했습니다.
- 현재 PR 검색 기능은 별도 이슈 #151 에서 이어서 구현할 예정입니다.