### PR TITLE
perf: PR Detail 성능 개선 스택 main 반영

### DIFF
--- a/app/api/notifications/summary/route.ts
+++ b/app/api/notifications/summary/route.ts
@@ -1,0 +1,16 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function GET() {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const unreadCount = await prisma.notification.count({
+    where: { userId: session.user.id, isRead: false },
+  })
+
+  return Response.json({ unreadCount })
+}

--- a/components/notification/NotificationBell.tsx
+++ b/components/notification/NotificationBell.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Bell } from "lucide-react"
-import { useNotifications } from "@/hooks/useNotifications"
+import { useNotificationSummary, useNotifications } from "@/hooks/useNotifications"
 import { getNotificationLink } from "@/lib/notification-link"
 import NotificationList from "./NotificationList"
 import type { Notification } from "@/types/notification"
@@ -12,7 +12,12 @@ export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const router = useRouter()
-  const { notifications, unreadCount, markAsRead, deleteNotification } = useNotifications()
+  const { unreadCount } = useNotificationSummary()
+  const { notifications, isLoading, markAsRead, deleteNotification } = useNotifications(
+    undefined,
+    undefined,
+    { enabled: isOpen }
+  )
 
   // 외부 클릭 시 드롭다운 닫기
   useEffect(() => {
@@ -63,12 +68,18 @@ export default function NotificationBell() {
 
       {isOpen && (
         <div className="absolute right-0 top-full mt-2 w-96 bg-white rounded-lg shadow-lg border border-slate-200 z-50">
-          <NotificationList
-            notifications={notifications}
-            onClickItem={handleClickItem}
-            onMarkAllRead={handleMarkAllRead}
-            onDelete={handleDelete}
-          />
+          {isLoading ? (
+            <div className="px-4 py-8 text-center text-sm text-slate-400">
+              Loading notifications...
+            </div>
+          ) : (
+            <NotificationList
+              notifications={notifications}
+              onClickItem={handleClickItem}
+              onMarkAllRead={handleMarkAllRead}
+              onDelete={handleDelete}
+            />
+          )}
           <div className="px-4 py-2 border-t border-slate-100">
             <button
               onClick={() => {

--- a/components/pulls/detail/IssueModalHost.tsx
+++ b/components/pulls/detail/IssueModalHost.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ReviewIssue } from "@/types/review";
+
+const IssueDetailModal = dynamic(
+  () => import("@/components/review/IssueDetailModal"),
+  { ssr: false }
+);
+
+interface IssueModalHostProps {
+  issue: ReviewIssue | null;
+  onClose: () => void;
+}
+
+export default function IssueModalHost({ issue, onClose }: IssueModalHostProps) {
+  if (!issue) return null;
+
+  return (
+    <IssueDetailModal
+      issue={issue}
+      onClose={onClose}
+    />
+  );
+}

--- a/components/pulls/detail/PRDetailLayout.tsx
+++ b/components/pulls/detail/PRDetailLayout.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import FloatingCommentsButton from "./FloatingCommentsButton";
+import IssueModalHost from "./IssueModalHost";
 import PRDetailStickyHeader from "./PRDetailStickyHeader";
 import PRDiffSection from "./PRDiffSection";
 import PRFileList from "./PRFileList";
@@ -13,6 +14,7 @@ import { usePRDetailReset } from "@/hooks/pr-detail/usePRDetailReset";
 import { useSocketRoom } from "@/hooks/useSocketRoom";
 import { layoutStyles } from "@/lib/styles";
 import { usePRDetailStore } from "@/stores/prDetailStore";
+import type { ReviewIssue } from "@/types/review";
 
 interface PRDetailLayoutProps {
   id: string;
@@ -34,6 +36,7 @@ export default function PRDetailLayout({
     );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [scrolled, setScrolled] = useState(false);
+  const [selectedIssue, setSelectedIssue] = useState<ReviewIssue | null>(null);
 
   useSocketRoom(id);
   usePRDetailReset(id);
@@ -51,6 +54,14 @@ export default function PRDetailLayout({
     if (!el || !target) return;
     target.scrollIntoView({ behavior: "smooth", block: "start" });
   };
+
+  const handleIssueClick = useCallback((issue: ReviewIssue) => {
+    setSelectedIssue(issue);
+  }, []);
+
+  const handleIssueClose = useCallback(() => {
+    setSelectedIssue(null);
+  }, []);
 
   return (
     <div className={`${layoutStyles.detailFrame} relative`}>
@@ -76,11 +87,15 @@ export default function PRDetailLayout({
         />
 
         <div className="space-y-4 p-4">
-          <ReviewSection prId={id} />
+          <ReviewSection
+            prId={id}
+            onIssueClick={handleIssueClick}
+          />
 
           <PRDiffSection
             prId={id}
             currentUserId={currentUserId}
+            onIssueClick={handleIssueClick}
           />
 
           <div id="general-comments" className="scroll-mt-36">
@@ -92,6 +107,11 @@ export default function PRDetailLayout({
           prId={id}
           visible={scrolled}
           onClick={handleScrollToComments}
+        />
+
+        <IssueModalHost
+          issue={selectedIssue}
+          onClose={handleIssueClose}
         />
       </div>
     </div>

--- a/components/pulls/detail/PRDiffSection.tsx
+++ b/components/pulls/detail/PRDiffSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -21,28 +21,24 @@ const PRDiffViewer = dynamic(() => import("./PRDiffViewer"), {
   loading: () => <Skeleton className="h-96 w-full rounded-lg" />,
 });
 
-const IssueDetailModal = dynamic(
-  () => import("@/components/review/IssueDetailModal"),
-  { ssr: false }
-);
-
 const EMPTY_ISSUES: ReviewIssue[] = [];
 const EMPTY_COMMENTS: CommentWithAuthor[] = [];
 
 interface PRDiffSectionProps {
   prId: string;
   currentUserId: string;
+  onIssueClick: (issue: ReviewIssue) => void;
 }
 
 export default function PRDiffSection({
   prId,
   currentUserId,
+  onIssueClick,
 }: PRDiffSectionProps) {
   const { data: files = [], isPending, isError } = useCachedPRFiles(prId);
   const { data: review } = useCachedReview(prId);
   const selectedFile = usePRDetailStore((state) => state.selectedFile);
   const { inlineCommentsByFile } = usePRCommentGroups(prId);
-  const [selectedIssue, setSelectedIssue] = useState<ReviewIssue | null>(null);
   const issuesByFile = useMemo(
     () => groupIssuesByFile(getIndexedReviewIssues(review)),
     [review]
@@ -73,17 +69,12 @@ export default function PRDiffSection({
           file={file}
           isActive={selectedFile === file.filename}
           issues={issuesByFile.get(file.filename) ?? EMPTY_ISSUES}
-          onIssueClick={setSelectedIssue}
+          onIssueClick={onIssueClick}
           prId={prId}
           currentUserId={currentUserId}
           inlineComments={inlineCommentsByFile[file.filename] ?? EMPTY_COMMENTS}
         />
       ))}
-
-      <IssueDetailModal
-        issue={selectedIssue}
-        onClose={() => setSelectedIssue(null)}
-      />
     </>
   );
 }

--- a/components/pulls/detail/ReviewSection.tsx
+++ b/components/pulls/detail/ReviewSection.tsx
@@ -3,27 +3,24 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { BotMessageSquare, ChevronDown } from "lucide-react";
-import dynamic from "next/dynamic";
 import ReviewPanel from "@/components/review/ReviewPanel";
 import { useReview } from "@/hooks/useReview";
 import type { ReviewIssue } from "@/types/review";
 
-const IssueDetailModal = dynamic(
-  () => import("@/components/review/IssueDetailModal"),
-  { ssr: false }
-);
-
 interface ReviewSectionProps {
   prId: string;
+  onIssueClick: (issue: ReviewIssue) => void;
 }
 
-export default function ReviewSection({ prId }: ReviewSectionProps) {
+export default function ReviewSection({
+  prId,
+  onIssueClick,
+}: ReviewSectionProps) {
   const { data: review } = useReview(prId);
   const searchParams = useSearchParams();
   const [reviewOpen, setReviewOpen] = useState(
     () => searchParams.get("review") === "open"
   );
-  const [selectedIssue, setSelectedIssue] = useState<ReviewIssue | null>(null);
 
   useEffect(() => {
     if (searchParams.get("review") !== "open") return;
@@ -68,16 +65,11 @@ export default function ReviewSection({ prId }: ReviewSectionProps) {
           <div className="p-4">
             <ReviewPanel
               prId={prId}
-              onIssueClick={setSelectedIssue}
+              onIssueClick={onIssueClick}
             />
           </div>
         )}
       </div>
-
-      <IssueDetailModal
-        issue={selectedIssue}
-        onClose={() => setSelectedIssue(null)}
-      />
     </>
   );
 }

--- a/components/realtime/SocketConnectionStatus.tsx
+++ b/components/realtime/SocketConnectionStatus.tsx
@@ -2,7 +2,7 @@
 
 import { AlertCircle, Loader2, Wifi, WifiOff } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
-import { useSocket } from "@/hooks/useSocket"
+import { useSocketState } from "@/hooks/useSocket"
 import { cn } from "@/lib/utils"
 
 interface SocketConnectionBadgeProps {
@@ -15,7 +15,7 @@ interface SocketConnectionNoticeProps {
 
 function getSocketStatusPresentation(params: {
   realtimeEnabled: boolean
-  connectionStatus: ReturnType<typeof useSocket>["connectionStatus"]
+  connectionStatus: ReturnType<typeof useSocketState>["connectionStatus"]
   fallbackActive: boolean
   connectionError: string | null
 }) {
@@ -23,7 +23,7 @@ function getSocketStatusPresentation(params: {
 
   if (!realtimeEnabled) {
     return {
-      badgeLabel: "Polling",
+      badgeLabel: "폴링",
       badgeClassName:
         "border-slate-200 bg-white/80 text-slate-500 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300",
       BadgeIcon: WifiOff,
@@ -33,7 +33,7 @@ function getSocketStatusPresentation(params: {
 
   if (connectionStatus === "connected") {
     return {
-      badgeLabel: fallbackActive ? "Recovering" : "Realtime",
+      badgeLabel: fallbackActive ? "복구 중" : "실시간",
       badgeClassName:
         "bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/10 dark:bg-emerald-500/15 dark:text-emerald-300",
       BadgeIcon: Wifi,
@@ -48,42 +48,42 @@ function getSocketStatusPresentation(params: {
         "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300",
       BadgeIcon: WifiOff,
       notice: connectionError
-        ? `Realtime sync is unavailable, so polling fallback is active. ${connectionError}`
-        : "Realtime sync is unavailable, so polling fallback is active.",
+        ? `실시간 동기화 서버에 연결할 수 없어 React Query 폴링 폴백으로 전환했습니다. ${connectionError}`
+        : "실시간 동기화 서버에 연결할 수 없어 React Query 폴링 폴백으로 전환했습니다.",
     }
   }
 
   if (connectionStatus === "connecting" || connectionStatus === "reconnecting") {
     return {
-      badgeLabel: connectionStatus === "connecting" ? "Connecting" : "Reconnecting",
+      badgeLabel: connectionStatus === "connecting" ? "연결 중" : "재연결 중",
       badgeClassName:
         "bg-blue-500/10 text-blue-700 hover:bg-blue-500/10 dark:bg-blue-500/15 dark:text-blue-300",
       BadgeIcon: Loader2,
       notice:
         connectionStatus === "reconnecting"
-          ? "Realtime connection is reconnecting."
+          ? "실시간 동기화 연결을 다시 시도하고 있습니다."
           : null,
     }
   }
 
   if (connectionStatus === "error") {
     return {
-      badgeLabel: "Socket Error",
+      badgeLabel: "소켓 오류",
       badgeClassName:
         "bg-rose-500/10 text-rose-700 hover:bg-rose-500/10 dark:bg-rose-500/15 dark:text-rose-300",
       BadgeIcon: AlertCircle,
       notice: connectionError
-        ? `Socket connection failed. ${connectionError}`
-        : "Socket connection failed.",
+        ? `소켓 연결에 실패했습니다. ${connectionError}`
+        : "소켓 연결에 실패했습니다.",
     }
   }
 
   return {
-    badgeLabel: "Offline",
+    badgeLabel: "오프라인",
     badgeClassName:
       "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10 dark:bg-amber-500/15 dark:text-amber-300",
     BadgeIcon: WifiOff,
-    notice: "Realtime connection was lost. Waiting to reconnect.",
+    notice: "실시간 동기화 연결이 끊어져 재연결을 대기 중입니다.",
   }
 }
 
@@ -91,7 +91,7 @@ export function SocketConnectionBadge({
   className,
 }: SocketConnectionBadgeProps) {
   const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } =
-    useSocket()
+    useSocketState()
 
   const presentation = getSocketStatusPresentation({
     realtimeEnabled,
@@ -115,7 +115,7 @@ export function SocketConnectionNotice({
   className,
 }: SocketConnectionNoticeProps) {
   const { realtimeEnabled, connectionStatus, fallbackActive, connectionError } =
-    useSocket()
+    useSocketState()
 
   const presentation = getSocketStatusPresentation({
     realtimeEnabled,

--- a/components/review/SuggestionCard.tsx
+++ b/components/review/SuggestionCard.tsx
@@ -1,50 +1,44 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Copy, Check, MapPin } from "lucide-react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { ChevronDown, ChevronRight, MapPin } from "lucide-react";
 import type { ReviewIssue } from "@/types/review";
 import ReviewBadge from "./ReviewBadge";
+import SuggestionCodeBlock from "./SuggestionCodeBlock";
 
 interface SuggestionCardProps {
   issue: ReviewIssue;
   onIssueClick?: (issue: ReviewIssue) => void;
 }
 
-export default function SuggestionCard({ issue, onIssueClick }: SuggestionCardProps) {
+export default function SuggestionCard({
+  issue,
+  onIssueClick,
+}: SuggestionCardProps) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    if (!issue.exampleCode) return;
-    await navigator.clipboard.writeText(issue.exampleCode);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   return (
     <div
       id={`suggestion-card-${issue.originalIndex}`}
-      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 overflow-hidden"
+      className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900"
     >
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
-        className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/60 transition-colors"
+        className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/60"
       >
-        <span className="mt-0.5 text-slate-400 shrink-0">
+        <span className="mt-0.5 shrink-0 text-slate-400">
           {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
         </span>
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-semibold text-slate-800 dark:text-slate-200 leading-snug">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-snug text-slate-800 dark:text-slate-200">
             {issue.title}
           </p>
-          <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
             <ReviewBadge severity={issue.severity} category={issue.category} />
             {issue.lineNumber != null && (
-              <span className="inline-flex items-center gap-1 text-[11px] text-slate-400 dark:text-slate-500 font-mono">
+              <span className="inline-flex items-center gap-1 font-mono text-[11px] text-slate-400 dark:text-slate-500">
                 <MapPin size={10} />
                 {issue.filePath}:{issue.lineNumber}
               </span>
@@ -54,62 +48,31 @@ export default function SuggestionCard({ issue, onIssueClick }: SuggestionCardPr
       </button>
 
       {open && (
-        <div className="px-4 pb-4 space-y-3 border-t border-slate-100 dark:border-slate-800 pt-3">
+        <div className="space-y-3 border-t border-slate-100 px-4 pb-4 pt-3 dark:border-slate-800">
           <div>
-            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
               설명
             </p>
-            <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
               {issue.description}
             </p>
           </div>
           <div>
-            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
               제안
             </p>
-            <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
               {issue.suggestion}
             </p>
           </div>
           {issue.exampleCode && (
-            <div>
-              <div className="flex items-center justify-between mb-1">
-                <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
-                  예시 코드
-                </p>
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className="inline-flex items-center gap-1 text-[11px] text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-                >
-                  {copied ? (
-                    <>
-                      <Check size={12} className="text-emerald-500" />
-                      <span className="text-emerald-500">복사됨</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy size={12} />
-                      <span>복사</span>
-                    </>
-                  )}
-                </button>
-              </div>
-              <SyntaxHighlighter
-                language="typescript"
-                style={oneDark}
-                customStyle={{ borderRadius: "0.5rem", fontSize: "12px", margin: 0, padding: "12px" }}
-                wrapLongLines
-              >
-                {issue.exampleCode}
-              </SyntaxHighlighter>
-            </div>
+            <SuggestionCodeBlock code={issue.exampleCode} language="typescript" />
           )}
           {onIssueClick && (
             <button
               type="button"
               onClick={() => onIssueClick(issue)}
-              className="inline-flex items-center gap-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors"
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
             >
               자세히 보기
             </button>

--- a/components/review/SuggestionCodeBlock/PlainCodeBlock.tsx
+++ b/components/review/SuggestionCodeBlock/PlainCodeBlock.tsx
@@ -1,0 +1,11 @@
+interface PlainCodeBlockProps {
+  code: string;
+}
+
+export default function PlainCodeBlock({ code }: PlainCodeBlockProps) {
+  return (
+    <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-slate-950 p-3 font-mono text-[12px] leading-relaxed text-slate-100 dark:bg-black">
+      <code>{code}</code>
+    </pre>
+  );
+}

--- a/components/review/SuggestionCodeBlock/SyntaxHighlightedCode.tsx
+++ b/components/review/SuggestionCodeBlock/SyntaxHighlightedCode.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+interface SyntaxHighlightedCodeProps {
+  code: string;
+  language?: string;
+}
+
+const CODE_BLOCK_STYLE = {
+  borderRadius: "0.5rem",
+  fontSize: "12px",
+  margin: 0,
+  padding: "12px",
+};
+
+export default function SyntaxHighlightedCode({
+  code,
+  language = "typescript",
+}: SyntaxHighlightedCodeProps) {
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={oneDark}
+      customStyle={CODE_BLOCK_STYLE}
+      wrapLongLines
+    >
+      {code}
+    </SyntaxHighlighter>
+  );
+}

--- a/components/review/SuggestionCodeBlock/index.tsx
+++ b/components/review/SuggestionCodeBlock/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState, type ComponentType } from "react";
+import { Check, Copy } from "lucide-react";
+import PlainCodeBlock from "./PlainCodeBlock";
+
+interface SuggestionCodeBlockProps {
+  code: string;
+  language?: string;
+}
+
+type HighlightedCodeComponent = ComponentType<{
+  code: string;
+  language?: string;
+}>;
+
+export default function SuggestionCodeBlock({
+  code,
+  language = "typescript",
+}: SuggestionCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const [HighlightedCode, setHighlightedCode] =
+    useState<HighlightedCodeComponent | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void import("./SyntaxHighlightedCode")
+      .then((module) => {
+        if (!cancelled) {
+          setHighlightedCode(() => module.default);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setHighlightedCode(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!copied) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          예시 코드
+        </p>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1 text-[11px] text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
+        >
+          {copied ? (
+            <>
+              <Check size={12} className="text-emerald-500" />
+              <span className="text-emerald-500">복사됨</span>
+            </>
+          ) : (
+            <>
+              <Copy size={12} />
+              <span>복사</span>
+            </>
+          )}
+        </button>
+      </div>
+
+      {HighlightedCode ? (
+        <HighlightedCode code={code} language={language} />
+      ) : (
+        <PlainCodeBlock code={code} />
+      )}
+    </div>
+  );
+}

--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -1,10 +1,12 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
+  appendCommentToThread,
   findCommentInThread,
   normalizeComment,
   toggleReactionForUser,
   updateCommentReactionsInThread,
 } from "@/lib/comments/cache"
+import { useSocketState } from "./useSocket"
 import type {
   CommentWithAuthor,
   CommentsListResponse,
@@ -63,6 +65,8 @@ export function useComments(prId: string) {
 
 export function useCreateComment(prId: string) {
   const queryClient = useQueryClient()
+  const { fallbackActive, realtimeEnabled } = useSocketState()
+  const shouldPatchCommentCache = !realtimeEnabled || fallbackActive
 
   return useMutation({
     mutationFn: async (input: CreateCommentInput) => {
@@ -74,6 +78,13 @@ export function useCreateComment(prId: string) {
       if (!res.ok) throw new Error("Failed to create comment.")
       const data = await res.json()
       return normalizeComment(data.comment as CommentWithAuthor)
+    },
+    onSuccess: (comment) => {
+      if (!shouldPatchCommentCache) return
+
+      queryClient.setQueryData<CommentWithAuthor[]>(["comments", prId], (old) =>
+        old ? appendCommentToThread(old, comment) : [comment]
+      )
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", prId] })

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -2,12 +2,14 @@
 
 import { useEffect, useCallback, useMemo, useRef } from "react"
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import type { QueryClient, QueryKey } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { useSocket } from "./useSocket"
+import { useSocket, useSocketState } from "./useSocket"
 import type {
   BaseNotification,
   Notification,
   NotificationsResponse,
+  NotificationSummaryResponse,
   NotificationFilterType,
   NotificationFilterRead,
 } from "@/types/notification"
@@ -18,6 +20,23 @@ import {
 } from "@/lib/measurements/socketMetrics"
 
 const toastedNotificationIds = new Set<string>()
+const NOTIFICATION_STALE_TIME_MS = 30_000
+const NOTIFICATION_POLL_INTERVAL_MS = 10_000
+const notificationSummaryQueryKey = ["notifications", "summary"] as const
+const notificationListQueryKey = (
+  type?: NotificationFilterType,
+  read?: NotificationFilterRead
+) => ["notifications", "list", type ?? "ALL", read ?? "all"] as const
+
+type UseNotificationsOptions = {
+  enabled?: boolean
+}
+
+async function fetchNotificationSummary(): Promise<NotificationSummaryResponse> {
+  const res = await fetch("/api/notifications/summary")
+  if (!res.ok) return { unreadCount: 0 }
+  return res.json()
+}
 
 async function fetchNotifications(
   type?: NotificationFilterType,
@@ -43,6 +62,71 @@ async function markAsReadApi(ids?: string[]): Promise<void> {
 
 async function deleteNotificationApi(id: string): Promise<void> {
   await fetch(`/api/notifications/${id}`, { method: "DELETE" })
+}
+
+function toListNotification(base: BaseNotification): Notification {
+  return {
+    ...base,
+    prTitle: base.prTitle ?? null,
+    prNumber: base.prNumber ?? null,
+    repoFullName: base.repoFullName ?? null,
+  }
+}
+
+function notificationMatchesFilters(
+  notification: Notification,
+  type?: NotificationFilterType,
+  read?: NotificationFilterRead
+) {
+  if (type && type !== "ALL" && notification.type !== type) return false
+  if (read === "unread" && notification.isRead) return false
+  if (read === "read" && !notification.isRead) return false
+  return true
+}
+
+function getListFilters(queryKey: QueryKey) {
+  const key = queryKey as readonly unknown[]
+  return {
+    type: key[2] as NotificationFilterType | undefined,
+    read: key[3] as NotificationFilterRead | undefined,
+  }
+}
+
+function updateExistingNotificationLists(
+  queryClient: QueryClient,
+  notification: Notification
+) {
+  const listQueries = queryClient.getQueriesData<NotificationsResponse>({
+    queryKey: ["notifications", "list"],
+  })
+
+  for (const [queryKey, old] of listQueries) {
+    if (!old) continue
+
+    const { type, read } = getListFilters(queryKey)
+    if (!notificationMatchesFilters(notification, type, read)) continue
+    if (old.notifications.some((item) => item.id === notification.id)) continue
+
+    queryClient.setQueryData<NotificationsResponse>(queryKey, {
+      notifications: [notification, ...old.notifications],
+      unreadCount: old.unreadCount + (notification.isRead ? 0 : 1),
+      total: old.total + 1,
+    })
+  }
+}
+
+function patchNotificationLists(
+  queryClient: QueryClient,
+  updater: (old: NotificationsResponse) => NotificationsResponse
+) {
+  const listQueries = queryClient.getQueriesData<NotificationsResponse>({
+    queryKey: ["notifications", "list"],
+  })
+
+  for (const [queryKey, old] of listQueries) {
+    if (!old) continue
+    queryClient.setQueryData<NotificationsResponse>(queryKey, updater(old))
+  }
 }
 
 function getToastMessage(notification: BaseNotification) {
@@ -113,22 +197,32 @@ function showNotificationToast(notification: BaseNotification) {
   })
 }
 
-export function useNotifications(
-  typeFilter?: NotificationFilterType,
-  readFilter?: NotificationFilterRead
-) {
+function showPollingNotificationToast() {
+  toast("New notification", {
+    description: "Open notifications to see the latest updates.",
+    duration: 5000,
+    action: {
+      label: "View",
+      onClick: () => {
+        window.location.assign("/notifications")
+      },
+    },
+  })
+}
+
+export function useNotificationSummary() {
   const { socket, fallbackActive, realtimeEnabled } = useSocket()
   const queryClient = useQueryClient()
   const previousFallbackRef = useRef(fallbackActive)
+  const previousUnreadCountRef = useRef<number | null>(null)
 
   const { data, isLoading } = useQuery({
-    queryKey: ["notifications", typeFilter, readFilter],
-    queryFn: () => fetchNotifications(typeFilter, readFilter),
-    refetchInterval: realtimeEnabled && !fallbackActive ? false : 10_000,
+    queryKey: notificationSummaryQueryKey,
+    queryFn: fetchNotificationSummary,
+    staleTime: NOTIFICATION_STALE_TIME_MS,
+    refetchInterval:
+      realtimeEnabled && !fallbackActive ? false : NOTIFICATION_POLL_INTERVAL_MS,
   })
-
-  const notifications = useMemo(() => data?.notifications ?? [], [data])
-  const unreadCount = useMemo(() => data?.unreadCount ?? 0, [data])
 
   const handleNew = useCallback(
     (base: BaseNotification) => {
@@ -139,28 +233,15 @@ export function useNotifications(
         showNotificationToast(base)
       }
 
-      const notification: Notification = {
-        ...base,
-        prTitle: null,
-        prNumber: null,
-        repoFullName: null,
-      }
+      const notification = toListNotification(base)
 
-      queryClient.setQueryData<NotificationsResponse>(
-        ["notifications", typeFilter, readFilter],
-        (old) => {
-          if (!old) return { notifications: [notification], unreadCount: 1, total: 1 }
-          return {
-            notifications: [notification, ...old.notifications],
-            unreadCount: old.unreadCount + 1,
-            total: old.total + 1,
-          }
-        }
+      queryClient.setQueryData<NotificationSummaryResponse>(
+        notificationSummaryQueryKey,
+        (old) => ({ unreadCount: (old?.unreadCount ?? 0) + 1 })
       )
-
-      queryClient.invalidateQueries({ queryKey: ["notifications"] })
+      updateExistingNotificationLists(queryClient, notification)
     },
-    [queryClient, typeFilter, readFilter]
+    [queryClient]
   )
 
   useEffect(() => {
@@ -182,24 +263,76 @@ export function useNotifications(
     previousFallbackRef.current = fallbackActive
   }, [fallbackActive, queryClient])
 
+  useEffect(() => {
+    if (!data) return
+
+    const unreadCount = data.unreadCount
+    const previousUnreadCount = previousUnreadCountRef.current
+    previousUnreadCountRef.current = unreadCount
+
+    if (previousUnreadCount == null) return
+    if (realtimeEnabled && !fallbackActive) return
+    if (unreadCount <= previousUnreadCount) return
+
+    showPollingNotificationToast()
+  }, [data, fallbackActive, realtimeEnabled])
+
+  return {
+    unreadCount: data?.unreadCount ?? 0,
+    isLoading,
+    fallbackActive,
+    realtimeEnabled,
+  }
+}
+
+export function useNotifications(
+  typeFilter?: NotificationFilterType,
+  readFilter?: NotificationFilterRead,
+  options: UseNotificationsOptions = {}
+) {
+  const { fallbackActive, realtimeEnabled } = useSocketState()
+  const queryClient = useQueryClient()
+  const enabled = options.enabled ?? true
+
+  const { data, isLoading } = useQuery({
+    queryKey: notificationListQueryKey(typeFilter, readFilter),
+    queryFn: () => fetchNotifications(typeFilter, readFilter),
+    enabled,
+    staleTime: NOTIFICATION_STALE_TIME_MS,
+    refetchInterval: enabled
+      ? realtimeEnabled && !fallbackActive
+        ? false
+        : NOTIFICATION_POLL_INTERVAL_MS
+      : false,
+  })
+
+  const notifications = useMemo(() => data?.notifications ?? [], [data])
+  const unreadCount = useMemo(() => data?.unreadCount ?? 0, [data])
+
   const { mutate: markAsRead } = useMutation({
     mutationFn: markAsReadApi,
     onMutate: async (ids?: string[]) => {
       await queryClient.cancelQueries({ queryKey: ["notifications"] })
-      queryClient.setQueryData<NotificationsResponse>(
-        ["notifications", typeFilter, readFilter],
-        (old) => {
-          if (!old) return old
-          return {
-            ...old,
-            notifications: old.notifications.map((n) =>
-              !ids || ids.includes(n.id) ? { ...n, isRead: true } : n
-            ),
-            unreadCount: ids
-              ? old.unreadCount - old.notifications.filter((n) => !n.isRead && ids.includes(n.id)).length
-              : 0,
-          }
+      patchNotificationLists(queryClient, (old) => {
+        const readCount = ids
+          ? old.notifications.filter((n) => !n.isRead && ids.includes(n.id)).length
+          : old.unreadCount
+
+        return {
+          ...old,
+          notifications: old.notifications.map((n) =>
+            !ids || ids.includes(n.id) ? { ...n, isRead: true } : n
+          ),
+          unreadCount: ids ? Math.max(0, old.unreadCount - readCount) : 0,
         }
+      })
+      queryClient.setQueryData<NotificationSummaryResponse>(
+        notificationSummaryQueryKey,
+        (old) => ({
+          unreadCount: ids
+            ? Math.max(0, (old?.unreadCount ?? 0) - ids.length)
+            : 0,
+        })
       )
     },
     onSettled: () => {
@@ -211,19 +344,31 @@ export function useNotifications(
     mutationFn: deleteNotificationApi,
     onMutate: async (id: string) => {
       await queryClient.cancelQueries({ queryKey: ["notifications"] })
-      queryClient.setQueryData<NotificationsResponse>(
-        ["notifications", typeFilter, readFilter],
-        (old) => {
-          if (!old) return old
-          const target = old.notifications.find((n) => n.id === id)
-          return {
-            ...old,
-            notifications: old.notifications.filter((n) => n.id !== id),
-            unreadCount: target && !target.isRead ? old.unreadCount - 1 : old.unreadCount,
-            total: old.total - 1,
-          }
+      let shouldDecrementUnread = false
+
+      patchNotificationLists(queryClient, (old) => {
+        const target = old.notifications.find((n) => n.id === id)
+        if (target && !target.isRead) shouldDecrementUnread = true
+
+        return {
+          ...old,
+          notifications: old.notifications.filter((n) => n.id !== id),
+          unreadCount:
+            target && !target.isRead
+              ? Math.max(0, old.unreadCount - 1)
+              : old.unreadCount,
+          total: Math.max(0, old.total - 1),
         }
-      )
+      })
+
+      if (shouldDecrementUnread) {
+        queryClient.setQueryData<NotificationSummaryResponse>(
+          notificationSummaryQueryKey,
+          (old) => ({
+            unreadCount: Math.max(0, (old?.unreadCount ?? 0) - 1),
+          })
+        )
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["notifications"] })

--- a/hooks/usePRFiles.ts
+++ b/hooks/usePRFiles.ts
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { UseQueryOptions } from "@tanstack/react-query";
-import { signOut } from "next-auth/react";
-import { toast } from "sonner";
+import { handleUnauthorizedAutoLogout } from "@/lib/client-auth";
 import type { PRFile } from "@/types/pulls";
 
 const GITHUB_REAUTH_REQUIRED = "GITHUB_REAUTH_REQUIRED";
-let githubReauthHandled = false;
+
 export const prFilesQueryKey = (id: string) => ["pullRequestFiles", id] as const;
+
 type PRFilesQueryKey = ReturnType<typeof prFilesQueryKey>;
 type PRFilesQueryOptions = Omit<
   UseQueryOptions<PRFile[], Error, PRFile[], PRFilesQueryKey>,
@@ -15,11 +15,13 @@ type PRFilesQueryOptions = Omit<
 >;
 
 class PRFilesError extends Error {
+  status: number;
   code?: string;
 
-  constructor(message: string, code?: string) {
+  constructor(message: string, status: number, code?: string) {
     super(message);
     this.name = "PRFilesError";
+    this.status = status;
     this.code = code;
   }
 }
@@ -34,6 +36,7 @@ async function fetchPRFiles(id: string): Promise<PRFile[]> {
 
     throw new PRFilesError(
       body?.error ?? "PR 파일 목록을 불러오지 못했습니다.",
+      res.status,
       body?.code
     );
   }
@@ -47,7 +50,10 @@ export function usePRFiles(id: string, options?: PRFilesQueryOptions) {
     queryKey: prFilesQueryKey(id),
     queryFn: () => fetchPRFiles(id),
     retry: (failureCount, error) => {
-      if (error instanceof PRFilesError && error.code === GITHUB_REAUTH_REQUIRED) {
+      if (
+        error instanceof PRFilesError &&
+        (error.status === 401 || error.code === GITHUB_REAUTH_REQUIRED)
+      ) {
         return false;
       }
 
@@ -57,24 +63,16 @@ export function usePRFiles(id: string, options?: PRFilesQueryOptions) {
   });
 
   useEffect(() => {
-    if (
-      query.error instanceof PRFilesError &&
-      query.error.code === GITHUB_REAUTH_REQUIRED &&
-      !githubReauthHandled
-    ) {
-      githubReauthHandled = true;
-
-      toast.error("GitHub 인증이 만료되었습니다.", {
-        description: "현재 계정에서 로그아웃 후 다시 로그인합니다.",
-        duration: 2000,
-      });
-
-      const timer = window.setTimeout(() => {
-        signOut({ callbackUrl: "/auth/login" });
-      }, 1200);
-
-      return () => window.clearTimeout(timer);
+    if (!(query.error instanceof PRFilesError) || query.error.status !== 401) {
+      return;
     }
+
+    const message =
+      query.error.code === GITHUB_REAUTH_REQUIRED
+        ? "GitHub 인증이 만료되어 다시 로그인합니다."
+        : "인증이 만료되어 다시 로그인합니다.";
+
+    handleUnauthorizedAutoLogout(message);
   }, [query.error]);
 
   return query;

--- a/hooks/useSocket.ts
+++ b/hooks/useSocket.ts
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useSyncExternalStore } from "react"
-import { io } from "socket.io-client"
 import type { TypedClientSocket } from "@/lib/socket/types"
 import {
   recordSocketConnectCall,
@@ -30,6 +29,7 @@ let fallbackActive = !realtimeEnabled
 let status: SocketConnectionStatus = "idle"
 let lastError: string | null = null
 let fallbackTimer: number | null = null
+let socketAttemptBlocked = false
 const listeners = new Set<() => void>()
 
 function notify() {
@@ -98,13 +98,31 @@ function clearFallbackTimer() {
   fallbackTimer = null
 }
 
+function stopSocketConnection() {
+  if (!socket) return
+
+  const currentSocket = socket
+  socket = null
+  currentSocket.removeAllListeners()
+  currentSocket.disconnect()
+}
+
+function activatePollingFallback() {
+  clearFallbackTimer()
+  socketAttemptBlocked = true
+  fallbackActive = true
+  connected = false
+  connecting = false
+  stopSocketConnection()
+  notify()
+}
+
 function scheduleFallbackActivation() {
   if (!realtimeEnabled || fallbackActive || fallbackTimer != null) return
 
   fallbackTimer = window.setTimeout(() => {
     fallbackTimer = null
-    fallbackActive = true
-    notify()
+    activatePollingFallback()
   }, SOCKET_FALLBACK_GRACE_MS)
 }
 
@@ -166,6 +184,14 @@ async function connect() {
     return
   }
 
+  if (socketAttemptBlocked) {
+    fallbackActive = true
+    connected = false
+    connecting = false
+    notify()
+    return
+  }
+
   if (socket) {
     if (!socket.connected && !connecting) {
       setConnectionState("reconnecting", {
@@ -198,6 +224,7 @@ async function connect() {
     }
 
     const { token } = await res.json()
+    const { io } = await import("socket.io-client")
 
     recordSocketCreate()
     socket = io(process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:4000", {
@@ -252,11 +279,7 @@ async function connect() {
   }
 }
 
-export function useSocket() {
-  useEffect(() => {
-    void connect()
-  }, [])
-
+export function useSocketState() {
   const currentSocket = useSyncExternalStore(
     subscribe,
     getSocketSnapshot,
@@ -297,4 +320,17 @@ export function useSocket() {
     realtimeEnabled: currentRealtimeEnabled,
     degraded: currentRealtimeEnabled && currentFallbackActive,
   }
+}
+
+export function useEnsureSocketConnection() {
+  useEffect(() => {
+    if (!realtimeEnabled) return
+
+    void connect()
+  }, [])
+}
+
+export function useSocket() {
+  useEnsureSocketConnection()
+  return useSocketState()
 }

--- a/lib/client-auth.ts
+++ b/lib/client-auth.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { toast } from "sonner";
+
+const AUTO_LOGOUT_DELAY_MS = 1800;
+const AUTH_CALLBACK_URL = "/auth/login";
+
+let logoutScheduled = false;
+
+export class ClientApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ClientApiError";
+    this.status = status;
+  }
+}
+
+export async function createClientApiError(
+  response: Response,
+  fallbackMessage: string
+): Promise<ClientApiError> {
+  const body = (await response.json().catch(() => null)) as
+    | { error?: string }
+    | null;
+
+  return new ClientApiError(
+    typeof body?.error === "string" ? body.error : fallbackMessage,
+    response.status
+  );
+}
+
+export function handleUnauthorizedAutoLogout(message?: string) {
+  if (typeof window === "undefined" || logoutScheduled) return;
+
+  logoutScheduled = true;
+
+  toast.error(message ?? "인증이 만료되어 다시 로그인합니다.", {
+    description: "잠시 후 로그인 화면으로 이동합니다.",
+    duration: AUTO_LOGOUT_DELAY_MS,
+  });
+
+  window.setTimeout(() => {
+    void signOut({ callbackUrl: AUTH_CALLBACK_URL });
+  }, AUTO_LOGOUT_DELAY_MS);
+}

--- a/pr-detail-header-loading-before.md
+++ b/pr-detail-header-loading-before.md
@@ -248,3 +248,200 @@ ReviewSection
 - #156 적용으로 loading responsibility는 더 명확해졌다.
 - 하지만 Lighthouse after 결과상 다음 병목은 `files loading gate`가 아니라 client-side JS/hydration이다.
 - 다음 작업은 `refractor` lazy loading을 별도 이슈/브랜치로 분리하는 것이 가장 객관적이고 측정 가능한 순서다.
+
+## 11. Lighthouse After Refractor Lazy Loading
+
+Report: `PR Detail Page Performance Report - 157 Applied`
+
+- Measured at: `2026-04-29 18:42`
+- Environment: `localhost:3000`
+- Related PR: [#158 perf: PR Detail 리뷰 코드 하이라이터 lazy loading](https://github.com/phnml1/CodeMate/pull/158)
+- Base PR: [#157 perf: PR Detail 헤더 렌더링과 files 로딩 분리](https://github.com/phnml1/CodeMate/pull/157)
+
+### Applied Change
+
+- `components/review/SuggestionCard.tsx`에서 `react-syntax-highlighter`와 `oneDark` static import를 제거했다.
+- `components/review/SuggestionCodeBlock/` 폴더를 추가했다.
+- suggestion card가 열리고 example code block이 실제로 mount될 때만 `SyntaxHighlightedCode`를 dynamic import한다.
+- highlighter import 전 또는 import 실패 시 plain `<pre><code>` fallback을 유지한다.
+- `react-syntax-highlighter` import는 `components/review/SuggestionCodeBlock/SyntaxHighlightedCode.tsx` 한 파일에만 남겼다.
+
+### Metrics Compared With `156 Applied`
+
+| Metric | 156 Applied | 157 Applied | Change |
+|---|---:|---:|---:|
+| Performance | 51 | 53 | +2 |
+| First Contentful Paint | 0.3s | 0.3s | 0 |
+| Largest Contentful Paint | 2.8s | 2.7s | -0.1s |
+| Total Blocking Time | 1,780ms | 1,240ms | -540ms |
+| Cumulative Layout Shift | 0 | 0 | 0 |
+| Speed Index | 2.1s | 1.8s | -0.3s |
+| Server response time observed | 1,551ms | 1,328ms | -223ms |
+| Time to First Byte | 1,560ms | 1,330ms | -230ms |
+| Maximum critical path latency | 1,854ms | 1,600ms | -254ms |
+| Element render delay | 4,370ms | 3,270ms | -1,100ms |
+| Main-thread work | 4.0s | 3.6s | -0.4s |
+| JavaScript execution time | 2.9s | 2.6s | -0.3s |
+| Script Evaluation | 2,671ms | 2,490ms | -181ms |
+| Script Parsing & Compilation | 400ms | 309ms | -91ms |
+| Total network payload | 1,608KiB | 1,286KiB | -322KiB |
+| Long tasks | 13 | 11 | -2 |
+
+### Important Result
+
+`node_modules_refractor_lang_ce18cb0d._.js` no longer appears in the largest payload list or CPU table.
+
+This strongly suggests that the review code highlighter was removed or deferred from the initial PR Detail route. This is the clearest measurable win so far because it directly reduced initial payload, parsing/compilation work, TBT, and element render delay.
+
+### Remaining Bottlenecks After `157 Applied`
+
+| Area | Evidence | Notes |
+|---|---|---|
+| Shared app shell hydration | `ProtectedLayout: 927.49ms`, `AppHeader: 923.68ms`, `AppSidebar: 489.37ms` | Header/sidebar/session/socket/UI primitives are now more visible. |
+| PR detail render cost | `PRDetailPage: 888.60ms` | Detail layout still mounts review, diff, comments, socket room, deep link, modal hosts, and floating button path. |
+| Socket reconnect | `Reconnect: 134.10ms`, `Reconnect: 85.30ms` | Reconnect traces remain one of the biggest post-load costs. |
+| Modal/dynamic loading | `IssueDetailModal` appears twice, `Dialog`, `BailoutToCSR`, `Promise Resolved: 349.50ms` | Modal is currently rendered from both review and diff sections. |
+| New long-task target | `node_modules_1819799d._.js` long tasks up to `432ms` | Need bundle/import tracing to identify the package group. |
+| Session/auth duplication | Multiple `Object.session` measures | `AppHeader`, `AppSidebar`, PR page, APIs, and socket token path all need inspection. |
+
+### Updated Priority
+
+1. Confirm `refractor` stays out of the initial route in follow-up measurements.
+2. Remove duplicated `IssueDetailModal` mounting by introducing a single modal owner.
+3. Reduce socket reconnect work and avoid socket attempts when the configured mode is polling or the socket server is unavailable.
+4. Inspect `node_modules_1819799d._.js` with bundle analysis/import tracing.
+5. Reduce shared app shell hydration by addressing session duplication and tooltip/dropdown mounting.
+
+## 12. Next Candidate: Single Issue Modal Owner
+
+Current modal ownership:
+
+```txt
+ReviewSection
+  owns selectedIssue
+  renders IssueDetailModal
+
+PRDiffSection
+  owns selectedIssue
+  renders IssueDetailModal
+```
+
+This means the PR Detail page has two dynamic imports and two modal hosts for the same conceptual UI: "show selected review issue detail".
+
+Proposed modal ownership:
+
+```txt
+PRDetailLayout
+  owns selectedIssue once
+  renders IssueDetailModal once, only when selectedIssue exists
+
+ReviewSection
+  receives onIssueClick
+  calls onIssueClick(issue)
+
+PRDiffSection
+  receives onIssueClick
+  calls onIssueClick(issue)
+```
+
+Expected impact:
+
+- `IssueDetailModal` and `Dialog` should stop appearing twice.
+- Closed modal code should not mount during initial render.
+- `LoadableComponent`, `BailoutToCSR`, and related promise work should decrease.
+- Review and diff sections become simpler because they no longer own modal state.
+
+## 13. After Single Issue Modal Owner
+
+Related change: `IssueModalHost` owns the issue detail modal once under `PRDetailLayout`.
+
+### Applied Structure
+
+Before:
+
+```txt
+ReviewSection
+  owns selectedIssue
+  dynamic-imports IssueDetailModal
+  renders IssueDetailModal
+
+PRDiffSection
+  owns selectedIssue
+  dynamic-imports IssueDetailModal
+  renders IssueDetailModal
+```
+
+After:
+
+```txt
+PRDetailLayout
+  owns selectedIssue once
+  passes onIssueClick to ReviewSection and PRDiffSection
+  renders IssueModalHost once
+
+IssueModalHost
+  returns null when selectedIssue is null
+  lazy-loads IssueDetailModal only after an issue is selected
+```
+
+### Lighthouse Follow-up Interpretation
+
+The follow-up Lighthouse PDFs after the `158` work show that the modal optimization is working in the intended direction.
+
+Before this change, the `157 Applied` report showed `IssueDetailModal` twice during the initial page lifetime. Those entries were paired with `Dialog`, `BailoutToCSR`, and multiple `LoadableComponent` entries. The report also showed `Promise Resolved: 349.50ms`.
+
+After the single-owner modal structure, the follow-up `158 Applied` measurements no longer show `IssueDetailModal` in User Timing search results. This matches the implementation because `IssueModalHost` returns `null` while no issue is selected:
+
+```tsx
+if (!issue) return null;
+```
+
+### 158 Applied Three-run Average
+
+| Metric | Average |
+|---|---:|
+| Performance | 56 |
+| First Contentful Paint | 0.33s |
+| Largest Contentful Paint | 2.47s |
+| Total Blocking Time | 1,183ms |
+| Cumulative Layout Shift | 0 |
+| Speed Index | 1.5s |
+| Time to First Byte | 957ms |
+| Server response time observed | 949ms |
+| Element render delay | 3,403ms |
+| JavaScript execution time | 2.4s |
+| Main-thread work | about 3.2s |
+| Unused JS savings | 370KiB |
+| Minify JS savings | 267KiB |
+
+Component timing averages from the 2nd and 3rd measurements:
+
+| Component / Measure | Average |
+|---|---:|
+| `ProtectedLayout` | 533.26ms |
+| `AppHeader` | 530.33ms |
+| `PRDetailPage` | 545.05ms |
+| `AppSidebar` | 443.52ms |
+| `Cascading Update` | 108.80ms |
+| `TooltipProviderProvider` | 69.05ms |
+| Long tasks count | about 9.5 |
+
+### Result
+
+- `IssueDetailModal` no longer appears in the initial-load User Timing search results.
+- The previous duplicated `IssueDetailModal` / `Dialog` / `BailoutToCSR` pattern appears removed.
+- `Promise Resolved` improved from `349.50ms` to either `205.70ms` or `11.50ms` in the follow-up reports, though this value still fluctuates.
+- `LoadableComponent` entries still exist, which means other dynamic imports remain.
+- Reconnect work still appears, including values around `85ms` to `120ms`.
+
+### Updated Bottleneck Layer
+
+This change should be treated as a successful cleanup of duplicated modal ownership, not as the final PR Detail performance fix. The remaining bottleneck layer is now:
+
+1. `ProtectedLayout` / `AppHeader` hydration and shared AppShell work.
+2. `PRDetailPage` initial render cost.
+3. `node_modules_1819799d._.js` long tasks.
+4. WebSocket reconnect work during or shortly after initial load.
+5. Repeated Tooltip / Popper / Radix primitive mounting.
+
+Recommended next target: inspect WebSocket connect/reconnect behavior and make sure socket connection and `socket.io-client` loading do not happen on the critical path when the page is measured in polling mode or when realtime is not immediately needed.

--- a/pr-detail-issue-modal-single-owner-plan.md
+++ b/pr-detail-issue-modal-single-owner-plan.md
@@ -1,0 +1,89 @@
+# PR Detail Issue Modal Single Owner Plan
+
+## 1. Current Structure
+
+현재 PR Detail page에는 같은 목적의 issue detail modal이 두 군데에서 따로 관리된다.
+
+```txt
+PRDetailLayout
+├─ ReviewSection
+│  ├─ selectedIssue state
+│  └─ IssueDetailModal
+│
+└─ PRDiffSection
+   ├─ selectedIssue state
+   └─ IssueDetailModal
+```
+
+## 2. Current Problem
+
+`IssueDetailModal`은 "선택된 review issue를 자세히 보여주는 모달"이라는 하나의 역할을 한다.
+
+그런데 현재는 다음 두 컴포넌트가 각각 modal state와 modal dynamic import를 갖는다.
+
+- `components/pulls/detail/ReviewSection.tsx`
+- `components/pulls/detail/PRDiffSection.tsx`
+
+이 구조에서는 modal이 닫혀 있어도 PR Detail tree 안에 modal host가 두 개 존재한다. Lighthouse에서도 `IssueDetailModal`, `Dialog`, `BailoutToCSR`가 두 번 나타난다.
+
+## 3. Proposed Structure
+
+`selectedIssue` state와 modal rendering 책임을 `PRDetailLayout` 또는 별도 `IssueModalHost`로 올린다.
+
+```txt
+PRDetailLayout
+├─ selectedIssue state
+├─ handleIssueClick(issue)
+│
+├─ ReviewSection
+│  └─ onIssueClick(issue)
+│
+├─ PRDiffSection
+│  └─ onIssueClick(issue)
+│
+└─ IssueModalHost
+   └─ selectedIssue가 있을 때만 IssueDetailModal lazy render
+```
+
+## 4. Responsibility Change
+
+### `PRDetailLayout`
+
+- `selectedIssue`를 한 번만 가진다.
+- `handleIssueClick(issue)`를 만든다.
+- `ReviewSection`과 `PRDiffSection`에 `onIssueClick`으로 전달한다.
+- `selectedIssue !== null`일 때만 `IssueModalHost`를 렌더링한다.
+
+### `ReviewSection`
+
+- `selectedIssue` state를 제거한다.
+- `IssueDetailModal` dynamic import를 제거한다.
+- review issue 클릭 시 `onIssueClick(issue)`만 호출한다.
+
+### `PRDiffSection`
+
+- `selectedIssue` state를 제거한다.
+- `IssueDetailModal` dynamic import를 제거한다.
+- diff issue 클릭 시 `onIssueClick(issue)`만 호출한다.
+
+### `IssueModalHost`
+
+- `IssueDetailModal` dynamic import를 한 곳에서만 담당한다.
+- `issue`가 없으면 `null`을 반환해서 closed modal code가 초기 렌더링에 끼지 않게 한다.
+
+## 5. Expected Impact
+
+- `IssueDetailModal` / `Dialog` 중복 mount 감소
+- `LoadableComponent` / `BailoutToCSR` 중복 감소
+- modal 관련 dynamic import가 한 곳으로 단순화
+- Review/Diff section의 책임 감소
+- Lighthouse의 `IssueDetailModal appears twice` 문제 완화 기대
+
+## 6. Safe Implementation Order
+
+1. `IssueModalHost` 컴포넌트 추가
+2. `PRDetailLayout`에 `selectedIssue` state 추가
+3. `ReviewSection`에 `onIssueClick` prop 추가
+4. `PRDiffSection`에 `onIssueClick` prop 추가
+5. 각 section 내부의 modal state/dynamic import 제거
+6. deep link, diff issue click, review issue click 동작 확인

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -31,6 +31,10 @@ export interface NotificationsResponse {
   total: number
 }
 
+export interface NotificationSummaryResponse {
+  unreadCount: number
+}
+
 export interface NotificationSetting {
   mentionEnabled: boolean
   newReviewEnabled: boolean


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [x] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

PR Detail 성능 개선 스택을 `main`으로 반영하기 위한 최종 PR입니다.

이미 `main`에 들어간 #157 이후의 후속 stacked 변경들을 포함합니다:

- #158: PR Detail 리뷰 코드 하이라이터 lazy loading
- #160: PR Detail files 401 자동 로그아웃 처리
- #161: PR Detail issue modal 단일 host 적용
- #162: 알림 summary 캐시와 polling fallback 최적화

현재 #160, #161, #162는 모두 `fix/159-pr-files-401-auto-logout` 계열 브랜치 안으로 머지되어 있으므로, 이 PR은 해당 누적 브랜치를 `main`에 병합하기 위한 PR입니다.

## 변경 사항

- PR Detail 초기 route bundle에서 `react-syntax-highlighter` / `refractor` 정적 로딩을 제거하고 suggestion card open 이후 lazy loading하도록 분리했습니다.
- `/api/pulls/[id]/files`가 401을 반환할 때 사용자 안내 toast와 자동 로그아웃 흐름으로 연결했습니다.
- `IssueDetailModal`을 `ReviewSection`과 `PRDiffSection`에서 각각 소유하던 구조를 단일 `IssueModalHost`로 정리했습니다.
- polling mode에서 socket 연결과 `socket.io-client` 로드를 시도하지 않도록 socket 상태 구독과 실제 연결 시작을 분리했습니다.
- polling/fallback mode에서 댓글 작성 성공 후 comment cache를 즉시 patch해 다음 polling 주기를 기다리지 않도록 했습니다.
- 헤더 알림 배지를 전체 알림 목록 조회에서 `/api/notifications/summary` unread count 조회로 분리했습니다.
- 알림 드롭다운은 열릴 때만 전체 목록을 lazy fetch하도록 변경했습니다.
- socket 알림 이벤트는 무분별한 invalidate/refetch 대신 React Query cache를 직접 업데이트하도록 정리했습니다.
- polling/fallback mode에서는 unread count 증가 감지만 보고 generic notification toast를 표시합니다.

## 스크린샷 (선택)

N/A - 성능, 인증 에러 처리, realtime fallback, modal ownership 개선이며 의도한 UI 디자인 변경은 없습니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
  - 수동 확인 필요
- [x] 기존 기능에 영향 없음 확인
  - Network 기준 polling mode에서 초기 `/api/notifications` 호출이 발생하지 않고 `/api/notifications/summary`만 호출되는 것을 확인했습니다.
  - polling mode에서 `/api/socket/token`과 `socket.io` app 연결이 발생하지 않는 것을 확인했습니다.
  - Lighthouse JSON 기준 초기 network에 `/api/notifications/summary`만 있고 `/api/notifications`, `/api/socket/token`, `socket.io`는 없는 것을 확인했습니다.
- [ ] 타입 에러 없음 (`tsc --noEmit`)
  - `npx.cmd tsc --noEmit --pretty false`
  - 결과: 실패
  - 기존 Prisma/generated 타입 불일치로 실패합니다. 예: `BaseNotification.reviewStatus` missing, Prisma `Review.stage`/`Notification.reviewStatus` field mismatch.
- [x] ESLint 경고/에러 없음
  - `npm.cmd run lint`
  - 결과: 통과, 기존 경고 1개 유지 (`hooks/useRealtimeComments.ts`의 `appendComment` unused)
- [x] 테스트 실행
  - `npm.cmd test -- --runInBand`
  - 결과: 통과, 22 suites / 131 tests passed

## 참고 사항

Lighthouse 측정상 현재 polling mode에서 알림/socket 최적화는 적용되어 있습니다. 다만 dev server 측정에서는 Next devtools/HMR chunk가 크게 섞이므로, 최종 성능 판단은 `next build && next start` 환경의 Lighthouse로 한 번 더 확인하는 것이 좋습니다.

현재 남은 주요 병목 후보:

- `PRDetailPage` 초기 렌더링 비용
- `ProtectedLayout` / `AppHeader` hydration 비용
- TTFB / initial server response
- `node_modules_1819799d._.js` long task
- `node_modules_8bc4272c._.js` unused JS
