### PR TITLE
hotfix: 저장소 PR 동기화 타임아웃 수정

### DIFF
--- a/__tests__/lib/pull-request-sync.test.ts
+++ b/__tests__/lib/pull-request-sync.test.ts
@@ -1,0 +1,93 @@
+import { prisma } from "@/lib/prisma"
+import { syncRepositoryPullRequests } from "@/lib/pull-request-sync"
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn(),
+    pullRequest: {
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+const mockedTransaction = prisma.$transaction as jest.Mock
+const mockedFindMany = prisma.pullRequest.findMany as jest.Mock
+const mockedUpsert = prisma.pullRequest.upsert as jest.Mock
+const mockedUpdate = prisma.pullRequest.update as jest.Mock
+
+function createPullRequest(number: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: number,
+    number,
+    title: `PR ${number}`,
+    body: null,
+    state: "open",
+    draft: false,
+    merged_at: null,
+    closed_at: null,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-02T00:00:00Z",
+    base: { ref: "main" },
+    head: { ref: `feature-${number}` },
+    ...overrides,
+  }
+}
+
+describe("syncRepositoryPullRequests", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("syncs pull requests without wrapping the full write set in a transaction", async () => {
+    const remotePullRequests = [createPullRequest(1), createPullRequest(2)]
+    const octokit = {
+      paginate: jest.fn().mockResolvedValue(remotePullRequests),
+      rest: {
+        pulls: {
+          list: jest.fn(),
+          get: jest.fn(({ pull_number }) =>
+            Promise.resolve({
+              data: createPullRequest(pull_number, {
+                additions: 12,
+                deletions: 3,
+                changed_files: 2,
+              }),
+            })
+          ),
+        },
+      },
+    }
+
+    mockedFindMany.mockResolvedValue([])
+    mockedUpsert.mockImplementation(({ create }) =>
+      Promise.resolve({ id: `local-pr-${create.number}`, number: create.number })
+    )
+    mockedUpdate.mockResolvedValue({})
+
+    const result = await syncRepositoryPullRequests({
+      octokit: octokit as never,
+      owner: "owner",
+      repo: "repo",
+      repositoryId: "repo-1",
+    })
+
+    expect(result).toEqual({
+      syncedCount: 2,
+      detailHydratedCount: 2,
+    })
+    expect(mockedTransaction).not.toHaveBeenCalled()
+    expect(mockedUpsert).toHaveBeenCalledTimes(2)
+    expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(2)
+    expect(mockedUpdate).toHaveBeenCalledTimes(2)
+    expect(mockedUpdate).toHaveBeenCalledWith({
+      where: { id: "local-pr-1" },
+      data: {
+        additions: 12,
+        deletions: 3,
+        changedFiles: 2,
+      },
+    })
+  })
+})

--- a/lib/pull-request-sync.ts
+++ b/lib/pull-request-sync.ts
@@ -19,6 +19,9 @@ export interface SyncRepositoryPullRequestsResult {
   detailHydratedCount: number
 }
 
