### PR TITLE
perf: 알림 summary 캐시와 polling fallback 최적화

### DIFF
--- a/app/api/notifications/summary/route.ts
+++ b/app/api/notifications/summary/route.ts
@@ -1,0 +1,16 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function GET() {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const unreadCount = await prisma.notification.count({
+    where: { userId: session.user.id, isRead: false },
+  })
+
+  return Response.json({ unreadCount })
+}

--- a/components/notification/NotificationBell.tsx
+++ b/components/notification/NotificationBell.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Bell } from "lucide-react"
-import { useNotifications } from "@/hooks/useNotifications"
+import { useNotificationSummary, useNotifications } from "@/hooks/useNotifications"
 import { getNotificationLink } from "@/lib/notification-link"
 import NotificationList from "./NotificationList"
 import type { Notification } from "@/types/notification"
@@ -12,7 +12,12 @@ export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const router = useRouter()
-  const { notifications, unreadCount, markAsRead, deleteNotification } = useNotifications()
+  const { unreadCount } = useNotificationSummary()
+  const { notifications, isLoading, markAsRead, deleteNotification } = useNotifications(
+    undefined,
+    undefined,
+    { enabled: isOpen }
+  )
 
   // 외부 클릭 시 드롭다운 닫기
   useEffect(() => {
@@ -63,12 +68,18 @@ export default function NotificationBell() {
 
       {isOpen && (
         <div className="absolute right-0 top-full mt-2 w-96 bg-white rounded-lg shadow-lg border border-slate-200 z-50">
-          <NotificationList
-            notifications={notifications}
-            onClickItem={handleClickItem}
-            onMarkAllRead={handleMarkAllRead}
-            onDelete={handleDelete}
-          />
+          {isLoading ? (
+            <div className="px-4 py-8 text-center text-sm text-slate-400">
+              Loading notifications...
+            </div>
+          ) : (
+            <NotificationList
+              notifications={notifications}
+              onClickItem={handleClickItem}
+              onMarkAllRead={handleMarkAllRead}
+              onDelete={handleDelete}
+            />
+          )}
           <div className="px-4 py-2 border-t border-slate-100">
             <button
               onClick={() => {

--- a/components/realtime/SocketConnectionStatus.tsx
+++ b/components/realtime/SocketConnectionStatus.tsx
@@ -2,7 +2,7 @@
 
 import { AlertCircle, Loader2, Wifi, WifiOff } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
-import { useSocket } from "@/hooks/useSocket"
+import { useSocketState } from "@/hooks/useSocket"
 import { cn } from "@/lib/utils"
 
 interface SocketConnectionBadgeProps {
@@ -15,7 +15,7 @@ interface SocketConnectionNoticeProps {
 
 function getSocketStatusPresentation(params: {
   realtimeEnabled: boolean
-  connectionStatus: ReturnType<typeof useSocket>["connectionStatus"]
+  connectionStatus: ReturnType<typeof useSocketState>["connectionStatus"]
   fallbackActive: boolean
   connectionError: string | null
 }) {
@@ -23,7 +23,7 @@ function getSocketStatusPresentation(params: {
 
   if (!realtimeEnabled) {
     return {
-      badgeLabel: "Polling",
+      badgeLabel: "폴링",
       badgeClassName:
         "border-slate-200 bg-white/80 text-slate-500 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300",
       BadgeIcon: WifiOff,
@@ -33,7 +33,7 @@ function getSocketStatusPresentation(params: {
 
   if (connectionStatus === "connected") {
     return {
-      badgeLabel: fallbackActive ? "Recovering" : "Realtime",
+      badgeLabel: fallbackActive ? "복구 중" : "실시간",
       badgeClassName:
         "bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/10 dark:bg-emerald-500/15 dark:text-emerald-300",
       BadgeIcon: Wifi,
@@ -48,42 +48,42 @@ function getSocketStatusPresentation(params: {
         "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300",
       BadgeIcon: WifiOff,
       notice: connectionError
-        ? `Realtime sync is unavailable, so polling fallback is active. ${connectionError}`
-        : "Realtime sync is unavailable, so polling fallback is active.",
+        ? `실시간 동기화 서버에 연결할 수 없어 React Query 폴링 폴백으로 전환했습니다. ${connectionError}`
+        : "실시간 동기화 서버에 연결할 수 없어 React Query 폴링 폴백으로 전환했습니다.",
     }
   }
 
   if (connectionStatus === "connecting" || connectionStatus === "reconnecting") {
     return {
-      badgeLabel: connectionStatus === "connecting" ? "Connecting" : "Reconnecting",
+      badgeLabel: connectionStatus === "connecting" ? "연결 중" : "재연결 중",
       badgeClassName:
         "bg-blue-500/10 text-blue-700 hover:bg-blue-500/10 dark:bg-blue-500/15 dark:text-blue-300",
       BadgeIcon: Loader2,
       notice:
         connectionStatus === "reconnecting"
-          ? "Realtime connection is reconnecting."
+          ? "실시간 동기화 연결을 다시 시도하고 있습니다."
           : null,
     }
   }
 
   if (connectionStatus === "error") {
     return {
-      badgeLabel: "Socket Error",
+      badgeLabel: "소켓 오류",
       badgeClassName:
         "bg-rose-500/10 text-rose-700 hover:bg-rose-500/10 dark:bg-rose-500/15 dark:text-rose-300",
       BadgeIcon: AlertCircle,
       notice: connectionError
-        ? `Socket connection failed. ${connectionError}`
-        : "Socket connection failed.",
+        ? `소켓 연결에 실패했습니다. ${connectionError}`
+        : "소켓 연결에 실패했습니다.",
     }
   }
 
   return {
-    badgeLabel: "Offline",
+    badgeLabel: "오프라인",
     badgeClassName:
       "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300",
     BadgeIcon: WifiOff,
-    notice: "Realtime connection was lost. Waiting to reconnect.",
+    notice: "실시간 동기화 연결이 끊어져 재연결을 대기 중입니다.",
   }
 }
 
@@ -91,7 +91,7 @@ export function SocketConnectionBadge({
   className,
 }: SocketConnectionBadgeProps) {
   const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } =
-    useSocket()
+    useSocketState()
 
   const presentation = getSocketStatusPresentation({
     realtimeEnabled,
@@ -115,7 +115,7 @@ export function SocketConnectionNotice({
   className,
 }: SocketConnectionNoticeProps) {
   const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } =
-    useSocket()
+    useSocketState()
 
   const presentation = getSocketStatusPresentation({
     realtimeEnabled,

--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -1,10 +1,12 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
+  appendCommentToThread,
   findCommentInThread,
   normalizeComment,
   toggleReactionForUser,
   updateCommentReactionsInThread,
 } from "@/lib/comments/cache"
+import { useSocketState } from "./useSocket"
 import type {
   CommentWithAuthor,
   CommentsListResponse,
@@ -63,6 +65,8 @@ export function useComments(prId: string) {
 
 export function useCreateComment(prId: string) {
   const queryClient = useQueryClient()
+  const { fallbackActive, realtimeEnabled } = useSocketState()
+  const shouldPatchCommentCache = !realtimeEnabled || fallbackActive
 
   return useMutation({
     mutationFn: async (input: CreateCommentInput) => {
@@ -74,6 +78,13 @@ export function useCreateComment(prId: string) {
       if (!res.ok) throw new Error("Failed to create comment.")
       const data = await res.json()
       return normalizeComment(data.comment as CommentWithAuthor)
+    },
+    onSuccess: (comment) => {
+      if (!shouldPatchCommentCache) return
+
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old ? appendCommentToThread(old, comment) : [comment]
+      )
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", prId] })

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -2,12 +2,14 @@
 
 import { useEffect, useCallback, useMemo, useRef } from "react"
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import type { QueryClient, QueryKey } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { useSocket } from "./useSocket"
+import { useSocket, useSocketState } from "./useSocket"
 import type {
   BaseNotification,
   Notification,
   NotificationsResponse,
+  NotificationSummaryResponse,
   NotificationFilterType,
   NotificationFilterRead,
 } from "@/types/notification"
@@ -18,6 +20,23 @@ import {
 } from "@/lib/measurements/socketMetrics"
 
 const toastedNotificationIds = new Set<string>()
+const NOTIFICATION_STALE_TIME_MS = 30_000
+const NOTIFICATION_POLL_INTERVAL_MS = 10_000
+const notificationSummaryQueryKey = ["notifications", "summary"] as const
+const notificationListQueryKey = (
+  type?: NotificationFilterType,
+  read?: NotificationFilterRead
+) => ["notifications", "list", type ?? "ALL", read ?? "all"] as const
+
+type UseNotificationsOptions = {
+  enabled?: boolean
+}
+
+async function fetchNotificationSummary(): Promise<NotificationSummaryResponse> {
+  const res = await fetch("/api/notifications/summary")
+  if (!res.ok) return { unreadCount: 0 }
+  return res.json()
+}
 
 async function fetchNotifications(
   type?: NotificationFilterType,
@@ -43,6 +62,71 @@ async function markAsReadApi(ids?: string[]): Promise<void> {
 
 async function deleteNotificationApi(id: string): Promise<void> {
   await fetch(`/api/notifications/${id}`, { method: "DELETE" })
+}
+
+function toListNotification(base: BaseNotification): Notification {
+  return {
+    ...base,
+    prTitle: base.prTitle ?? null,
+    prNumber: base.prNumber ?? null,
+    repoFullName: base.repoFullName ?? null,
+  }
+}
+
+function notificationMatchesFilters(
+  notification: Notification,
+  type?: NotificationFilterType,
+  read?: NotificationFilterRead
+) {
+  if (type && type !== "ALL" && notification.type !== type) return false
+  if (read === "unread" && notification.isRead) return false
+  if (read === "read" && !notification.isRead) return false
+  return true
+}
+
+function getListFilters(queryKey: QueryKey) {
+  const key = queryKey as readonly unknown[]
+  return {
+    type: key[2] as NotificationFilterType | undefined,
+    read: key[3] as NotificationFilterRead | undefined,
+  }
+}
+
+function updateExistingNotificationLists(
+  queryClient: QueryClient,
+  notification: Notification
+) {
+  const listQueries = queryClient.getQueriesData<NotificationsResponse>({
+    queryKey: ["notifications", "list"],
+  })
+
+  for (const [queryKey, old] of listQueries) {
+    if (!old) continue
+
+    const { type, read } = getListFilters(queryKey)
+    if (!notificationMatchesFilters(notification, type, read)) continue
+    if (old.notifications.some((item) => item.id === notification.id)) continue
+
+    queryClient.setQueryData<NotificationsResponse>(queryKey, {
+      notifications: [notification, ...old.notifications],
+      unreadCount: old.unreadCount + (notification.isRead ? 0 : 1),
+      total: old.total + 1,
+    })
+  }
+}
+
+function patchNotificationLists(
+  queryClient: QueryClient,
+  updater: (old: NotificationsResponse) => NotificationsResponse
+) {
+  const listQueries = queryClient.getQueriesData<NotificationsResponse>({
+    queryKey: ["notifications", "list"],
+  })
+
+  for (const [queryKey, old] of listQueries) {
+    if (!old) continue
+    queryClient.setQueryData<NotificationsResponse>(queryKey, updater(old))
+  }
 }
 
 function getToastMessage(notification: BaseNotification) {
@@ -113,22 +197,32 @@ function showNotificationToast(notification: BaseNotification) {
   })
 }
 
-export function useNotifications(
-  typeFilter?: NotificationFilterType,
-  readFilter?: NotificationFilterRead
-) {
+function showPollingNotificationToast() {
+  toast("New notification", {
+    description: "Open notifications to see the latest updates.",
+    duration: 5000,
+    action: {
+      label: "View",
+      onClick: () => {
+        window.location.assign("/notifications")
+      },
+    },
+  })
+}
+
+export function useNotificationSummary() {
   const { socket, fallbackActive, realtimeEnabled } = useSocket()
   const queryClient = useQueryClient()
   const previousFallbackRef = useRef(fallbackActive)
+  const previousUnreadCountRef = useRef<number | null>(null)
 
   const { data, isLoading } = useQuery({
-    queryKey: ["notifications", typeFilter, readFilter],
-    queryFn: () => fetchNotifications(typeFilter, readFilter),
-    refetchInterval: realtimeEnabled && !fallbackActive ? false : 10_000,
+    queryKey: notificationSummaryQueryKey,
+    queryFn: fetchNotificationSummary,
+    staleTime: NOTIFICATION_STALE_TIME_MS,
+    refetchInterval:
+      realtimeEnabled && !fallbackActive ? false : NOTIFICATION_POLL_INTERVAL_MS,
   })
-
-  const notifications = useMemo(() => data?.notifications ?? [], [data])
-  const unreadCount = useMemo(() => data?.unreadCount ?? 0, [data])
 
   const handleNew = useCallback(
     (base: BaseNotification) => {
@@ -139,28 +233,15 @@ export function useNotifications(
         showNotificationToast(base)
       }
 
-      const notification: Notification = {
-        ...base,
-        prTitle: null,
-        prNumber: null,
-        repoFullName: null,
-      }
+      const notification = toListNotification(base)
 
-      queryClient.setQueryData<NotificationsResponse>(
-        ["notifications", typeFilter, readFilter],
-        (old) => {
-          if (!old) return { notifications: [notification], unreadCount: 1, total: 1 }
-          return {
-            notifications: [notification, ...old.notifications],
-            unreadCount: old.unreadCount + 1,
-            total: old.total + 1,
-          }
-        }
+      queryClient.setQueryData<NotificationSummaryResponse>(
+        notificationSummaryQueryKey,
+        (old) => ({ unreadCount: (old?.unreadCount ?? 0) + 1 })
       )
-
-      queryClient.invalidateQueries({ queryKey: ["notifications"] })
+      updateExistingNotificationLists(queryClient, notification)
     },
-    [queryClient, typeFilter, readFilter]
+    [queryClient]
   )
 
   useEffect(() => {
@@ -182,24 +263,76 @@ export function useNotifications(
     previousFallbackRef.current = fallbackActive
   }, [fallbackActive, queryClient])
 
+  useEffect(() => {
+    if (!data) return
+
+    const unreadCount = data.unreadCount
+    const previousUnreadCount = previousUnreadCountRef.current
+    previousUnreadCountRef.current = unreadCount
+
+    if (previousUnreadCount == null) return
+    if (realtimeEnabled && !fallbackActive) return
+    if (unreadCount <= previousUnreadCount) return
+
+    showPollingNotificationToast()
+  }, [data, fallbackActive, realtimeEnabled])
+
+  return {
+    unreadCount: data?.unreadCount ?? 0,
+    isLoading,
+    fallbackActive,
+    realtimeEnabled,
+  }
+}
+
+export function useNotifications(
+  typeFilter?: NotificationFilterType,
+  readFilter?: NotificationFilterRead,
+  options: UseNotificationsOptions = {}
+) {
+  const { fallbackActive, realtimeEnabled } = useSocketState()
+  const queryClient = useQueryClient()
+  const enabled = options.enabled ?? true
+
+  const { data, isLoading } = useQuery({
+    queryKey: notificationListQueryKey(typeFilter, readFilter),
+    queryFn: () => fetchNotifications(typeFilter, readFilter),
+    enabled,
+    staleTime: NOTIFICATION_STALE_TIME_MS,
+    refetchInterval: enabled
+      ? realtimeEnabled && !fallbackActive
+        ? false
+        : NOTIFICATION_POLL_INTERVAL_MS
+      : false,
+  })
+
+  const notifications = useMemo(() => data?.notifications ?? [], [data])
+  const unreadCount = useMemo(() => data?.unreadCount ?? 0, [data])
+
   const { mutate: markAsRead } = useMutation({
     mutationFn: markAsReadApi,
     onMutate: async (ids?: string[]) => {
       await queryClient.cancelQueries({ queryKey: ["notifications"] })
-      queryClient.setQueryData<NotificationsResponse>(
-        ["notifications", typeFilter, readFilter],
-        (old) => {
-          if (!old) return old
-          return {
-            ...old,
-            notifications: old.notifications.map((n) =>
-              !ids || ids.includes(n.id) ? { ...n, isRead: true } : n
-            ),
-            unreadCount: ids
-              ? old.unreadCount - old.notifications.filter((n) => !n.isRead && ids.includes(n.id)).length
-              : 0,
-          }
+      patchNotificationLists(queryClient, (old) => {
+        const readCount = ids
+          ? old.notifications.filter((n) => !n.isRead && ids.includes(n.id)).length
+          : old.unreadCount
+
+        return {
+          ...old,
+          notifications: old.notifications.map((n) =>
+            !ids || ids.includes(n.id) ? { ...n, isRead: true } : n
+          ),
+          unreadCount: ids ? Math.max(0, old.unreadCount - readCount) : 0,
         }
+      })
+      queryClient.setQueryData<NotificationSummaryResponse>(
+        notificationSummaryQueryKey,
+        (old) => ({
+          unreadCount: ids
+            ? Math.max(0, (old?.unreadCount ?? 0) - ids.length)
+            : 0,
+        })
       )
     },
     onSettled: () => {
@@ -211,19 +344,31 @@ export function useNotifications(
     mutationFn: deleteNotificationApi,
     onMutate: async (id: string) => {
       await queryClient.cancelQueries({ queryKey: ["notifications"] })
-      queryClient.setQueryData<NotificationsResponse>(
-        ["notifications", typeFilter, readFilter],
-        (old) => {
-          if (!old) return old
-          const target = old.notifications.find((n) => n.id === id)
-          return {
-            ...old,
-            notifications: old.notifications.filter((n) => n.id !== id),
-            unreadCount: target && !target.isRead ? old.unreadCount - 1 : old.unreadCount,
-            total: old.total - 1,
-          }
+      let shouldDecrementUnread = false
+
+      patchNotificationLists(queryClient, (old) => {
+        const target = old.notifications.find((n) => n.id === id)
+        if (target && !target.isRead) shouldDecrementUnread = true
+
+        return {
+          ...old,
+          notifications: old.notifications.filter((n) => n.id !== id),
+          unreadCount:
+            target && !target.isRead
+              ? Math.max(0, old.unreadCount - 1)
+              : old.unreadCount,
+          total: Math.max(0, old.total - 1),
         }
-      )
+      })
+
+      if (shouldDecrementUnread) {
+        queryClient.setQueryData<NotificationSummaryResponse>(
+          notificationSummaryQueryKey,
+          (old) => ({
+            unreadCount: Math.max(0, (old?.unreadCount ?? 0) - 1),
+          })
+        )
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["notifications"] })

--- a/hooks/useSocket.ts
+++ b/hooks/useSocket.ts
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useSyncExternalStore } from "react"
-import { io } from "socket.io-client"
 import type { TypedClientSocket } from "@/lib/socket/types"
 import {
   recordSocketConnectCall,
@@ -30,6 +29,7 @@ let fallbackActive = !realtimeEnabled
 let status: SocketConnectionStatus = "idle"
 let lastError: string | null = null
 let fallbackTimer: number | null = null
+let socketAttemptBlocked = false
 const listeners = new Set<() => void>()
 
 function notify() {
@@ -98,13 +98,31 @@ function clearFallbackTimer() {
   fallbackTimer = null
 }
 
+function stopSocketConnection() {
+  if (!socket) return
+
+  const currentSocket = socket
+  socket = null
+  currentSocket.removeAllListeners()
+  currentSocket.disconnect()
+}
+
+function activatePollingFallback() {
+  clearFallbackTimer()
+  socketAttemptBlocked = true
+  fallbackActive = true
+  connected = false
+  connecting = false
+  stopSocketConnection()
+  notify()
+}
+
 function scheduleFallbackActivation() {
   if (!realtimeEnabled || fallbackActive || fallbackTimer != null) return
 
   fallbackTimer = window.setTimeout(() => {
     fallbackTimer = null
-    fallbackActive = true
-    notify()
+    activatePollingFallback()
   }, SOCKET_FALLBACK_GRACE_MS)
 }
 
@@ -166,6 +184,14 @@ async function connect() {
     return
   }
 
+  if (socketAttemptBlocked) {
+    fallbackActive = true
+    connected = false
+    connecting = false
+    notify()
+    return
+  }
+
   if (socket) {
     if (!socket.connected && !connecting) {
       setConnectionState("reconnecting", {
@@ -198,6 +224,7 @@ async function connect() {
     }
 
     const { token } = await res.json()
+    const { io } = await import("socket.io-client")
 
     recordSocketCreate()
     socket = io(process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:4000", {
@@ -252,11 +279,7 @@ async function connect() {
   }
 }
 
-export function useSocket() {
-  useEffect(() => {
-    void connect()
-  }, [])
-
+export function useSocketState() {
   const currentSocket = useSyncExternalStore(
     subscribe,
     getSocketSnapshot,
@@ -297,4 +320,17 @@ export function useSocket() {
     realtimeEnabled: currentRealtimeEnabled,
     degraded: currentRealtimeEnabled && currentFallbackActive,
   }
+}
+
+export function useEnsureSocketConnection() {
+  useEffect(() => {
+    if (!realtimeEnabled) return
+
+    void connect()
+  }, [])
+}
+
+export function useSocket() {
+  useEnsureSocketConnection()
+  return useSocketState()
 }

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -31,6 +31,10 @@ export interface NotificationsResponse {
   total: number
 }
 
+export interface NotificationSummaryResponse {
+  unreadCount: number
+}
+
 export interface NotificationSetting {
   mentionEnabled: boolean
   newReviewEnabled: boolean


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

보호 페이지의 공통 헤더에서 알림 전체 목록 API를 즉시 호출하던 구조를 unread summary 중심으로 분리했습니다. 초기 페이지 로드에서는 `/api/notifications/summary`만 호출하고, 알림 드롭다운을 열 때만 `/api/notifications` 목록을 lazy fetch합니다.

또한 polling 모드에서는 socket 연결과 socket.io client bundle 로드를 시도하지 않도록 상태 구독과 실제 연결을 분리했고, polling/fallback 상태에서도 댓글 작성 직후 cache를 먼저 패치해 다음 polling 주기를 기다리지 않도록 했습니다.

이 PR은 #161 이후의 후속 stacked PR이며, base는 `fix/159-pr-files-401-auto-logout`입니다.

## 변경 사항

- `hooks/useSocket.ts`
  - `useSocketState()`와 `useEnsureSocketConnection()` 분리
  - `socket.io-client`를 실제 연결 시점에 dynamic import
  - polling mode에서는 socket token/API/socket.io 연결 시도를 하지 않도록 유지
- `components/realtime/SocketConnectionStatus.tsx`
  - 상태 배지는 `useSocketState()`만 구독하도록 변경
  - 배지 표시 때문에 socket 연결이 시작되지 않도록 분리
- `hooks/useComments.ts`
  - polling/fallback 상태에서 댓글 생성 성공 시 `setQueryData`로 comments cache에 즉시 append
  - socket mode에서는 기존 realtime 이벤트 흐름을 유지
- `app/api/notifications/summary/route.ts`
  - unread count 전용 summary API 추가
  - 헤더 배지용 DB query를 unread count 단일 조회로 축소
- `hooks/useNotifications.ts`
  - `useNotificationSummary()`와 `useNotifications()` 분리
  - socket notification event에서는 무분별한 invalidate/refetch 대신 summary/list cache 직접 업데이트
  - polling/fallback mode에서 unread count 증가 시 generic toast 표시
  - 알림 목록 query는 `enabled` 옵션으로 드롭다운 open 시에만 실행 가능하게 변경
- `components/notification/NotificationBell.tsx`
  - 헤더 배지는 summary hook 사용
  - 드롭다운 open 시에만 전체 notification list fetch
- `types/notification.ts`
  - `NotificationSummaryResponse` 타입 추가

## 스크린샷 (선택)

N/A - 네트워크/API 호출 경로와 realtime fallback 동작 최적화이며 의도한 UI 변경은 없습니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
  - 수동 확인 필요
- [x] 기존 기능에 영향 없음 확인
  - Network 기준 polling mode에서 초기 `/api/notifications` 호출이 발생하지 않고 `/api/notifications/summary`만 호출되는 것을 확인했습니다.
  - polling mode에서 `/api/socket/token`과 `socket.io` app 연결이 발생하지 않는 것을 확인했습니다.
- [ ] 타입 에러 없음 (`tsc --noEmit`)
  - `npx.cmd tsc --noEmit --pretty false`
  - 결과: 실패
  - 기존 Prisma/generated 타입 불일치로 실패합니다. 예: `BaseNotification.reviewStatus` missing, Prisma `Review.stage`/`Notification.reviewStatus` field mismatch.
- [x] ESLint 경고/에러 없음
  - `npm.cmd run lint`
  - 결과: 통과, 기존 경고 1개 유지 (`hooks/useRealtimeComments.ts`의 `appendComment` unused)
- [x] 테스트 실행
  - `npm.cmd test -- --runInBand`
  - 결과: 통과, 22 suites / 131 tests passed

## 참고 사항

이번 변경에서 기대하는 확인 포인트:

- 초기 로드: `/api/notifications/summary`만 호출, `/api/notifications` 미호출
- 드롭다운 open: 그때 `/api/notifications` 호출
- socket mode: `notification:new` 수신 시 rich toast 유지, list invalidate/refetch 없이 cache 직접 업데이트
- polling/fallback mode: unread count 증가 시 generic toast만 표시하고 전체 목록은 드롭다운 open 전까지 가져오지 않음
