### PR TITLE
feat: implement PR search filter

### DIFF
--- a/__tests__/api/pulls/route.test.ts
+++ b/__tests__/api/pulls/route.test.ts
@@ -89,7 +89,9 @@ describe("GET /api/pulls", () => {
     expect(body.pagination).toEqual({ total: 1, page: 1, limit: 20, totalPages: 1 })
     expect(mockedFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { repoId: { in: ["repo-1"] } },
+        where: {
+          AND: [{ repoId: { in: ["repo-1"] } }],
+        },
         skip: 0,
         take: 20,
       })
@@ -124,7 +126,9 @@ describe("GET /api/pulls", () => {
 
     expect(mockedFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { repoId: { in: ["repo-1"] }, status: "OPEN" },
+        where: {
+          AND: [{ repoId: { in: ["repo-1"] } }, { status: "OPEN" }],
+        },
       })
     )
   })

--- a/app/api/pulls/route.ts
+++ b/app/api/pulls/route.ts
@@ -20,6 +20,7 @@ export async function GET(request: Request) {
 
     const repoId = searchParams.get("repoId") ?? undefined
     const statusParam = searchParams.get("status") ?? undefined
+    const search = searchParams.get("search")?.trim() ?? ""
     const pageParam = parseInt(searchParams.get("page") ?? "1", 10)
     const limitParam = parseInt(
       searchParams.get("limit") ?? String(DEFAULT_LIMIT),
@@ -44,8 +45,30 @@ export async function GET(request: Request) {
     )
 
     const where = {
-      ...accessiblePullRequestWhere,
-      ...(statusParam && { status: statusParam as PRStatus }),
+      AND: [
+        accessiblePullRequestWhere,
+        ...(statusParam ? [{ status: statusParam as PRStatus }] : []),
+        ...(search
+          ? [
+              {
+                OR: [
+                  {
+                    title: {
+                      contains: search,
+                      mode: "insensitive" as const,
+                    },
+                  },
+                  {
+                    description: {
+                      contains: search,
+                      mode: "insensitive" as const,
+                    },
+                  },
+                ],
+              },
+            ]
+          : []),
+      ],
     }
 
     const [total, pullRequests] = await Promise.all([

--- a/components/pulls/PRList.tsx
+++ b/components/pulls/PRList.tsx
@@ -14,6 +14,7 @@ import PRListFooter from "./PRListFooter";
 export default function PRList() {
   const searchParams = useSearchParams();
   const statusTab = (searchParams.get("status") as PRFilterTab) ?? "All";
+  const search = searchParams.get("search") ?? undefined;
   const apiStatus = FILTER_TAB_TO_STATUS[statusTab];
 
   const {
@@ -23,7 +24,7 @@ export default function PRList() {
     isFetchingNextPage,
     isLoading,
     isError,
-  } = usePullRequests(apiStatus);
+  } = usePullRequests({ status: apiStatus, search });
 
   if (isLoading) {
     return (
@@ -38,7 +39,7 @@ export default function PRList() {
   if (isError) {
     return (
       <div className={surfaceStyles.emptyState}>
-        PR 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        PR 목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
       </div>
     );
   }
@@ -51,23 +52,23 @@ export default function PRList() {
 
   return (
     <div className={layoutStyles.listStack}>
-        {pullRequests.map((pr, index) => (
-          <PRCard key={pr.id} {...pr} animationDelay={index * 75} />
-        ))}
+      {pullRequests.map((pr, index) => (
+        <PRCard key={pr.id} {...pr} animationDelay={index * 75} />
+      ))}
 
-        <InfiniteScrollTrigger
-          onLoadMore={fetchNextPage}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          loadingFallback={
-            <div className={layoutStyles.listStack}>
-              <PRCardSkeleton />
-              <PRCardSkeleton />
-            </div>
-          }
-        />
+      <InfiniteScrollTrigger
+        onLoadMore={fetchNextPage}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        loadingFallback={
+          <div className={layoutStyles.listStack}>
+            <PRCardSkeleton />
+            <PRCardSkeleton />
+          </div>
+        }
+      />
 
-        {!hasNextPage && <PRListFooter />}
+      {!hasNextPage && <PRListFooter />}
     </div>
   );
 }

--- a/components/pulls/PRSearchInput.tsx
+++ b/components/pulls/PRSearchInput.tsx
@@ -1,27 +1,61 @@
 "use client";
 
-import { useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Search } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
 
+const SEARCH_SYNC_DELAY_MS = 300;
+
 export default function PRSearchInput() {
+  const pathname = usePathname();
+  const router = useRouter();
   const searchParams = useSearchParams();
-  const [search, setSearch] = useState(searchParams.get("search") ?? "");
+  const searchQuery = searchParams.get("search") ?? "";
+  const [search, setSearch] = useState(searchQuery);
+
+  useEffect(() => {
+    setSearch(searchQuery);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      const normalizedSearch = search.trim();
+
+      if (normalizedSearch === searchQuery) {
+        return;
+      }
+
+      const params = new URLSearchParams(searchParams.toString());
+
+      if (normalizedSearch) {
+        params.set("search", normalizedSearch);
+      } else {
+        params.delete("search");
+      }
+
+      params.delete("page");
+
+      const nextUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+      router.replace(nextUrl);
+    }, SEARCH_SYNC_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pathname, router, search, searchParams, searchQuery]);
 
   return (
     <div className="relative flex-1 md:max-w-xs lg:max-w-md">
       <Search
-        className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400"
+        className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
         aria-hidden
       />
       <Input
         type="text"
-        placeholder="PR 제목, 작성자 검색..."
+        placeholder="PR 제목, 설명 검색..."
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        className="w-full pl-10 pr-4 py-2.5 sm:py-3 bg-white border-slate-200 rounded-[18px] text-xs sm:text-sm focus:ring-4 focus:ring-blue-700/5 focus:border-blue-700 placeholder:text-slate-400"
+        className="w-full rounded-[18px] border-slate-200 bg-white py-2.5 pr-4 pl-10 text-xs placeholder:text-slate-400 focus:border-blue-700 focus:ring-4 focus:ring-blue-700/5 sm:py-3 sm:text-sm"
       />
     </div>
   );

--- a/hooks/usePullRequests.ts
+++ b/hooks/usePullRequests.ts
@@ -2,27 +2,38 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { PRStatus, PullRequestListResponse } from "@/types/pulls";
 
+interface PullRequestFilter {
+  status?: PRStatus;
+  search?: string;
+}
+
 async function fetchPullRequestsPage({
   status,
+  search,
   page,
-}: {
-  status?: PRStatus;
+}: PullRequestFilter & {
   page: number;
 }): Promise<PullRequestListResponse> {
   const params = new URLSearchParams();
+
   if (status) params.set("status", status);
+  if (search) params.set("search", search);
   params.set("page", String(page));
 
   const res = await fetch(`/api/pulls?${params}`);
-  if (!res.ok) throw new Error("PR 목록을 불러오는 데 실패했습니다.");
+
+  if (!res.ok) {
+    throw new Error("Failed to load pull requests.");
+  }
+
   return res.json();
 }
 
-export function usePullRequests(status?: PRStatus) {
+export function usePullRequests(filter: PullRequestFilter) {
   return useInfiniteQuery({
-    queryKey: ["pullRequests", status],
+    queryKey: ["pullRequests", filter.status, filter.search],
     queryFn: ({ pageParam }) =>
-      fetchPullRequestsPage({ status, page: pageParam }),
+      fetchPullRequestsPage({ ...filter, page: pageParam }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {
       const { page, totalPages } = lastPage.pagination;


### PR DESCRIPTION
## 작업 유형

- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [x] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

PR 목록 페이지의 검색 입력을 실제 검색 필터로 연결했습니다. 검색어가 URL의 `search` 쿼리와 동기화되고, 목록 조회 훅과 `/api/pulls` 검색 조건에 반영됩니다. Closes #151.

## 변경 사항

- PR 검색 입력이 `search` 쿼리와 동기화되도록 구현
- 검색 입력 변경 시 URL을 지연 반영하도록 처리해 과도한 요청을 줄임
- PR 목록 조회 훅에 `search` 필터와 query key 반영
- `/api/pulls` 에 제목/설명 기준 검색 조건 추가
- 검색어 변경 시 목록 페이지가 새 조건으로 다시 조회되도록 연결

## 스크린샷 (선택)

해당 없음

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [x] ESLint 경고/에러 없음

실행 결과:
- `npm.cmd run lint -- components/pulls/PRSearchInput.tsx components/pulls/PRList.tsx hooks/usePullRequests.ts app/api/pulls/route.ts` 통과
- 브라우저 수동 확인과 `tsc --noEmit` 는 이번 PR에서 실행하지 못했습니다

## 참고 사항

- 검색 대상은 현재 PR 제목과 설명입니다.
- 저장소 드롭다운 필터(#150)와는 별도 브랜치/PR로 분리했습니다.