### PR TITLE
perf: PR Detail issue modal 단일 host 적용

### DIFF
--- a/components/pulls/detail/IssueModalHost.tsx
+++ b/components/pulls/detail/IssueModalHost.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ReviewIssue } from "@/types/review";
+
+const IssueDetailModal = dynamic(
+  () => import("@/components/review/IssueDetailModal"),
+  { ssr: false }
+);
+
+interface IssueModalHostProps {
+  issue: ReviewIssue | null;
+  onClose: () => void;
+}
+
+export default function IssueModalHost({ issue, onClose }: IssueModalHostProps) {
+  if (!issue) return null;
+
+  return (
+    <IssueDetailModal
+      issue={issue}
+      onClose={onClose}
+    />
+  );
+}

--- a/components/pulls/detail/PRDetailLayout.tsx
+++ b/components/pulls/detail/PRDetailLayout.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import FloatingCommentsButton from "./FloatingCommentsButton";
+import IssueModalHost from "./IssueModalHost";
 import PRDetailStickyHeader from "./PRDetailStickyHeader";
 import PRDiffSection from "./PRDiffSection";
 import PRFileList from "./PRFileList";
@@ -13,6 +14,7 @@ import { usePRDetailReset } from "@/hooks/pr-detail/usePRDetailReset";
 import { useSocketRoom } from "@/hooks/useSocketRoom";
 import { layoutStyles } from "@/lib/styles";
 import { usePRDetailStore } from "@/stores/prDetailStore";
