### PR TITLE
perf: PR Detail 리뷰 코드 하이라이터 lazy loading

### DIFF
--- a/components/review/SuggestionCard.tsx
+++ b/components/review/SuggestionCard.tsx
@@ -1,50 +1,44 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Copy, Check, MapPin } from "lucide-react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { ChevronDown, ChevronRight, MapPin } from "lucide-react";
 import type { ReviewIssue } from "@/types/review";
 import ReviewBadge from "./ReviewBadge";
+import SuggestionCodeBlock from "./SuggestionCodeBlock";
 
 interface SuggestionCardProps {
   issue: ReviewIssue;
   onIssueClick?: (issue: ReviewIssue) => void;
 }
 
-export default function SuggestionCard({ issue, onIssueClick }: SuggestionCardProps) {
+export default function SuggestionCard({
+  issue,
+  onIssueClick,
+}: SuggestionCardProps) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    if (!issue.exampleCode) return;
-    await navigator.clipboard.writeText(issue.exampleCode);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   return (
     <div
       id={`suggestion-card-${issue.originalIndex}`}
-      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 overflow-hidden"
+      className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900"
     >
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
-        className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/60 transition-colors"
+        className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/60"
       >
-        <span className="mt-0.5 text-slate-400 shrink-0">
+        <span className="mt-0.5 shrink-0 text-slate-400">
           {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
         </span>
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-semibold text-slate-800 dark:text-slate-200 leading-snug">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-snug text-slate-800 dark:text-slate-200">
             {issue.title}
           </p>
-          <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
             <ReviewBadge severity={issue.severity} category={issue.category} />
             {issue.lineNumber != null && (
-              <span className="inline-flex items-center gap-1 text-[11px] text-slate-400 dark:text-slate-500 font-mono">
+              <span className="inline-flex items-center gap-1 font-mono text-[11px] text-slate-400 dark:text-slate-500">
                 <MapPin size={10} />
                 {issue.filePath}:{issue.lineNumber}
               </span>
@@ -54,62 +48,31 @@ export default function SuggestionCard({ issue, onIssueClick }: SuggestionCardPr
       </button>
 
       {open && (
-        <div className="px-4 pb-4 space-y-3 border-t border-slate-100 dark:border-slate-800 pt-3">
+        <div className="space-y-3 border-t border-slate-100 px-4 pb-4 pt-3 dark:border-slate-800">
           <div>
-            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
               설명
             </p>
-            <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
               {issue.description}
             </p>
           </div>
           <div>
-            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
               제안
             </p>
-            <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
               {issue.suggestion}
             </p>
           </div>
           {issue.exampleCode && (
-            <div>
-              <div className="flex items-center justify-between mb-1">
-                <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
-                  예시 코드
-                </p>
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className="inline-flex items-center gap-1 text-[11px] text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-                >
-                  {copied ? (
-                    <>
-                      <Check size={12} className="text-emerald-500" />
-                      <span className="text-emerald-500">복사됨</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy size={12} />
-                      <span>복사</span>
-                    </>
-                  )}
-                </button>
-              </div>
-              <SyntaxHighlighter
-                language="typescript"
-                style={oneDark}
-                customStyle={{ borderRadius: "0.5rem", fontSize: "12px", margin: 0, padding: "12px" }}
-                wrapLongLines
-              >
-                {issue.exampleCode}
-              </SyntaxHighlighter>
-            </div>
+            <SuggestionCodeBlock code={issue.exampleCode} language="typescript" />
           )}
           {onIssueClick && (
             <button
               type="button"
               onClick={() => onIssueClick(issue)}
-              className="inline-flex items-center gap-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors"
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
             >
               자세히 보기
             </button>

--- a/components/review/SuggestionCodeBlock/PlainCodeBlock.tsx
+++ b/components/review/SuggestionCodeBlock/PlainCodeBlock.tsx
@@ -1,0 +1,11 @@
+interface PlainCodeBlockProps {
+  code: string;
+}
+
+export default function PlainCodeBlock({ code }: PlainCodeBlockProps) {
+  return (
+    <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-slate-950 p-3 font-mono text-[12px] leading-relaxed text-slate-100 dark:bg-black">
+      <code>{code}</code>
+    </pre>
+  );
+}

--- a/components/review/SuggestionCodeBlock/SyntaxHighlightedCode.tsx
+++ b/components/review/SuggestionCodeBlock/SyntaxHighlightedCode.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+interface SyntaxHighlightedCodeProps {
+  code: string;
+  language?: string;
+}
+
+const CODE_BLOCK_STYLE = {
+  borderRadius: "0.5rem",
+  fontSize: "12px",
+  margin: 0,
+  padding: "12px",
+};
+
+export default function SyntaxHighlightedCode({
+  code,
+  language = "typescript",
+}: SyntaxHighlightedCodeProps) {
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={oneDark}
+      customStyle={CODE_BLOCK_STYLE}
+      wrapLongLines
+    >
+      {code}
+    </SyntaxHighlighter>
+  );
+}

--- a/components/review/SuggestionCodeBlock/index.tsx
+++ b/components/review/SuggestionCodeBlock/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState, type ComponentType } from "react";
+import { Check, Copy } from "lucide-react";
+import PlainCodeBlock from "./PlainCodeBlock";
+
+interface SuggestionCodeBlockProps {
+  code: string;
+  language?: string;
+}
+
+type HighlightedCodeComponent = ComponentType<{
+  code: string;
+  language?: string;
+}>;
+
+export default function SuggestionCodeBlock({
+  code,
+  language = "typescript",
+}: SuggestionCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const [HighlightedCode, setHighlightedCode] =
+    useState<HighlightedCodeComponent | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void import("./SyntaxHighlightedCode")
+      .then((module) => {
+        if (!cancelled) {
+          setHighlightedCode(() => module.default);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setHighlightedCode(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!copied) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          예시 코드
+        </p>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1 text-[11px] text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
+        >
+          {copied ? (
+            <>
+              <Check size={12} className="text-emerald-500" />
+              <span className="text-emerald-500">복사됨</span>
+            </>
+          ) : (
+            <>
+              <Copy size={12} />
+              <span>복사</span>
+            </>
+          )}
+        </button>
+      </div>
+
+      {HighlightedCode ? (
+        <HighlightedCode code={code} language={language} />
+      ) : (
+        <PlainCodeBlock code={code} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

Depends on #157

PR Detail 초기 진입 시 `react-syntax-highlighter` / `refractor`가 review suggestion card import 경로를 통해 초기 route bundle에 포함되는 문제를 줄이기 위해, 예시 코드 하이라이터를 suggestion card open 이후 lazy import하도록 분리했습니다.

## 변경 사항

- `SuggestionCard`에서 `react-syntax-highlighter`, `oneDark`, copy 상태/핸들러를 제거했습니다.
- `SuggestionCodeBlock` 폴더를 추가해 예시 코드 표시와 복사 책임을 별도 컴포넌트로 분리했습니다.
- `SuggestionCodeBlock/index.tsx`에서 mount 시점에만 `SyntaxHighlightedCode`를 dynamic import하도록 변경했습니다.
- highlighter 로딩 전 또는 로딩 실패 시 plain `<pre><code>` fallback이 유지되도록 했습니다.
- `react-syntax-highlighter` 정적 import는 `SuggestionCodeBlock/SyntaxHighlightedCode.tsx` 한 곳으로 격리했습니다.

## 스크린샷 (선택)

- 해당 없음. UI 플로우 변경 없이 코드 하이라이터 로딩 시점만 지연시키는 성능 리팩토링입니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

검증 결과:

- `rg "react-syntax-highlighter|SyntaxHighlighter|oneDark|refractor" components app hooks lib -g "!lib/generated/**"`: `SuggestionCodeBlock/SyntaxHighlightedCode.tsx`에만 남는 것 확인.
- `npm.cmd run lint`: 통과. 단, 기존 `hooks/useRealtimeComments.ts`의 `appendComment` unused warning 1건이 남아 있습니다.
- `npm.cmd test -- --runInBand`: 통과. 22 suites / 131 tests passed.
- `npx.cmd tsc --noEmit`: 실패. 기존 Prisma/generated 타입 불일치로 실패했습니다.
  - `BaseNotification.reviewStatus` 누락 관련 오류
  - Prisma `Review.stage` / `Notification.reviewStatus` generated type 불일치
  - 이번 PR에서 수정한 review code highlighter lazy loading 파일과는 직접 관련 없는 기존 타입 이슈입니다.

## 참고 사항

Lighthouse `157 적용` 측정에서 `node_modules_refractor_lang_ce18cb0d._.js`가 초기 payload / CPU table에서 사라지고, total payload가 `1,608KiB -> 1,286KiB`로 감소한 것으로 확인됐습니다. suggestion card를 직접 열면 highlighter chunk가 이후 로드될 수 있으므로, 초기 진입 성능 측정은 card를 열지 않은 상태에서 비교해야 합니다.