+const PR_WRITE_BATCH_SIZE = 25
+const PR_DETAIL_FETCH_BATCH_SIZE = 5
+
 export function getPullRequestStatus(pr: {
   state: string
   draft?: boolean | null
@@ -32,6 +35,21 @@ export function getPullRequestStatus(pr: {
   }
 
   return "OPEN"
+}
+
+async function mapInBatches<T, Result>(
+  items: T[],
+  batchSize: number,
+  handler: (item: T) => Promise<Result>
+): Promise<Result[]> {
+  const results: Result[] = []
+
+  for (let index = 0; index < items.length; index += batchSize) {
+    const batch = items.slice(index, index + batchSize)
+    results.push(...(await Promise.all(batch.map(handler))))
+  }
+
+  return results
 }
 
 function getNeedsDetailHydration(
@@ -146,8 +164,10 @@ export async function syncRepositoryPullRequests({
     getNeedsDetailHydration(existingByNumber.get(pullRequest.number), pullRequest)
   )
 
-  const syncedPullRequests = await prisma.$transaction(
-    remotePullRequests.map((pullRequest) =>
+  const syncedPullRequests = await mapInBatches(
+    remotePullRequests,
+    PR_WRITE_BATCH_SIZE,
+    (pullRequest) =>
       prisma.pullRequest.upsert({
         where: { githubId: BigInt(pullRequest.id) },
         update: {
@@ -167,48 +187,49 @@ export async function syncRepositoryPullRequests({
         },
         create: toUpsertPayload(pullRequest, repositoryId),
       })
-    )
   )
 
   const syncedByNumber = new Map(
     syncedPullRequests.map((pullRequest) => [pullRequest.number, pullRequest.id])
   )
 
-  const hydratedResults: {
-    id: string
-    additions: number
-    deletions: number
-    changedFiles: number
-  }[] = []
+  const hydratedResults = await mapInBatches(
+    pullRequestsToHydrate,
+    PR_DETAIL_FETCH_BATCH_SIZE,
+    async (pullRequest) => {
+      try {
+        const { data } = await octokit.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: pullRequest.number,
+        })
 
-  for (const pullRequest of pullRequestsToHydrate) {
-    try {
-      const { data } = await octokit.rest.pulls.get({
-        owner,
-        repo,
-        pull_number: pullRequest.number,
-      })
+        const localId = syncedByNumber.get(pullRequest.number)
 
-      const localId = syncedByNumber.get(pullRequest.number)
+        if (!localId) {
+          return null
+        }
 
-      if (!localId) {
-        continue
+        return {
+          id: localId,
+          additions: data.additions ?? 0,
+          deletions: data.deletions ?? 0,
+          changedFiles: data.changed_files ?? 0,
+        }
+      } catch {
+        // Continue syncing other PRs when one detail request fails.
+        return null
       }
-
-      hydratedResults.push({
-        id: localId,
-        additions: data.additions ?? 0,
-        deletions: data.deletions ?? 0,
-        changedFiles: data.changed_files ?? 0,
-      })
-    } catch {
-      // Continue syncing other PRs when one detail request fails.
     }
-  }
+  )
 
-  if (hydratedResults.length > 0) {
-    await prisma.$transaction(
-      hydratedResults.map((result) =>
+  const validHydratedResults = hydratedResults.filter((result) => result !== null)
+
+  if (validHydratedResults.length > 0) {
+    await mapInBatches(
+      validHydratedResults,
+      PR_WRITE_BATCH_SIZE,
+      (result) =>
         prisma.pullRequest.update({
           where: { id: result.id },
           data: {
@@ -217,12 +238,11 @@ export async function syncRepositoryPullRequests({
             changedFiles: result.changedFiles,
           },
         })
-      )
     )
   }
 
   return {
     syncedCount: remotePullRequests.length,
-    detailHydratedCount: hydratedResults.length,
+    detailHydratedCount: validHydratedResults.length,
   }
 }


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [x] Week 3-4: GitHub 연동
- [ ] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 협업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

Closes #166.

저장소 PR 동기화에서 모든 PR upsert/update를 하나의 Prisma `$transaction`으로 묶어 처리하던 구조를 작은 배치 처리로 변경합니다. PR 수가 많은 저장소에서 Prisma 기본 트랜잭션 제한을 넘겨 `P2028`이 발생하던 문제를 줄입니다.

## 변경 사항

- PR 목록 upsert를 25개 단위 배치로 처리하도록 변경했습니다.
- 상세 PR 조회를 5개 단위로 제한해 GitHub API 및 서버 부하를 낮췄습니다.
- 상세 통계 update도 25개 단위 배치로 처리하도록 변경했습니다.
- 전체 write set이 `$transaction` 하나로 감싸지지 않는지 회귀 테스트를 추가했습니다.

## 스크린샷 (선택)

해당 없음. 서버 동기화 로직 수정입니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`tsc --noEmit`)
- [ ] ESLint 경고/에러 없음

검증 결과:

- `C:\project\CodeMate\node_modules\.bin\jest.cmd __tests__\lib\pull-request-sync.test.ts --runInBand`: 통과, 1 suite / 1 test
- `C:\project\CodeMate\node_modules\.bin\jest.cmd --runInBand`: 통과, 23 suites / 133 tests
- `C:\project\CodeMate\node_modules\.bin\tsc.cmd --noEmit`: 통과
- `C:\project\CodeMate\node_modules\.bin\eslint.cmd`: 에러 0개, 기존 경고 1개 (`hooks/useRealtimeComments.ts`의 unused var, 본 PR 변경 범위 외)

## 참고 사항

이 변경은 GitHub가 원본인 PR 목록 동기화 작업에 맞춰 부분 반영 후 재시도가 가능한 구조를 선택한 것입니다. 중간 실패 시 일부 PR만 반영될 수 있지만 다음 동기화에서 같은 GitHub ID 기준으로 다시 upsert되어 복구됩니다.