+import type { ReviewIssue } from "@/types/review";
 
 interface PRDetailLayoutProps {
   id: string;
@@ -34,6 +36,7 @@ export default function PRDetailLayout({
     );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [scrolled, setScrolled] = useState(false);
+  const [selectedIssue, setSelectedIssue] = useState<ReviewIssue | null>(null);
 
   useSocketRoom(id);
   usePRDetailReset(id);
@@ -51,6 +54,14 @@ export default function PRDetailLayout({
     if (!el || !target) return;
     target.scrollIntoView({ behavior: "smooth", block: "start" });
   };
+
+  const handleIssueClick = useCallback((issue: ReviewIssue) => {
+    setSelectedIssue(issue);
+  }, []);
+
+  const handleIssueClose = useCallback(() => {
+    setSelectedIssue(null);
+  }, []);
 
   return (
     <div className={`${layoutStyles.detailFrame} relative`}>
@@ -76,11 +87,15 @@ export default function PRDetailLayout({
         />
 
         <div className="space-y-4 p-4">
-          <ReviewSection prId={id} />
+          <ReviewSection
+            prId={id}
+            onIssueClick={handleIssueClick}
+          />
 
           <PRDiffSection
             prId={id}
             currentUserId={currentUserId}
+            onIssueClick={handleIssueClick}
           />
 
           <div id="general-comments" className="scroll-mt-36">
@@ -92,6 +107,11 @@ export default function PRDetailLayout({
           prId={id}
           visible={scrolled}
           onClick={handleScrollToComments}
+        />
+
+        <IssueModalHost
+          issue={selectedIssue}
+          onClose={handleIssueClose}
         />
       </div>
     </div>

--- a/components/pulls/detail/PRDiffSection.tsx
+++ b/components/pulls/detail/PRDiffSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -21,28 +21,24 @@ const PRDiffViewer = dynamic(() => import("./PRDiffViewer"), {
   loading: () => <Skeleton className="h-96 w-full rounded-lg" />,
 });
 
-const IssueDetailModal = dynamic(
-  () => import("@/components/review/IssueDetailModal"),
-  { ssr: false }
-);
-
 const EMPTY_ISSUES: ReviewIssue[] = [];
 const EMPTY_COMMENTS: CommentWithAuthor[] = [];
 
 interface PRDiffSectionProps {
   prId: string;
   currentUserId: string;
+  onIssueClick: (issue: ReviewIssue) => void;
 }
 
 export default function PRDiffSection({
   prId,
   currentUserId,
+  onIssueClick,
 }: PRDiffSectionProps) {
   const { data: files = [], isPending, isError } = useCachedPRFiles(prId);
   const { data: review } = useCachedReview(prId);
   const selectedFile = usePRDetailStore((state) => state.selectedFile);
   const { inlineCommentsByFile } = usePRCommentGroups(prId);
-  const [selectedIssue, setSelectedIssue] = useState<ReviewIssue | null>(null);
   const issuesByFile = useMemo(
     () => groupIssuesByFile(getIndexedReviewIssues(review)),
     [review]
@@ -73,17 +69,12 @@ export default function PRDiffSection({
           file={file}
           isActive={selectedFile === file.filename}
           issues={issuesByFile.get(file.filename) ?? EMPTY_ISSUES}
-          onIssueClick={setSelectedIssue}
+          onIssueClick={onIssueClick}
           prId={prId}
           currentUserId={currentUserId}
           inlineComments={inlineCommentsByFile[file.filename] ?? EMPTY_COMMENTS}
         />
       ))}
-
-      <IssueDetailModal
-        issue={selectedIssue}
-        onClose={() => setSelectedIssue(null)}
-      />
     </>
   );
 }

--- a/components/pulls/detail/ReviewSection.tsx
+++ b/components/pulls/detail/ReviewSection.tsx
@@ -3,27 +3,24 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { BotMessageSquare, ChevronDown } from "lucide-react";
-import dynamic from "next/dynamic";
 import ReviewPanel from "@/components/review/ReviewPanel";
 import { useReview } from "@/hooks/useReview";
 import type { ReviewIssue } from "@/types/review";
 
-const IssueDetailModal = dynamic(
-  () => import("@/components/review/IssueDetailModal"),
-  { ssr: false }
-);
-
 interface ReviewSectionProps {
   prId: string;
+  onIssueClick: (issue: ReviewIssue) => void;
 }
 
-export default function ReviewSection({ prId }: ReviewSectionProps) {
+export default function ReviewSection({
+  prId,
+  onIssueClick,
+}: ReviewSectionProps) {
   const { data: review } = useReview(prId);
   const searchParams = useSearchParams();
   const [reviewOpen, setReviewOpen] = useState(
     () => searchParams.get("review") === "open"
   );
-  const [selectedIssue, setSelectedIssue] = useState<ReviewIssue | null>(null);
 
   useEffect(() => {
     if (searchParams.get("review") !== "open") return;
@@ -68,16 +65,11 @@ export default function ReviewSection({ prId }: ReviewSectionProps) {
           <div className="p-4">
             <ReviewPanel
               prId={prId}
-              onIssueClick={setSelectedIssue}
+              onIssueClick={onIssueClick}
             />
           </div>
         )}
       </div>
-
-      <IssueDetailModal
-        issue={selectedIssue}
-        onClose={() => setSelectedIssue(null)}
-      />
     </>
   );
 }

--- a/pr-detail-header-loading-before.md
+++ b/pr-detail-header-loading-before.md
@@ -248,3 +248,200 @@ ReviewSection
 - #156 적용으로 loading responsibility는 더 명확해졌다.
 - 하지만 Lighthouse after 결과상 다음 병목은 `files loading gate`가 아니라 client-side JS/hydration이다.
 - 다음 작업은 `refractor` lazy loading을 별도 이슈/브랜치로 분리하는 것이 가장 객관적이고 측정 가능한 순서다.
+
+## 11. Lighthouse After Refractor Lazy Loading
+
+Report: `PR Detail Page Performance Report - 157 Applied`
+
+- Measured at: `2026-04-29 18:42`
+- Environment: `localhost:3000`
+- Related PR: [#158 perf: PR Detail 리뷰 코드 하이라이터 lazy loading](https://github.com/phnml1/CodeMate/pull/158)
+- Base PR: [#157 perf: PR Detail 헤더 렌더링과 files 로딩 분리](https://github.com/phnml1/CodeMate/pull/157)
+
+### Applied Change
+
+- `components/review/SuggestionCard.tsx`에서 `react-syntax-highlighter`와 `oneDark` static import를 제거했다.
+- `components/review/SuggestionCodeBlock/` 폴더를 추가했다.
+- suggestion card가 열리고 example code block이 실제로 mount될 때만 `SyntaxHighlightedCode`를 dynamic import한다.
+- highlighter import 전 또는 import 실패 시 plain `<pre><code>` fallback을 유지한다.
+- `react-syntax-highlighter` import는 `components/review/SuggestionCodeBlock/SyntaxHighlightedCode.tsx` 한 파일에만 남겼다.
+
+### Metrics Compared With `156 Applied`
+
+| Metric | 156 Applied | 157 Applied | Change |
+|---|---:|---:|---:|
+| Performance | 51 | 53 | +2 |
+| First Contentful Paint | 0.3s | 0.3s | 0 |
+| Largest Contentful Paint | 2.8s | 2.7s | -0.1s |
+| Total Blocking Time | 1,780ms | 1,240ms | -540ms |
+| Cumulative Layout Shift | 0 | 0 | 0 |
+| Speed Index | 2.1s | 1.8s | -0.3s |
+| Server response time observed | 1,551ms | 1,328ms | -223ms |
+| Time to First Byte | 1,560ms | 1,330ms | -230ms |
+| Maximum critical path latency | 1,854ms | 1,600ms | -254ms |
+| Element render delay | 4,370ms | 3,270ms | -1,100ms |
+| Main-thread work | 4.0s | 3.6s | -0.4s |
+| JavaScript execution time | 2.9s | 2.6s | -0.3s |
+| Script Evaluation | 2,671ms | 2,490ms | -181ms |
+| Script Parsing & Compilation | 400ms | 309ms | -91ms |
+| Total network payload | 1,608KiB | 1,286KiB | -322KiB |
+| Long tasks | 13 | 11 | -2 |
+
+### Important Result
+
+`node_modules_refractor_lang_ce18cb0d._.js` no longer appears in the largest payload list or CPU table.
+
+This strongly suggests that the review code highlighter was removed or deferred from the initial PR Detail route. This is the clearest measurable win so far because it directly reduced initial payload, parsing/compilation work, TBT, and element render delay.
+
+### Remaining Bottlenecks After `157 Applied`
+
+| Area | Evidence | Notes |
+|---|---|---|
+| Shared app shell hydration | `ProtectedLayout: 927.49ms`, `AppHeader: 923.68ms`, `AppSidebar: 489.37ms` | Header/sidebar/session/socket/UI primitives are now more visible. |
+| PR detail render cost | `PRDetailPage: 888.60ms` | Detail layout still mounts review, diff, comments, socket room, deep link, modal hosts, and floating button path. |
+| Socket reconnect | `Reconnect: 134.10ms`, `Reconnect: 85.30ms` | Reconnect traces remain one of the biggest post-load costs. |
+| Modal/dynamic loading | `IssueDetailModal` appears twice, `Dialog`, `BailoutToCSR`, `Promise Resolved: 349.50ms` | Modal is currently rendered from both review and diff sections. |
+| New long-task target | `node_modules_1819799d._.js` long tasks up to `432ms` | Need bundle/import tracing to identify the package group. |
+| Session/auth duplication | Multiple `Object.session` measures | `AppHeader`, `AppSidebar`, PR page, APIs, and socket token path all need inspection. |
+
+### Updated Priority
+
+1. Confirm `refractor` stays out of the initial route in follow-up measurements.
+2. Remove duplicated `IssueDetailModal` mounting by introducing a single modal owner.
+3. Reduce socket reconnect work and avoid socket attempts when the configured mode is polling or the socket server is unavailable.
+4. Inspect `node_modules_1819799d._.js` with bundle analysis/import tracing.
+5. Reduce shared app shell hydration by addressing session duplication and tooltip/dropdown mounting.
+
+## 12. Next Candidate: Single Issue Modal Owner
+
+Current modal ownership:
+
+```txt
+ReviewSection
+  owns selectedIssue
+  renders IssueDetailModal
+
+PRDiffSection
+  owns selectedIssue
+  renders IssueDetailModal
+```
+
+This means the PR Detail page has two dynamic imports and two modal hosts for the same conceptual UI: "show selected review issue detail".
+
+Proposed modal ownership:
+
+```txt
+PRDetailLayout
+  owns selectedIssue once
+  renders IssueDetailModal once, only when selectedIssue exists
+
+ReviewSection
+  receives onIssueClick
+  calls onIssueClick(issue)
+
+PRDiffSection
+  receives onIssueClick
+  calls onIssueClick(issue)
+```
+
+Expected impact:
+
+- `IssueDetailModal` and `Dialog` should stop appearing twice.
+- Closed modal code should not mount during initial render.
+- `LoadableComponent`, `BailoutToCSR`, and related promise work should decrease.
+- Review and diff sections become simpler because they no longer own modal state.
+
+## 13. After Single Issue Modal Owner
+
+Related change: `IssueModalHost` owns the issue detail modal once under `PRDetailLayout`.
+
+### Applied Structure
+
+Before:
+
+```txt
+ReviewSection
+  owns selectedIssue
+  dynamic-imports IssueDetailModal
+  renders IssueDetailModal
+
+PRDiffSection
+  owns selectedIssue
+  dynamic-imports IssueDetailModal
+  renders IssueDetailModal
+```
+
+After:
+
+```txt
+PRDetailLayout
+  owns selectedIssue once
+  passes onIssueClick to ReviewSection and PRDiffSection
+  renders IssueModalHost once
+
+IssueModalHost
+  returns null when selectedIssue is null
+  lazy-loads IssueDetailModal only after an issue is selected
+```
+
+### Lighthouse Follow-up Interpretation
+
+The follow-up Lighthouse PDFs after the `158` work show that the modal optimization is working in the intended direction.
+
+Before this change, the `157 Applied` report showed `IssueDetailModal` twice during the initial page lifetime. Those entries were paired with `Dialog`, `BailoutToCSR`, and multiple `LoadableComponent` entries. The report also showed `Promise Resolved: 349.50ms`.
+
+After the single-owner modal structure, the follow-up `158 Applied` measurements no longer show `IssueDetailModal` in User Timing search results. This matches the implementation because `IssueModalHost` returns `null` while no issue is selected:
+
+```tsx
+if (!issue) return null;
+```
+
+### 158 Applied Three-run Average
+
+| Metric | Average |
+|---|---:|
+| Performance | 56 |
+| First Contentful Paint | 0.33s |
+| Largest Contentful Paint | 2.47s |
+| Total Blocking Time | 1,183ms |
+| Cumulative Layout Shift | 0 |
+| Speed Index | 1.5s |
+| Time to First Byte | 957ms |
+| Server response time observed | 949ms |
+| Element render delay | 3,403ms |
+| JavaScript execution time | 2.4s |
+| Main-thread work | about 3.2s |
+| Unused JS savings | 370KiB |
+| Minify JS savings | 267KiB |
+
+Component timing averages from the 2nd and 3rd measurements:
+
+| Component / Measure | Average |
+|---|---:|
+| `ProtectedLayout` | 533.26ms |
+| `AppHeader` | 530.33ms |
+| `PRDetailPage` | 545.05ms |
+| `AppSidebar` | 443.52ms |
+| `Cascading Update` | 108.80ms |
+| `TooltipProviderProvider` | 69.05ms |
+| Long tasks count | about 9.5 |
+
+### Result
+
+- `IssueDetailModal` no longer appears in the initial-load User Timing search results.
+- The previous duplicated `IssueDetailModal` / `Dialog` / `BailoutToCSR` pattern appears removed.
+- `Promise Resolved` improved from `349.50ms` to either `205.70ms` or `11.50ms` in the follow-up reports, though this value still fluctuates.
+- `LoadableComponent` entries still exist, which means other dynamic imports remain.
+- Reconnect work still appears, including values around `85ms` to `120ms`.
+
+### Updated Bottleneck Layer
+
+This change should be treated as a successful cleanup of duplicated modal ownership, not as the final PR Detail performance fix. The remaining bottleneck layer is now:
+
+1. `ProtectedLayout` / `AppHeader` hydration and shared AppShell work.
+2. `PRDetailPage` initial render cost.
+3. `node_modules_1819799d._.js` long tasks.
+4. WebSocket reconnect work during or shortly after initial load.
+5. Repeated Tooltip / Popper / Radix primitive mounting.
+
+Recommended next target: inspect WebSocket connect/reconnect behavior and make sure socket connection and `socket.io-client` loading do not happen on the critical path when the page is measured in polling mode or when realtime is not immediately needed.


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [x] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

PR Detail 페이지에서 `ReviewSection`과 `PRDiffSection`이 각각 `IssueDetailModal`을 소유하면서 초기 로드 측정에 `IssueDetailModal`, `Dialog`, `BailoutToCSR`가 중복으로 나타나던 구조를 정리했습니다.

이 PR은 `PRDetailLayout` 아래에 단일 `IssueModalHost`를 두고, 두 섹션은 `onIssueClick` 이벤트만 부모로 올리도록 바꿉니다. `IssueModalHost`는 선택된 issue가 없으면 `null`을 반환하므로 초기 로드에서는 issue modal dynamic import가 트리거되지 않습니다.

이 PR은 #160 위에 쌓인 stacked PR입니다.

## 변경 사항

- `components/pulls/detail/IssueModalHost.tsx` 추가
  - `IssueDetailModal` dynamic import를 한 곳으로 단일화
  - `issue`가 없으면 렌더하지 않도록 처리
- `components/pulls/detail/PRDetailLayout.tsx`
  - `selectedIssue` local state를 단일 owner로 추가
  - `ReviewSection`, `PRDiffSection`에 같은 `onIssueClick` handler 전달
  - `IssueModalHost`를 한 번만 렌더
- `components/pulls/detail/ReviewSection.tsx`
  - 내부 `selectedIssue` state와 `IssueDetailModal` dynamic import 제거
  - `ReviewPanel`에 부모 handler 전달
- `components/pulls/detail/PRDiffSection.tsx`
  - 내부 `selectedIssue` state와 `IssueDetailModal` dynamic import 제거
  - `PRDiffViewer`에 부모 handler 전달
- `pr-detail-header-loading-before.md`
  - 158 적용 후 3회 평균 Lighthouse 수치 추가
  - `IssueDetailModal` 중복 마운트 제거 결과와 다음 병목 레이어 기록

## 스크린샷 (선택)

N/A - PR Detail의 issue modal ownership과 성능 기록 문서 변경이며, 의도한 UI 변경은 없습니다.

## 테스트

- [x] ESLint 실행
  - `npm.cmd run lint`
  - 결과: 통과, 기존 경고 1개 유지 (`hooks/useRealtimeComments.ts`의 `appendComment` unused)
- [ ] 타입 에러 없음 (`tsc --noEmit`)
  - `npx.cmd tsc --noEmit --pretty false`
  - 결과: 실패
  - 이번 변경과 무관한 기존 Prisma/generated 타입 불일치에서 실패
  - 예: `reviewStatus` missing / `stage` does not exist in Prisma review types
- [ ] 로컬 개발 서버에서 정상 동작 확인
  - 미실행
- [ ] 기존 기능 영향 없음 확인
  - 코드 경로 기준으로 modal open handler 전달 구조만 변경, 후속 브라우저 확인 필요

## 참고 사항

후속 Lighthouse에서 확인할 항목:

- `IssueDetailModal`이 초기 User Timing 검색 결과에서 사라졌는지
- `Dialog` / `BailoutToCSR` 중복 패턴이 줄었는지
- `LoadableComponent`, `Promise Resolved`가 남아 있다면 어떤 dynamic import에서 발생하는지
- 다음 병목 후보: WebSocket reconnect, `node_modules_1819799d._.js`, AppShell hydration
