### PR TITLE
fix: PR Detail files 401 자동 로그아웃 처리

### DIFF
--- a/hooks/usePRFiles.ts
+++ b/hooks/usePRFiles.ts
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { UseQueryOptions } from "@tanstack/react-query";
-import { signOut } from "next-auth/react";
-import { toast } from "sonner";
+import { handleUnauthorizedAutoLogout } from "@/lib/client-auth";
 import type { PRFile } from "@/types/pulls";
 
 const GITHUB_REAUTH_REQUIRED = "GITHUB_REAUTH_REQUIRED";
-let githubReauthHandled = false;
+
 export const prFilesQueryKey = (id: string) => ["pullRequestFiles", id] as const;
+
 type PRFilesQueryKey = ReturnType<typeof prFilesQueryKey>;
 type PRFilesQueryOptions = Omit<
   UseQueryOptions<PRFile[], Error, PRFile[], PRFilesQueryKey>,
@@ -15,11 +15,13 @@ type PRFilesQueryOptions = Omit<
 >;
 
 class PRFilesError extends Error {
+  status: number;
   code?: string;
 
-  constructor(message: string, code?: string) {
+  constructor(message: string, status: number, code?: string) {
     super(message);
     this.name = "PRFilesError";
+    this.status = status;
     this.code = code;
   }
 }
@@ -34,6 +36,7 @@ async function fetchPRFiles(id: string): Promise<PRFile[]> {
 
     throw new PRFilesError(
       body?.error ?? "PR 파일 목록을 불러오지 못했습니다.",
+      res.status,
       body?.code
     );
   }
@@ -47,7 +50,10 @@ export function usePRFiles(id: string, options?: PRFilesQueryOptions) {
     queryKey: prFilesQueryKey(id),
     queryFn: () => fetchPRFiles(id),
     retry: (failureCount, error) => {
-      if (error instanceof PRFilesError && error.code === GITHUB_REAUTH_REQUIRED) {
+      if (
+        error instanceof PRFilesError &&
+        (error.status === 401 || error.code === GITHUB_REAUTH_REQUIRED)
+      ) {
         return false;
       }
 
@@ -57,24 +63,16 @@ export function usePRFiles(id: string, options?: PRFilesQueryOptions) {
   });
 
   useEffect(() => {
-    if (
-      query.error instanceof PRFilesError &&
-      query.error.code === GITHUB_REAUTH_REQUIRED &&
-      !githubReauthHandled
-    ) {
-      githubReauthHandled = true;
-
-      toast.error("GitHub 인증이 만료되었습니다.", {
-        description: "현재 계정에서 로그아웃 후 다시 로그인합니다.",
-        duration: 2000,
-      });
-
-      const timer = window.setTimeout(() => {
-        signOut({ callbackUrl: "/auth/login" });
-      }, 1200);
-
-      return () => window.clearTimeout(timer);
+    if (!(query.error instanceof PRFilesError) || query.error.status !== 401) {
+      return;
     }
+
+    const message =
+      query.error.code === GITHUB_REAUTH_REQUIRED
+        ? "GitHub 인증이 만료되어 다시 로그인합니다."
+        : "인증이 만료되어 다시 로그인합니다.";
+
+    handleUnauthorizedAutoLogout(message);
   }, [query.error]);
 
   return query;

--- a/lib/client-auth.ts
+++ b/lib/client-auth.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { toast } from "sonner";
+
+const AUTO_LOGOUT_DELAY_MS = 1800;
+const AUTH_CALLBACK_URL = "/auth/login";
+
+let logoutScheduled = false;
+
+export class ClientApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ClientApiError";
+    this.status = status;
+  }
+}
+
+export async function createClientApiError(
+  response: Response,
+  fallbackMessage: string
+): Promise<ClientApiError> {
+  const body = (await response.json().catch(() => null)) as
+    | { error?: string }
+    | null;
+
+  return new ClientApiError(
+    typeof body?.error === "string" ? body.error : fallbackMessage,
+    response.status
+  );
+}
+
+export function handleUnauthorizedAutoLogout(message?: string) {
+  if (typeof window === "undefined" || logoutScheduled) return;
+
+  logoutScheduled = true;
+
+  toast.error(message ?? "인증이 만료되어 다시 로그인합니다.", {
+    description: "잠시 후 로그인 화면으로 이동합니다.",
+    duration: AUTO_LOGOUT_DELAY_MS,
+  });
+
+  window.setTimeout(() => {
+    void signOut({ callbackUrl: AUTH_CALLBACK_URL });
+  }, AUTO_LOGOUT_DELAY_MS);
+}

--- a/pr-detail-issue-modal-single-owner-plan.md
+++ b/pr-detail-issue-modal-single-owner-plan.md
@@ -1,0 +1,89 @@
+# PR Detail Issue Modal Single Owner Plan
+
+## 1. Current Structure
+
+현재 PR Detail page에는 같은 목적의 issue detail modal이 두 군데에서 따로 관리된다.
+
+```txt
+PRDetailLayout
+├─ ReviewSection
+│  ├─ selectedIssue state
+│  └─ IssueDetailModal
+│
+└─ PRDiffSection
+   ├─ selectedIssue state
+   └─ IssueDetailModal
+```
+
+## 2. Current Problem
+
+`IssueDetailModal`은 "선택된 review issue를 자세히 보여주는 모달"이라는 하나의 역할을 한다.
+
+그런데 현재는 다음 두 컴포넌트가 각각 modal state와 modal dynamic import를 갖는다.
+
+- `components/pulls/detail/ReviewSection.tsx`
+- `components/pulls/detail/PRDiffSection.tsx`
+
+이 구조에서는 modal이 닫혀 있어도 PR Detail tree 안에 modal host가 두 개 존재한다. Lighthouse에서도 `IssueDetailModal`, `Dialog`, `BailoutToCSR`가 두 번 나타난다.
+
+## 3. Proposed Structure
+
+`selectedIssue` state와 modal rendering 책임을 `PRDetailLayout` 또는 별도 `IssueModalHost`로 올린다.
+
+```txt
+PRDetailLayout
+├─ selectedIssue state
+├─ handleIssueClick(issue)
+│
+├─ ReviewSection
+│  └─ onIssueClick(issue)
+│
+├─ PRDiffSection
+│  └─ onIssueClick(issue)
+│
+└─ IssueModalHost
+   └─ selectedIssue가 있을 때만 IssueDetailModal lazy render
+```
+
+## 4. Responsibility Change
+
+### `PRDetailLayout`
+
+- `selectedIssue`를 한 번만 가진다.
+- `handleIssueClick(issue)`를 만든다.
+- `ReviewSection`과 `PRDiffSection`에 `onIssueClick`으로 전달한다.
+- `selectedIssue !== null`일 때만 `IssueModalHost`를 렌더링한다.
+
+### `ReviewSection`
+
+- `selectedIssue` state를 제거한다.
+- `IssueDetailModal` dynamic import를 제거한다.
+- review issue 클릭 시 `onIssueClick(issue)`만 호출한다.
+
+### `PRDiffSection`
+
+- `selectedIssue` state를 제거한다.
+- `IssueDetailModal` dynamic import를 제거한다.
+- diff issue 클릭 시 `onIssueClick(issue)`만 호출한다.
+
+### `IssueModalHost`
+
+- `IssueDetailModal` dynamic import를 한 곳에서만 담당한다.
+- `issue`가 없으면 `null`을 반환해서 closed modal code가 초기 렌더링에 끼지 않게 한다.
+
+## 5. Expected Impact
+
+- `IssueDetailModal` / `Dialog` 중복 mount 감소
+- `LoadableComponent` / `BailoutToCSR` 중복 감소
+- modal 관련 dynamic import가 한 곳으로 단순화
+- Review/Diff section의 책임 감소
+- Lighthouse의 `IssueDetailModal appears twice` 문제 완화 기대
+
+## 6. Safe Implementation Order
+
+1. `IssueModalHost` 컴포넌트 추가
+2. `PRDetailLayout`에 `selectedIssue` state 추가
+3. `ReviewSection`에 `onIssueClick` prop 추가
+4. `PRDiffSection`에 `onIssueClick` prop 추가
+5. 각 section 내부의 modal state/dynamic import 제거
+6. deep link, diff issue click, review issue click 동작 확인


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [x] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

Closes #159

Depends on #158

PR Detail 페이지에서 `/api/pulls/[id]/files`가 401을 반환할 때 조용히 파일 로딩 실패 상태로만 남는 문제를 수정했습니다. 이제 files API의 일반 401과 GitHub 재인증 필요 401 모두 사용자에게 안내 toast를 보여주고 로그인 페이지로 자동 이동합니다.

## 변경 사항

- `usePRFiles`의 에러 객체에 HTTP status를 보존하도록 변경했습니다.
- files API 401 응답은 React Query retry 대상에서 제외했습니다.
- `GITHUB_REAUTH_REQUIRED`뿐 아니라 일반 `status === 401`도 자동 로그아웃 처리로 연결했습니다.
- 공용 `handleUnauthorizedAutoLogout` 유틸을 통해 toast 안내와 `signOut`을 처리하도록 정리했습니다.
- `pr-detail-issue-modal-single-owner-plan.md`를 루트에 추가해 다음 PR Detail modal 단일화 계획을 문서화했습니다.

## 스크린샷 (선택)

- 해당 없음. 인증 만료 처리 로직과 문서 추가 작업입니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [ ] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

검증 결과:

- `npm.cmd run lint`: 통과. 단, 기존 `hooks/useRealtimeComments.ts`의 `appendComment` unused warning 1건이 남아 있습니다.
- `npm.cmd test -- --runInBand`: 통과. 22 suites / 131 tests passed.
- `npx.cmd tsc --noEmit`: 실패. 기존 Prisma/generated 타입 불일치로 실패했습니다.
  - `BaseNotification.reviewStatus` 누락 관련 오류
  - Prisma `Review.stage` / `Notification.reviewStatus` generated type 불일치
  - 이번 PR에서 수정한 `usePRFiles` 401 처리와는 직접 관련 없는 기존 타입 이슈입니다.

## 참고 사항

이 PR은 #158 위에 쌓인 stacked PR입니다. #158이 main에 병합되면 base branch를 main으로 retarget할 수 있습니다.