### PR TITLE
hotfix: handle notification schema drift

### DIFF
--- a/__tests__/api/notifications/[id]/route.test.ts
+++ b/__tests__/api/notifications/[id]/route.test.ts
@@ -64,7 +64,10 @@ describe("DELETE /api/notifications/[id]", () => {
 
     expect(res.status).toBe(200)
     expect(body.success).toBe(true)
-    expect(mockedDelete).toHaveBeenCalledWith({ where: { id: "notif-1" } })
+    expect(mockedDelete).toHaveBeenCalledWith({
+      where: { id: "notif-1" },
+      select: { id: true },
+    })
   })
 
   it("다른 사용자의 알림은 삭제할 수 없다", async () => {

--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -22,7 +22,10 @@ export async function DELETE(
     return Response.json({ error: "Notification not found" }, { status: 404 })
   }
 
-  await prisma.notification.delete({ where: { id } })
+  await prisma.notification.delete({
+    where: { id },
+    select: { id: true },
+  })
 
   return Response.json({ success: true })
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,4 +1,8 @@
 import { auth } from "@/lib/auth"
+import {
+  notificationCompatSelect,
+  toBaseNotification,
+} from "@/lib/notifications/compat"
 import { prisma } from "@/lib/prisma"
 import type { NotificationType } from "@/types/notification"
 
@@ -28,6 +32,7 @@ export async function GET(request: Request) {
   const [notifications, total, unreadCount] = await Promise.all([
     prisma.notification.findMany({
       where,
+      select: notificationCompatSelect,
       orderBy: [{ isRead: "asc" }, { createdAt: "desc" }],
       take: 50,
     }),
@@ -65,8 +70,7 @@ export async function GET(request: Request) {
     notifications: notifications.map((n) => {
       const pr = n.prId ? prMap.get(n.prId) : null
       return {
-        ...n,
-        createdAt: n.createdAt.toISOString(),
+        ...toBaseNotification(n),
         prTitle: pr?.title ?? null,
         prNumber: pr?.number ?? null,
         repoFullName: pr?.repoFullName ?? null,

--- a/app/api/pulls/[id]/comments/route.ts
+++ b/app/api/pulls/[id]/comments/route.ts
@@ -1,5 +1,9 @@
 import { auth } from "@/lib/auth"
 import { getEnabledUserIds } from "@/lib/notification-settings"
+import {
+  notificationCompatSelect,
+  toBaseNotification,
+} from "@/lib/notifications/compat"
 import { prisma } from "@/lib/prisma"
 import {
   buildAccessiblePullRequestWhere,
@@ -27,12 +31,10 @@ async function createNotificationsForUsers(params: {
           prId: params.prId,
           commentId: params.commentId,
         },
+        select: notificationCompatSelect,
       })
 
-      emitNotification(userId, {
-        ...notification,
-        createdAt: notification.createdAt.toISOString(),
-      })
+      emitNotification(userId, toBaseNotification(notification))
     })
   )
 }

--- a/app/api/webhook/github/route.ts
+++ b/app/api/webhook/github/route.ts
@@ -2,6 +2,10 @@ import { revalidateTag } from "next/cache"
 import { NextResponse, after } from "next/server"
 import { analyzeReview } from "@/lib/ai/analyze"
 import { getEnabledUserIds } from "@/lib/notification-settings"
+import {
+  notificationCompatSelect,
+  toBaseNotification,
+} from "@/lib/notifications/compat"
 import { prisma } from "@/lib/prisma"
 import { getRepositoryMemberIds } from "@/lib/repository-access"
 import { upsertReviewNotifications } from "@/lib/review-notifications"
@@ -55,11 +59,11 @@ async function notifyUsers(params: {
           userId,
           prId: params.prId,
         },
+        select: notificationCompatSelect,
       })
 
       emitNotification(userId, {
-        ...notification,
-        createdAt: notification.createdAt.toISOString(),
+        ...toBaseNotification(notification),
         prTitle: params.prTitle,
         prNumber: params.prNumber,
       })

--- a/lib/notifications/compat.ts
+++ b/lib/notifications/compat.ts
@@ -1,0 +1,44 @@
+import type {
+  BaseNotification,
+  NotificationReviewStatus,
+} from "@/types/notification"
+
+export const notificationCompatSelect = {
+  id: true,
+  type: true,
+  title: true,
+  message: true,
+  isRead: true,
+  userId: true,
+  prId: true,
+  commentId: true,
+  createdAt: true,
+} as const
+
+type NotificationCompatRecord = Omit<BaseNotification, "createdAt" | "reviewStatus"> & {
+  createdAt: Date
+}
+
+function inferReviewStatus(
+  notification: Pick<NotificationCompatRecord, "type" | "title">
+): NotificationReviewStatus | null {
+  if (notification.type === "REVIEW_FAILED") return "FAILED"
+  if (notification.type !== "NEW_REVIEW") return null
+
+  const title = notification.title.toLowerCase()
+
+  if (title.includes("progress") || title.includes("pending")) return "PENDING"
+  if (title.includes("failed")) return "FAILED"
+  return "COMPLETED"
+}
+
+export function toBaseNotification(
+  notification: NotificationCompatRecord,
+  reviewStatus?: NotificationReviewStatus | null
+): BaseNotification {
+  return {
+    ...notification,
+    reviewStatus: reviewStatus ?? inferReviewStatus(notification),
+    createdAt: notification.createdAt.toISOString(),
+  }
+}

--- a/lib/review-notifications.ts
+++ b/lib/review-notifications.ts
@@ -1,4 +1,8 @@
 import { prisma } from "@/lib/prisma";
+import {
+  notificationCompatSelect,
+  toBaseNotification,
+} from "@/lib/notifications/compat";
 import { emitNotification } from "@/lib/socket/emitter";
 import type { NotificationReviewStatus } from "@/types/notification";
 
@@ -58,25 +62,24 @@ export async function upsertReviewNotifications(params: {
               title: content.title,
               message: content.message,
               isRead: false,
-              reviewStatus: params.status,
               createdAt: new Date(),
             },
+            select: notificationCompatSelect,
           })
         : await prisma.notification.create({
             data: {
               type: "NEW_REVIEW",
-              reviewStatus: params.status,
               title: content.title,
               message: content.message,
               isRead: false,
               userId,
               prId: params.prId,
             },
+            select: notificationCompatSelect,
           });
 
       emitNotification(userId, {
-        ...notification,
-        createdAt: notification.createdAt.toISOString(),
+        ...toBaseNotification(notification, params.status),
         prTitle: params.prTitle,
         prNumber: params.prNumber,
       });


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩터링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 작업
- [x] Week 9-10: 대시보드 & 배포

## 개요

Production DB에 `Notification.reviewStatus` 마이그레이션이 아직 적용되지 않은 상태에서도 알림 목록 조회와 알림 생성/삭제가 실패하지 않도록 호환 레이어를 추가합니다.

Closes #167

## 변경 사항

- Notification 조회/생성/삭제 경로에서 필요한 컬럼만 명시적으로 `select`하도록 변경했습니다.
- `reviewStatus` DB 컬럼을 직접 읽지 않고도 UI payload에 `reviewStatus`를 제공할 수 있도록 `lib/notifications/compat.ts`를 추가했습니다.
- 알림 목록 API, 댓글 알림 생성, GitHub webhook 알림 생성, AI review notification upsert 경로가 새 compatibility helper를 사용하도록 정리했습니다.
- 삭제 API도 Prisma 기본 반환 전체 필드를 피하도록 `select: { id: true }`를 사용합니다.

## 스크린샷 (선택)

Not applicable. API/schema compatibility fix이며 UI 변경은 없습니다.

## 테스트

- [x] ESLint 실행: 통과, 기존 `hooks/useRealtimeComments.ts` unused warning 1개 유지
- [x] Prisma generate 실행: 통과
- [x] Next.js production build 실행: 통과
- [x] PR 브랜치 diff가 알림 schema drift 대응 파일만 포함하는지 확인

## 참고 사항

- 장기적으로는 production DB에 `20260422030000_add_notification_review_status` migration을 적용해야 합니다.
- 이 PR은 migration 적용 전에도 production 알림 목록이 죽지 않도록 하는 compatibility hotfix입니다.