### PR TITLE
hotfix: enable polling fallback on socket failure

### DIFF
--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -20,7 +20,7 @@ export default async function AppHeader() {
       <div className="flex items-center gap-2 md:gap-4">
         <SocketConnectionBadge className="hidden lg:inline-flex" />
         <HeaderSearch />
-        <NotificationBell />
+        {user?.id ? <NotificationBell /> : null}
         <HeaderProfile
           user={user ? { name: user.name, email: user.email, image: user.image } : undefined}
         />

--- a/hooks/useSocket.ts
+++ b/hooks/useSocket.ts
@@ -25,6 +25,7 @@ const realtimeEnabled = process.env.NEXT_PUBLIC_REALTIME_MODE === "socket"
 let socket: TypedClientSocket | null = null
 let connected = false
 let connecting = false
+let everConnected = false
 let fallbackActive = !realtimeEnabled
 let status: SocketConnectionStatus = "idle"
 let lastError: string | null = null
@@ -107,12 +108,14 @@ function stopSocketConnection() {
   currentSocket.disconnect()
 }
 
-function activatePollingFallback() {
+function activatePollingFallback(error?: string | null) {
   clearFallbackTimer()
   socketAttemptBlocked = true
   fallbackActive = true
   connected = false
   connecting = false
+  status = error ? "error" : "disconnected"
+  lastError = error ?? null
   stopSocketConnection()
   notify()
 }
@@ -122,7 +125,7 @@ function scheduleFallbackActivation() {
 
   fallbackTimer = window.setTimeout(() => {
     fallbackTimer = null
-    activatePollingFallback()
+    activatePollingFallback(lastError)
   }, SOCKET_FALLBACK_GRACE_MS)
 }
 
@@ -215,11 +218,11 @@ async function connect() {
   try {
     const res = await fetch("/api/socket/token")
     if (!res.ok) {
-      setConnectionState("error", {
-        connected: false,
-        connecting: false,
-        error: "Failed to fetch a socket auth token.",
-      })
+      const error =
+        res.status === 401 || res.status === 403
+          ? "Socket auth is unavailable, so realtime is disabled and polling fallback is active."
+          : "Failed to fetch a socket auth token, so polling fallback is active."
+      activatePollingFallback(error)
       return
     }
 
@@ -239,6 +242,7 @@ async function connect() {
 
     socket.on("connect", () => {
       recordSocketConnected()
+      everConnected = true
       setConnectionState("connected", {
         connected: true,
         connecting: false,
@@ -260,6 +264,12 @@ async function connect() {
 
     socket.on("connect_error", (error) => {
       recordSocketConnectError(error.message)
+
+      if (!everConnected) {
+        activatePollingFallback(error.message)
+        return
+      }
+
       const shouldRetry = socket?.active ?? false
 
       setConnectionState(shouldRetry ? "reconnecting" : "error", {
@@ -270,12 +280,12 @@ async function connect() {
     })
 
     notify()
-  } catch {
-    setConnectionState("error", {
-      connected: false,
-      connecting: false,
-      error: "Failed to initialize the socket connection.",
-    })
+  } catch (error) {
+    activatePollingFallback(
+      error instanceof Error
+        ? error.message
+        : "Failed to initialize the socket connection."
+    )
   }
 }
 


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩터링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

Production에서 socket 서버가 내려가 있거나 `/api/socket/token` 요청이 실패할 때 realtime 복구 대기 상태에 머물지 않고 polling fallback으로 전환되도록 수정합니다.

Closes #164

## 변경 사항

- `/api/socket/token`이 401/403 또는 기타 실패를 반환하면 즉시 polling fallback을 활성화합니다.
- 최초 socket 연결이 한 번도 성공하지 않은 상태에서 `connect_error`가 발생하면 즉시 polling fallback으로 고정합니다.
- 과거에 연결 성공한 socket이 끊긴 경우에는 기존 8초 grace 재연결 흐름을 유지합니다.
- 서버 세션이 없을 때 protected header의 `NotificationBell`을 mount하지 않아 socket token 요청이 로그인 흐름에 섞이지 않도록 했습니다.

## 스크린샷 (선택)

Not applicable. UI 변경이 아니라 realtime fallback 동작 수정입니다.

## 테스트

- [x] ESLint 실행: 통과, 기존 `hooks/useRealtimeComments.ts` unused warning 1개 유지
- [x] Prisma generate 실행: 통과
- [x] Next.js production build 실행: 통과
- [x] PR 브랜치 diff가 `components/layout/AppHeader.tsx`, `hooks/useSocket.ts` 두 파일만 포함하는지 확인

## 참고 사항

- Socket 서버 자체가 동작하지 않는 production 상황에서도 로그인 상태 유지와 polling fallback 전환을 우선합니다.
- Notification DB schema 호환 패치는 별도 변경으로, 이 PR 범위에 포함하지 않았습니다.