### PR TITLE
hotfix: skip webhook registration without admin access

### DIFF
--- a/__tests__/api/github/repos.test.ts
+++ b/__tests__/api/github/repos.test.ts
@@ -54,8 +54,20 @@ describe("GET /api/github/repos", () => {
         repos: {
           listForAuthenticatedUser: jest.fn().mockResolvedValue({
             data: [
-              { id: 1, name: "repo-a", full_name: "user/repo-a", language: "TypeScript" },
-              { id: 2, name: "repo-b", full_name: "user/repo-b", language: "Python" },
+              {
+                id: 1,
+                name: "repo-a",
+                full_name: "user/repo-a",
+                language: "TypeScript",
+                permissions: { admin: true },
+              },
+              {
+                id: 2,
+                name: "repo-b",
+                full_name: "user/repo-b",
+                language: "Python",
+                permissions: { admin: false },
+              },
             ],
             headers: {},
           }),
@@ -74,6 +86,7 @@ describe("GET /api/github/repos", () => {
         name: "repo-a",
         fullName: "user/repo-a",
         language: "TypeScript",
+        canAdminister: true,
         isConnected: true,
         repositoryId: "db-repo-1",
       },
@@ -82,8 +95,8 @@ describe("GET /api/github/repos", () => {
         name: "repo-b",
         fullName: "user/repo-b",
         language: "Python",
+        canAdminister: false,
         isConnected: false,
-        repositoryId: undefined,
       },
     ])
     expect(body.pagination).toEqual({ page: 1, perPage: 20, hasNextPage: false })

--- a/__tests__/api/repositories/route.test.ts
+++ b/__tests__/api/repositories/route.test.ts
@@ -98,6 +98,7 @@ describe("POST /api/repositories", () => {
         name: "my-repo",
         fullName: "user/my-repo",
         language: "TypeScript",
+        canAdminister: true,
       })
     )
     const body = await response.json()
@@ -126,6 +127,58 @@ describe("POST /api/repositories", () => {
       },
       select: expect.any(Object),
     })
+    expect(mockedSyncRepositoryPullRequests).toHaveBeenCalledWith({
+      octokit: expect.any(Object),
+      owner: "user",
+      repo: "my-repo",
+      repositoryId: "repo-1",
+    })
+    expect(mockedUpdate).toHaveBeenCalledWith({
+      where: { id: "repo-1" },
+      data: { webhookId: 9999 },
+      select: expect.any(Object),
+    })
+  })
+
+  it("skips webhook registration when the user cannot administer the repository", async () => {
+    const createWebhook = jest.fn()
+
+    mockedAuth.mockResolvedValue({ user: { id: "user-1" } })
+    mockedFindUnique.mockResolvedValue(null)
+    mockedSyncRepositoryPullRequests.mockResolvedValue({
+      syncedCount: 0,
+      detailHydratedCount: 0,
+    })
+    mockedGetOctokit.mockResolvedValue({
+      rest: {
+        repos: {
+          createWebhook,
+        },
+      },
+    })
+    mockedCreate.mockResolvedValue({
+      id: "repo-1",
+      githubId: BigInt(12345),
+      name: "my-repo",
+      fullName: "user/my-repo",
+      description: null,
+      language: "TypeScript",
+      webhookId: null,
+    })
+
+    const response = await POST(
+      createRequest({
+        githubId: 12345,
+        name: "my-repo",
+        fullName: "user/my-repo",
+        language: "TypeScript",
+        canAdminister: false,
+      })
+    )
+
+    expect(response.status).toBe(201)
+    expect(createWebhook).not.toHaveBeenCalled()
+    expect(mockedUpdate).not.toHaveBeenCalled()
     expect(mockedSyncRepositoryPullRequests).toHaveBeenCalledWith({
       octokit: expect.any(Object),
       owner: "user",

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -48,6 +48,7 @@ export async function GET(req: NextRequest) {
       name: repo.name,
       fullName: repo.full_name,
       language: repo.language,
+      canAdminister: repo.permissions?.admin ?? false,
       isConnected: connectedMap.has(BigInt(repo.id)),
       repositoryId: connectedMap.get(BigInt(repo.id)),
     }))

--- a/app/api/repositories/route.ts
+++ b/app/api/repositories/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json()
-    const { githubId, name, fullName, description, language } = body
+    const { githubId, name, fullName, description, language, canAdminister } = body
 
     if (!githubId || !name || !fullName) {
       return NextResponse.json(
@@ -117,7 +117,7 @@ export async function POST(request: Request) {
 
     const [owner, repo] = fullName.split("/")
 
-    if (!repository.webhookId) {
+    if (!repository.webhookId && canAdminister === true) {
       try {
         const octokit = await getOctokit(session.user.id)
         const { data: hook } = await octokit.rest.repos.createWebhook({

--- a/components/github/RepoList.tsx
+++ b/components/github/RepoList.tsx
@@ -95,6 +95,7 @@ export default function RepoList({
                 name: repo.name,
                 fullName: repo.fullName,
                 language: repo.language,
+                canAdminister: repo.canAdminister,
               })
             }
             onDisconnect={() => repo.repositoryId && disconnect(repo.repositoryId)}

--- a/hooks/useConnectRepository.ts
+++ b/hooks/useConnectRepository.ts
@@ -5,6 +5,7 @@ interface ConnectRepositoryInput {
   name: string
   fullName: string
   language: string | null
+  canAdminister: boolean
 }
 
 async function connectRepository(input: ConnectRepositoryInput) {

--- a/types/repos.ts
+++ b/types/repos.ts
@@ -3,6 +3,7 @@ export interface GitHubRepo {
   name: string;
   fullName: string;
   language: string | null;
+  canAdminister: boolean;
   isConnected: boolean;
   repositoryId?: string;
 }


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [x] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

Closes #169.

저장소 연동 시 사용자가 해당 GitHub 저장소의 관리자 권한이 없으면 webhook 생성 API가 403을 반환하던 문제를 수정합니다. GitHub 저장소 목록에서 `permissions.admin` 값을 받아 연결 요청에 전달하고, 서버에서는 관리자 권한이 확인된 경우에만 webhook 등록을 시도합니다.

## 변경 사항

- GitHub 저장소 목록 API 응답에 `canAdminister` 필드를 추가했습니다.
- 저장소 연결 요청 payload에 `canAdminister`를 포함했습니다.
- `POST /api/repositories`에서 `canAdminister === true`일 때만 webhook 생성을 시도하도록 변경했습니다.
- 저장소 목록/연동 API 테스트에 관리자 권한별 webhook 등록 동작 검증을 추가했습니다.

## 스크린샷 (선택)

해당 없음. 서버/API 동작 수정입니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

검증 결과:

- `C:\project\CodeMate\node_modules\.bin\jest.cmd --runInBand`: 통과, 22 suites / 132 tests
- `C:\project\CodeMate\node_modules\.bin\tsc.cmd --noEmit`: 통과
- `C:\project\CodeMate\node_modules\.bin\eslint.cmd`: 에러 0개, 기존 경고 1개 (`hooks/useRealtimeComments.ts`의 unused var, 본 PR 변경 범위 외)

## 참고 사항

관리자 권한이 없는 저장소는 webhook 기반 자동 이벤트 수신은 등록되지 않지만, 저장소 연동과 PR 동기화는 계속 진행됩니다.