### PR TITLE
fix: AI 리뷰 요청 안정화 및 즉시 실패 피드백

### DIFF
--- a/app/api/pulls/[id]/review/route.ts
+++ b/app/api/pulls/[id]/review/route.ts
@@ -1,28 +1,75 @@
 import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { buildAccessiblePullRequestWhere } from "@/lib/repository-access";
 import type { AIReviewResponse } from "@/lib/ai/parsers";
+import type { Review } from "@/types/review";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { id } = await params;
+    const session = await auth();
 
-    const review = await prisma.review.findFirst({
-      where: { pullRequestId: id },
-      orderBy: { reviewedAt: "desc" },
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const pullRequestWhere = await buildAccessiblePullRequestWhere(
+      session.user.id
+    );
+
+    const pullRequest = await prisma.pullRequest.findFirst({
+      where: {
+        id,
+        ...pullRequestWhere,
+      },
+      select: {
+        reviews: {
+          select: {
+            id: true,
+            pullRequestId: true,
+            aiSuggestions: true,
+            qualityScore: true,
+            severity: true,
+            issueCount: true,
+            status: true,
+            stage: true,
+            reviewedAt: true,
+          },
+          take: 1,
+          orderBy: { reviewedAt: "desc" },
+        },
+      },
     });
+
+    if (!pullRequest) {
+      return NextResponse.json(
+        { error: "Pull request not found" },
+        { status: 404 }
+      );
+    }
+
+    const review = pullRequest.reviews[0];
 
     if (!review) {
       return NextResponse.json(null);
     }
 
-    return NextResponse.json({
+    const response: Review = {
       ...review,
       aiSuggestions: review.aiSuggestions as AIReviewResponse,
-    });
-  } catch {
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+      reviewedAt: review.reviewedAt.toISOString(),
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error("[GET /api/pulls/[id]/review]", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/review/analyze/route.ts
+++ b/app/api/review/analyze/route.ts
@@ -4,6 +4,34 @@ import { getEnabledUserIds } from "@/lib/notification-settings";
 import { prisma } from "@/lib/prisma";
 import { getRepositoryMemberIds } from "@/lib/repository-access";
 import { upsertReviewNotifications } from "@/lib/review-notifications";
+import type { NotificationReviewStatus } from "@/types/notification";
+
+async function notifyReviewStatus(params: {
+  repositoryId: string;
+  prId: string;
+  prTitle: string;
+  prNumber: number;
+  status: NotificationReviewStatus;
+}) {
+  try {
+    const repositoryUserIds = [
+      ...new Set(await getRepositoryMemberIds(params.repositoryId)),
+    ];
+    const notificationType =
+      params.status === "FAILED" ? "REVIEW_FAILED" : "NEW_REVIEW";
+    const userIds = await getEnabledUserIds(repositoryUserIds, notificationType);
+
+    await upsertReviewNotifications({
+      userIds,
+      prId: params.prId,
+      prTitle: params.prTitle,
+      prNumber: params.prNumber,
+      status: params.status,
+    });
+  } catch (error) {
+    console.error("[review notification] failed:", error);
+  }
+}
 
 export async function POST(request: Request) {
   try {
@@ -34,14 +62,8 @@ export async function POST(request: Request) {
       );
     }
 
-    const repositoryUserIds = [...new Set(await getRepositoryMemberIds(pr.repoId))];
-    const pendingRecipientIds = await getEnabledUserIds(
-      repositoryUserIds,
-      "NEW_REVIEW"
-    );
-
-    await upsertReviewNotifications({
-      userIds: pendingRecipientIds,
+    void notifyReviewStatus({
+      repositoryId: pr.repoId,
       prId: pullRequestId,
       prTitle: pr.title,
       prNumber: pr.number,
@@ -54,13 +76,8 @@ export async function POST(request: Request) {
           return;
         }
 
-        const targetRecipients =
-          result.status === "FAILED"
-            ? await getEnabledUserIds(repositoryUserIds, "REVIEW_FAILED")
-            : pendingRecipientIds;
-
-        await upsertReviewNotifications({
-          userIds: targetRecipients,
+        await notifyReviewStatus({
+          repositoryId: pr.repoId,
           prId: pullRequestId,
           prTitle: pr.title,
           prNumber: pr.number,

--- a/components/review/ReviewPanel/ReviewCompletedState/ReviewCompletedHeader.tsx
+++ b/components/review/ReviewPanel/ReviewCompletedState/ReviewCompletedHeader.tsx
@@ -6,6 +6,7 @@ import type { Review } from "@/types/review";
 interface ReviewCompletedHeaderProps {
   assessment: Review["aiSuggestions"]["overallAssessment"] | undefined;
   isRequesting: boolean;
+  requestError?: string | null;
   score: number;
   onRequestReview: () => void;
 }
@@ -13,6 +14,7 @@ interface ReviewCompletedHeaderProps {
 export default function ReviewCompletedHeader({
   assessment,
   isRequesting,
+  requestError,
   score,
   onRequestReview,
 }: ReviewCompletedHeaderProps) {
@@ -48,6 +50,11 @@ export default function ReviewCompletedHeader({
             </>
           )}
         </button>
+        {requestError && (
+          <p className="basis-full rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-300">
+            {requestError}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/components/review/ReviewPanel/ReviewCompletedState/index.tsx
+++ b/components/review/ReviewPanel/ReviewCompletedState/index.tsx
@@ -14,6 +14,7 @@ import ReviewSummaryBox from "./ReviewSummaryBox";
 interface ReviewCompletedStateProps {
   review: Review;
   isRequesting: boolean;
+  requestError?: string | null;
   onRequestReview: () => void;
   onIssueClick?: (issue: ReviewIssue) => void;
 }
@@ -21,6 +22,7 @@ interface ReviewCompletedStateProps {
 export default function ReviewCompletedState({
   review,
   isRequesting,
+  requestError,
   onRequestReview,
   onIssueClick,
 }: ReviewCompletedStateProps) {
@@ -33,6 +35,7 @@ export default function ReviewCompletedState({
       <ReviewCompletedHeader
         assessment={view.assessment}
         isRequesting={isRequesting}
+        requestError={requestError}
         score={review.qualityScore}
         onRequestReview={onRequestReview}
       />

--- a/components/review/ReviewPanel/ReviewEmptyState.tsx
+++ b/components/review/ReviewPanel/ReviewEmptyState.tsx
@@ -2,11 +2,13 @@ import { BotMessageSquare, Loader2 } from "lucide-react";
 
 interface ReviewEmptyStateProps {
   isRequesting: boolean;
+  requestError?: string | null;
   onRequestReview: () => void;
 }
 
 export default function ReviewEmptyState({
   isRequesting,
+  requestError,
   onRequestReview,
 }: ReviewEmptyStateProps) {
   return (
@@ -23,6 +25,11 @@ export default function ReviewEmptyState({
           요청하면 AI가 이 PR을 분석해서 리뷰를 생성합니다.
         </p>
       </div>
+      {requestError && (
+        <p className="max-w-md rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-center text-xs font-medium text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-300">
+          {requestError}
+        </p>
+      )}
       <button
         type="button"
         onClick={onRequestReview}

--- a/components/review/ReviewPanel/ReviewFailedState.tsx
+++ b/components/review/ReviewPanel/ReviewFailedState.tsx
@@ -4,12 +4,14 @@ import type { Review } from "@/types/review";
 interface ReviewFailedStateProps {
   review: Review;
   isRequesting: boolean;
+  requestError?: string | null;
   onRequestReview: () => void;
 }
 
 export default function ReviewFailedState({
   review,
   isRequesting,
+  requestError,
   onRequestReview,
 }: ReviewFailedStateProps) {
   return (
@@ -30,6 +32,12 @@ export default function ReviewFailedState({
           </div>
         </div>
       </div>
+
+      {requestError && (
+        <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-300">
+          {requestError}
+        </p>
+      )}
 
       <button
         type="button"

--- a/components/review/ReviewPanel/index.tsx
+++ b/components/review/ReviewPanel/index.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { usePRReviewActions } from "@/hooks/pr-detail/usePRReviewActions";
-import { useReviewQuery } from "@/hooks/useReview";
+import {
+  useReviewQuery,
+  useReviewRealtimeInvalidation,
+} from "@/hooks/useReview";
 import type { ReviewIssue } from "@/types/review";
 import ReviewCompletedState from "./ReviewCompletedState";
 import ReviewEmptyState from "./ReviewEmptyState";
@@ -16,7 +19,9 @@ interface ReviewPanelProps {
 
 export default function ReviewPanel({ prId, onIssueClick }: ReviewPanelProps) {
   const { data: review, isPending } = useReviewQuery(prId);
-  const { requestReview, isRequesting } = usePRReviewActions(prId);
+  useReviewRealtimeInvalidation(prId);
+  const { requestReview, isRequesting, requestError } =
+    usePRReviewActions(prId);
 
   if (isPending) {
     return <ReviewLoadingState />;
@@ -26,6 +31,7 @@ export default function ReviewPanel({ prId, onIssueClick }: ReviewPanelProps) {
     return (
       <ReviewEmptyState
         isRequesting={isRequesting}
+        requestError={requestError}
         onRequestReview={requestReview}
       />
     );
@@ -36,6 +42,7 @@ export default function ReviewPanel({ prId, onIssueClick }: ReviewPanelProps) {
       <ReviewFailedState
         review={review}
         isRequesting={isRequesting}
+        requestError={requestError}
         onRequestReview={requestReview}
       />
     );
@@ -49,6 +56,7 @@ export default function ReviewPanel({ prId, onIssueClick }: ReviewPanelProps) {
     <ReviewCompletedState
       review={review}
       isRequesting={isRequesting}
+      requestError={requestError}
       onIssueClick={onIssueClick}
       onRequestReview={requestReview}
     />

--- a/hooks/pr-detail/usePRReviewActions.ts
+++ b/hooks/pr-detail/usePRReviewActions.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import type { Review } from "@/types/review";
 
 function createPendingReview(prId: string): Review {
@@ -25,9 +26,11 @@ function createPendingReview(prId: string): Review {
 export function usePRReviewActions(prId: string) {
   const queryClient = useQueryClient();
   const [isRequesting, setIsRequesting] = useState(false);
+  const [requestError, setRequestError] = useState<string | null>(null);
 
   const requestReview = useCallback(async () => {
     setIsRequesting(true);
+    setRequestError(null);
 
     try {
       const res = await fetch("/api/review/analyze", {
@@ -36,7 +39,12 @@ export function usePRReviewActions(prId: string) {
         body: JSON.stringify({ pullRequestId: prId }),
       });
 
-      if (!res.ok) return;
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "AI 리뷰 요청에 실패했습니다.");
+      }
 
       queryClient.setQueryData<Review | null>(["review", prId], (current) =>
         current
@@ -49,10 +57,21 @@ export function usePRReviewActions(prId: string) {
       );
 
       await queryClient.invalidateQueries({ queryKey: ["review", prId] });
+      toast.success("AI 리뷰 요청을 시작했습니다.");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "AI 리뷰 요청에 실패했습니다.";
+
+      setRequestError(message);
+      toast.error("AI 리뷰 요청 실패", {
+        description: message,
+      });
     } finally {
       setIsRequesting(false);
     }
   }, [prId, queryClient]);
 
-  return { requestReview, isRequesting };
+  return { requestReview, isRequesting, requestError };
 }

--- a/hooks/useReview.ts
+++ b/hooks/useReview.ts
@@ -19,9 +19,30 @@ type ReviewQueryOptions = Omit<
   "queryKey" | "queryFn"
 >
 
+class ReviewError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = "ReviewError"
+    this.status = status
+  }
+}
+
 async function fetchReview(prId: string): Promise<Review | null> {
   const res = await fetch(`/api/pulls/${prId}/review`)
-  if (!res.ok) throw new Error("리뷰 데이터를 불러오는 데 실패했습니다.")
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as
+      | { error?: string }
+      | null
+
+    throw new ReviewError(
+      body?.error ?? "리뷰 데이터를 불러오지 못했습니다.",
+      res.status
+    )
+  }
+
   return res.json()
 }
 
@@ -34,15 +55,17 @@ export function useReviewQuery(prId: string, options?: ReviewQueryOptions) {
       if (status === "PENDING" || status === "IN_PROGRESS") return 3000
       return false
     },
+    retry: false,
+    staleTime: 30_000,
     ...options,
   })
 }
 
-export function useReview(prId: string) {
+export function useReviewRealtimeInvalidation(prId: string) {
   const { socket } = useSocket()
   const queryClient = useQueryClient()
 
-  // Socket: NEW_REVIEW 알림 수신 시 즉시 refetch
+  // Socket: refetch review data when a review notification arrives.
   useEffect(() => {
     if (!socket) return
 
@@ -64,6 +87,8 @@ export function useReview(prId: string) {
       recordHandlerRemoved("notification:new")
     }
   }, [socket, prId, queryClient])
+}
 
+export function useReview(prId: string) {
   return useReviewQuery(prId)
 }

--- a/pr-detail-lighthouse-improvement-plan.md
+++ b/pr-detail-lighthouse-improvement-plan.md
@@ -1,0 +1,246 @@
+# PR Detail Lighthouse Improvement Plan
+
+## 1. Measurement Snapshot
+
+- Target URL: `http://localhost:3000/pulls/cmotp4ehl001uokqdedir2ij1`
+- Lighthouse version: `13.0.2`
+- Fetch time: `2026-05-09T12:14:33.824Z`
+
+| Metric | Current |
+|---|---:|
+| Performance | 54 |
+| First Contentful Paint | 0.6s |
+| Largest Contentful Paint | 2.0s |
+| Speed Index | 3.5s |
+| Total Blocking Time | 1,110ms |
+| Max Potential FID | 810ms |
+| Cumulative Layout Shift | 0.000015 |
+| Time to Interactive | 2.3s |
+| Root document response time | 1,270ms |
+| Main-thread work | 4.1s |
+| JavaScript execution time | 1.2s |
+
+## 2. Primary Findings
+
+### 2.1 Review API Error
+
+Lighthouse reports two console errors from:
+
+```txt
+GET /api/pulls/cmotp4ehl001uokqdedir2ij1/review
+500 Internal Server Error
+```
+
+This should be fixed before comparing performance runs because the failed request adds noise, creates console errors, and may trigger retry behavior.
+
+### 2.2 LCP Is The PR Title
+
+The LCP element is the PR detail title:
+
+```txt
+h1.text-xl
+perf: PR Detail 성능 개선 스택 main 반영
+```
+
+The title is not image-bound. The main LCP opportunities are:
+
+- reduce root document response time
+- render or hydrate the minimal PR header data earlier
+- avoid making the PR title wait for client-side data fetches when possible
+
+### 2.3 Diff Rendering Dominates The Page
+
+The report shows:
+
+- total DOM elements: `10,242`
+- largest child set: `tbody` under `hooks/useNotifications.ts`, `325` children
+- style and layout work: `1.2s`
+- Speed Index: `3.5s`
+- full page contains many expanded diff tables for 19 changed files
+
+This points to diff table DOM size and layout work as the biggest frontend rendering target.
+
+### 2.4 Files API Is A Large Critical Input
+
+The files request is one of the largest and slowest page data requests:
+
+```txt
+GET /api/pulls/cmotp4ehl001uokqdedir2ij1/files
+transfer: 58.2KB
+duration: about 1.83s
+```
+
+The PR title and header do not need full patch bodies, so file metadata and patch content should be split or lazily fetched.
+
+### 2.5 One JS Chunk Has High Evaluation Cost
+
+The largest script evaluation cost is:
+
+```txt
+/_next/static/chunks/4af27f77bd5de33b.js
+transfer: 70.6KB
+script evaluation: 1.17s
+unused JS: 21KB
+```
+
+The Lighthouse JSON does not identify the source modules for this chunk. A bundle analyzer or Next build stats should be used before assigning the cost to a specific component or dependency.
+
+## 3. Implementation Goals
+
+1. Remove measurement noise from expected API failures.
+2. Make PR title/header visible as early as possible.
+3. Reduce initial diff DOM size and layout work.
+4. Split expensive patch data from lightweight file metadata.
+5. Identify and defer initial JavaScript that is not needed for the first screen.
+
+## 4. Implementation Plan
+
+### Phase 1. Stabilize Review API
+
+Target files:
+
+- `hooks/useReview.ts`
+- `components/pulls/detail/ReviewSection.tsx`
+- `components/review/ReviewPanel/index.tsx`
+- `app/api/pulls/[id]/review/route.ts`
+
+Tasks:
+
+- Treat "review does not exist yet" as a normal empty state instead of a 500.
+- Return a stable JSON shape such as `{ review: null }` or `{ status: "not_found" }`.
+- Disable or limit client retry for expected not-found states.
+- Make `ReviewSection` and `ReviewPanel` render the empty state without logging browser errors.
+
+Acceptance criteria:
+
+- Lighthouse `errors-in-console` no longer reports `/review` 500 errors.
+- Network tab shows no repeated failed `/review` request on initial page load.
+- Review UI still works when review data exists.
+
+### Phase 2. Improve PR Header LCP Path
+
+Target files:
+
+- `app/(protected)/pulls/[id]/page.tsx`
+- `components/pulls/detail/PRDetailContainer.tsx`
+- `components/pulls/detail/PRDetailHeader.tsx`
+- `hooks/usePRDetail.ts`
+
+Tasks:
+
+- Profile the server page path around `auth()` and initial render.
+- Fetch only minimal PR header data server-side or prehydrate the PR detail query.
+- Pass initial PR title/status/branch metadata into the client detail container.
+- Keep files and diff loading separate from the PR header path.
+
+Acceptance criteria:
+
+- PR title can render without waiting for `/api/pulls/[id]/files`.
+- LCP remains the PR title but moves earlier.
+- Root document response time does not regress materially after adding server-side header data.
+
+### Phase 3. Reduce Initial Diff DOM
+
+Target files:
+
+- `components/pulls/detail/PRDiffSection.tsx`
+- `components/pulls/detail/PRDiffViewer/index.tsx`
+- `components/pulls/detail/PRDiffViewer/DiffTable.tsx`
+- `components/pulls/detail/MobileFileDropdown.tsx`
+- `components/pulls/detail/PRFileList.tsx`
+
+Tasks:
+
+- Render only the selected file's diff on mobile.
+- On desktop, mount only visible or explicitly expanded file diffs initially.
+- Default very large files to collapsed state.
+- Keep file headers and file list visible while deferring large diff tables.
+- Consider row virtualization for large `DiffTable` bodies after the lazy-mount step is stable.
+
+Acceptance criteria:
+
+- Initial DOM element count drops significantly from `10,242`.
+- Largest `tbody` child count no longer appears in the initial Lighthouse DOM snapshot unless that file is selected.
+- Style and layout time decreases from the current `1.2s` range.
+- File navigation, issue click handling, and comment anchors still work.
+
+### Phase 4. Split Files Metadata From Patch Content
+
+Target files:
+
+- `app/api/pulls/[id]/files/route.ts`
+- `hooks/usePRFiles.ts`
+- `components/pulls/detail/PRFileList.tsx`
+- `components/pulls/detail/PRDiffSection.tsx`
+- `components/pulls/detail/PRDiffViewer/index.tsx`
+
+Tasks:
+
+- Add or adjust an endpoint that returns lightweight file metadata only.
+- Fetch full patch content only when a file is selected, expanded, or scrolled into view.
+- Cache patch responses per PR/file key.
+- Keep existing UI states for loading, error, empty patch, and binary/no-diff files.
+
+Acceptance criteria:
+
+- Initial `/files` payload no longer includes all patch bodies.
+- Initial page load transfers less data than the current `58.2KB` files response.
+- Expanding or selecting a file fetches and renders its patch predictably.
+- Previously supported diff interactions still work.
+
+### Phase 5. Analyze And Defer Heavy JavaScript
+
+Target files:
+
+- To be decided after bundle analysis.
+
+Tasks:
+
+- Run Next bundle analysis or inspect build stats to map `4af27f77bd5de33b.js`.
+- Identify whether the heavy work comes from diff rendering, syntax highlighting, socket code, modal code, or shared UI dependencies.
+- Move non-first-screen modules behind dynamic imports only after confirming their source.
+- Ensure syntax highlighting and modal code are loaded only when the relevant UI is opened.
+
+Acceptance criteria:
+
+- The largest initial JS chunk has a known source module list.
+- Initial script evaluation time decreases from the current `1.17s` chunk cost.
+- No user-visible loading regressions for review suggestions, issue modals, or socket status UI.
+
+## 5. Verification Plan
+
+Run each measurement at least 3 times and compare averages, not one-off runs.
+
+Recommended checks:
+
+- `npm run lint`
+- `npm run build`
+- Lighthouse on the same URL and same device mode
+- Browser console check for `/review` errors
+- Manual PR detail flow:
+  - page load
+  - file list navigation
+  - mobile file dropdown
+  - diff issue click
+  - review issue click
+  - large file expand/collapse
+  - comment section load
+
+Target metrics:
+
+| Metric | Target |
+|---|---:|
+| Performance | 80+ |
+| LCP | under 1.5s |
+| Speed Index | under 2.5s |
+| TBT | under 500ms |
+| Console errors | 0 |
+| CLS | keep near 0 |
+
+## 6. Notes And Non-Goals
+
+- Do not attribute the heavy JS chunk to a specific dependency until bundle analysis confirms it.
+- Do not optimize GitHub avatar caching first; it is not a meaningful bottleneck in this report.
+- Do not prioritize CLS; the current CLS value is already effectively zero.
+- Accessibility issues should be handled separately unless a change directly touches the same markup.
+- Avoid hiding diff content permanently. The goal is lazy rendering and progressive loading, not removing useful review context.


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [x] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [x] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

Closes #172

AI 리뷰 요청/조회 흐름을 안정화했습니다. `Review.stage` 마이그레이션을 실제 DB에 적용했고, socket/notification 경로가 불안정해도 리뷰 요청 자체가 막히지 않도록 분리했습니다. 또한 리뷰 요청 실패 시 즉시 toast와 패널 내 메시지로 피드백을 보여줍니다.

## 변경 사항

- `/api/pulls/[id]/review`에 인증/접근권한 확인과 안정적인 응답 shape 추가
- `/api/review/analyze`에서 notification/socket emit 실패가 review 요청을 막지 않도록 분리
- `useReview`에서 query와 socket invalidation 책임 분리
- review query 실패 시 불필요한 retry 방지 및 staleTime 적용
- review 요청 POST 실패 시 즉시 toast와 패널 내 에러 표시
- Lighthouse 기반 PR Detail 성능 개선 계획 문서 추가
- Supabase DB에 `Review.stage`, `Notification.reviewStatus` 관련 migration 적용 완료

## 스크린샷 (선택)

없음

## 테스트

- [x] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`npm run build`)
- [x] ESLint 경고/에러 없음

검증 결과:

- `npx prisma migrate deploy` 성공
- `npx prisma migrate status` 결과: Database schema is up to date
- `npm run lint` 통과
  - 기존 warning 1개: `hooks/useRealtimeComments.ts`의 unused `appendComment`
- `npm run build` 통과

## 참고 사항

- socket server는 review 요청의 필수 조건이 아니며, 완료/실패 알림을 빠르게 받기 위한 보조 채널입니다.
- socket 연결이 없으면 notification summary polling으로 알림 배지가 늦게 갱신될 수 있습니다.
- 현재 브랜치에는 unrelated workspace 변경을 포함하지 않았습니다.