### PR TITLE
perf: PR 상세 헤더 LCP 경로 개선

### DIFF
--- a/app/(protected)/pulls/[id]/page.tsx
+++ b/app/(protected)/pulls/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { auth } from "@/lib/auth"
 import PRDetailContainer from "@/components/pulls/detail/PRDetailContainer"
 import CommentSection from "@/components/comment/CommentSection"
+import { getPullRequestDetailForUser } from "@/lib/pr-detail/pullRequestDetail"
 
 interface PRDetailPageProps {
   params: Promise<{ id: string }>
@@ -21,12 +22,16 @@ export default async function PRDetailPage({ params }: PRDetailPageProps) {
   const { id } = await params;
   const session = await auth();
   const currentUserId = session?.user?.id ?? "";
+  const initialPullRequest = session?.user?.id
+    ? await getPullRequestDetailForUser(id, session.user.id)
+    : null;
 
   return (
     <PRDetailContainer
       id={id}
       commentSlot={<CommentSection prId={id} />}
       currentUserId={currentUserId}
+      initialPullRequest={initialPullRequest}
     />
   );
 }

--- a/app/api/pulls/[id]/route.ts
+++ b/app/api/pulls/[id]/route.ts
@@ -1,10 +1,5 @@
 import { auth } from "@/lib/auth"
-import { getOctokit } from "@/lib/github"
-import { prisma } from "@/lib/prisma"
-import {
-  buildAccessiblePullRequestWhere,
-  getRepositoryPrimaryUser,
-} from "@/lib/repository-access"
+import { getPullRequestDetailForUser } from "@/lib/pr-detail/pullRequestDetail"
 import { NextResponse } from "next/server"
 
 export async function GET(
@@ -19,83 +14,13 @@ export async function GET(
     }
 
     const { id } = await params
-    const pullRequestWhere = await buildAccessiblePullRequestWhere(
-      session.user.id
-    )
-
-    const pr = await prisma.pullRequest.findFirst({
-      where: {
-        id,
-        ...pullRequestWhere,
-      },
-      include: {
-        repo: {
-          select: {
-            id: true,
-            name: true,
-            fullName: true,
-          },
-        },
-        reviews: {
-          select: {
-            id: true,
-            status: true,
-            qualityScore: true,
-            issueCount: true,
-            severity: true,
-            reviewedAt: true,
-          },
-          take: 1,
-          orderBy: { reviewedAt: "desc" },
-        },
-      },
-    })
+    const pr = await getPullRequestDetailForUser(id, session.user.id)
 
     if (!pr) {
       return NextResponse.json({ error: "Pull request not found" }, { status: 404 })
     }
 
-    const owner = await getRepositoryPrimaryUser(pr.repo.id)
-
-    let { additions, deletions, changedFiles } = pr
-
-    if (additions === 0 && deletions === 0 && changedFiles === 0) {
-      try {
-        const octokit = await getOctokit(session.user.id)
-        const [ownerName, repoName] = pr.repo.fullName.split("/")
-        const { data } = await octokit.pulls.get({
-          owner: ownerName,
-          repo: repoName,
-          pull_number: pr.number,
-        })
-
-        additions = data.additions
-        deletions = data.deletions
-        changedFiles = data.changed_files
-
-        prisma.pullRequest
-          .update({ where: { id }, data: { additions, deletions, changedFiles } })
-          .catch(() => {})
-      } catch {
-        // Keep stored values when GitHub hydration fails.
-      }
-    }
-
-    const { githubId, repo: repository, ...rest } = pr
-
-    return NextResponse.json({
-      ...rest,
-      githubId: Number(githubId),
-      additions,
-      deletions,
-      changedFiles,
-      repo: {
-        id: repository.id,
-        name: repository.name,
-        fullName: repository.fullName,
-        owner,
-      },
-    })
+    return NextResponse.json(pr)
   } catch {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }

--- a/components/pulls/detail/PRDetailContainer.tsx
+++ b/components/pulls/detail/PRDetailContainer.tsx
@@ -4,19 +4,25 @@ import PRDetailLayout from "@/components/pulls/detail/PRDetailLayout";
 import { usePRDetail } from "@/hooks/usePRDetail";
 import { usePRFiles } from "@/hooks/usePRFiles";
 import { layoutStyles } from "@/lib/styles";
+import type { PullRequest } from "@/types/pulls";
 
 interface PRDetailContainerProps {
   id: string;
   commentSlot: React.ReactNode;
   currentUserId: string;
+  initialPullRequest?: PullRequest | null;
 }
 
 export default function PRDetailContainer({
   id,
   commentSlot,
   currentUserId,
+  initialPullRequest,
 }: PRDetailContainerProps) {
-  const { data: pr, isPending: prPending, isError: prError } = usePRDetail(id);
+  const { data: pr, isPending: prPending, isError: prError } = usePRDetail(id, {
+    initialData: initialPullRequest ?? undefined,
+    staleTime: initialPullRequest ? 30_000 : undefined,
+  });
   usePRFiles(id);
 
   if (prPending) {
@@ -53,6 +59,7 @@ export default function PRDetailContainer({
       id={id}
       commentSlot={commentSlot}
       currentUserId={currentUserId}
+      initialPullRequest={pr}
     />
   );
 }

--- a/components/pulls/detail/PRDetailHeader.tsx
+++ b/components/pulls/detail/PRDetailHeader.tsx
@@ -6,18 +6,25 @@ import { timeAgo } from "@/lib/date";
 import { PR_STATUS_STYLE } from "@/constants/pulls";
 import { SocketConnectionBadge } from "@/components/realtime/SocketConnectionStatus";
 import { useCachedPRDetail } from "@/hooks/pr-detail/usePRDetailCachedQueries";
+import type { PullRequest } from "@/types/pulls";
 import BranchChip from "./BranchChip";
 
 interface PRDetailHeaderProps {
   prId: string;
   scrolled?: boolean;
+  initialPullRequest?: PullRequest;
 }
 
-export default function PRDetailHeader({ prId, scrolled = false }: PRDetailHeaderProps) {
+export default function PRDetailHeader({
+  prId,
+  scrolled = false,
+  initialPullRequest,
+}: PRDetailHeaderProps) {
   const router = useRouter();
   const { data: pr } = useCachedPRDetail(prId);
+  const displayPr = pr ?? initialPullRequest;
 
-  if (!pr) return null;
+  if (!displayPr) return null;
 
   return (
     <div
@@ -36,26 +43,26 @@ export default function PRDetailHeader({ prId, scrolled = false }: PRDetailHeade
             <ChevronLeft size={16} />
           </button>
 
-          <span className={`px-2 py-0.5 rounded-full border text-[9px] font-black uppercase tracking-wider shrink-0 ${PR_STATUS_STYLE[pr.status]}`}>
-            {pr.status}
+          <span className={`px-2 py-0.5 rounded-full border text-[9px] font-black uppercase tracking-wider shrink-0 ${PR_STATUS_STYLE[displayPr.status]}`}>
+            {displayPr.status}
           </span>
 
           <SocketConnectionBadge className="hidden md:inline-flex" />
 
           <h1 className="text-xs md:text-sm font-bold text-slate-900 dark:text-white truncate flex-1 min-w-0">
-            {pr.title}
+            {displayPr.title}
           </h1>
 
           <span className="text-[10px] text-slate-400 font-mono shrink-0 hidden sm:block">
-            #{pr.number}
+            #{displayPr.number}
           </span>
 
           <div className="hidden md:flex items-center gap-1 text-[10px] font-bold shrink-0">
             <span className="px-1.5 py-0.5 bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 rounded-full border border-emerald-100 dark:border-emerald-500/20">
-              +{pr.additions}
+              +{displayPr.additions}
             </span>
             <span className="px-1.5 py-0.5 bg-rose-50 dark:bg-rose-500/10 text-rose-500 rounded-full border border-rose-100 dark:border-rose-500/20">
-              -{pr.deletions}
+              -{displayPr.deletions}
             </span>
           </div>
         </div>
@@ -75,24 +82,24 @@ export default function PRDetailHeader({ prId, scrolled = false }: PRDetailHeade
               </button>
               <div className="flex flex-wrap items-baseline gap-2">
                 <h1 className="text-xl md:text-2xl font-bold text-slate-900 dark:text-white tracking-tight break-all">
-                  {pr.title}
+                  {displayPr.title}
                 </h1>
                 <span className="text-lg md:text-2xl font-light text-slate-400">
-                  #{pr.number}
+                  #{displayPr.number}
                 </span>
               </div>
             </div>
 
             <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
-              <span className={`px-2.5 py-0.5 rounded-full border text-[10px] font-black uppercase tracking-wider ${PR_STATUS_STYLE[pr.status]}`}>
-                {pr.status}
+              <span className={`px-2.5 py-0.5 rounded-full border text-[10px] font-black uppercase tracking-wider ${PR_STATUS_STYLE[displayPr.status]}`}>
+                {displayPr.status}
               </span>
               <div className="flex flex-wrap items-center gap-1.5 text-slate-500 dark:text-slate-400 font-medium">
-                <span className="font-bold text-slate-900 dark:text-slate-200">{pr.repo.name}</span>
+                <span className="font-bold text-slate-900 dark:text-slate-200">{displayPr.repo.name}</span>
                 <span className="hidden sm:inline">wants to merge into</span>
-                <BranchChip name={pr.baseBranch} />
+                <BranchChip name={displayPr.baseBranch} />
                 <span className="hidden sm:inline">from</span>
-                <BranchChip name={pr.headBranch} />
+                <BranchChip name={displayPr.headBranch} />
               </div>
             </div>
           </div>
@@ -102,19 +109,19 @@ export default function PRDetailHeader({ prId, scrolled = false }: PRDetailHeade
             <div className="flex items-center gap-2 text-[10px] md:text-xs font-bold">
               <SocketConnectionBadge className="hidden md:inline-flex" />
               <span className="px-2 py-1 bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 rounded-full border border-emerald-100 dark:border-emerald-500/20">
-                +{pr.additions}
+                +{displayPr.additions}
               </span>
               <span className="px-2 py-1 bg-rose-50 dark:bg-rose-500/10 text-rose-500 rounded-full border border-rose-100 dark:border-rose-500/20">
-                -{pr.deletions}
+                -{displayPr.deletions}
               </span>
               <div className="hidden sm:flex items-center gap-1.5 px-3 py-1 bg-slate-50 dark:bg-slate-800 text-slate-500 dark:text-slate-400 rounded-full border border-slate-100 dark:border-slate-700">
                 <FileText size={14} />
-                {pr.changedFiles} files
+                {displayPr.changedFiles} files
               </div>
             </div>
             <div className="flex items-center gap-1.5 text-[10px] md:text-xs text-slate-400 font-medium">
               <Clock size={12} />
-              {timeAgo(pr.createdAt)}
+              {timeAgo(displayPr.createdAt)}
             </div>
           </div>
 

--- a/components/pulls/detail/PRDetailLayout.tsx
+++ b/components/pulls/detail/PRDetailLayout.tsx
@@ -14,18 +14,21 @@ import { usePRDetailReset } from "@/hooks/pr-detail/usePRDetailReset";
 import { useSocketRoom } from "@/hooks/useSocketRoom";
 import { layoutStyles } from "@/lib/styles";
 import { usePRDetailStore } from "@/stores/prDetailStore";
+import type { PullRequest } from "@/types/pulls";
 import type { ReviewIssue } from "@/types/review";
 
 interface PRDetailLayoutProps {
   id: string;
   commentSlot: React.ReactNode;
   currentUserId: string;
+  initialPullRequest: PullRequest;
 }
 
 export default function PRDetailLayout({
   id,
   commentSlot,
   currentUserId,
+  initialPullRequest,
 }: PRDetailLayoutProps) {
   const { sidebarCollapsed, setSidebarCollapsed } =
     usePRDetailStore(
@@ -84,6 +87,7 @@ export default function PRDetailLayout({
         <PRDetailStickyHeader
           prId={id}
           scrolled={scrolled}
+          initialPullRequest={initialPullRequest}
         />
 
         <div className="space-y-4 p-4">

--- a/components/pulls/detail/PRDetailStickyHeader.tsx
+++ b/components/pulls/detail/PRDetailStickyHeader.tsx
@@ -3,19 +3,26 @@
 import PRDetailHeader from "./PRDetailHeader";
 import InlineTypingBanner from "./InlineTypingBanner";
 import MobileFileDropdown from "./MobileFileDropdown";
+import type { PullRequest } from "@/types/pulls";
 
 interface PRDetailStickyHeaderProps {
   prId: string;
   scrolled: boolean;
+  initialPullRequest: PullRequest;
 }
 
 export default function PRDetailStickyHeader({
   prId,
   scrolled,
+  initialPullRequest,
 }: PRDetailStickyHeaderProps) {
   return (
     <div className="sticky top-0 z-20">
-      <PRDetailHeader prId={prId} scrolled={scrolled} />
+      <PRDetailHeader
+        prId={prId}
+        scrolled={scrolled}
+        initialPullRequest={initialPullRequest}
+      />
       <InlineTypingBanner prId={prId} />
       <MobileFileDropdown prId={prId} />
     </div>

--- a/lib/pr-detail/pullRequestDetail.ts
+++ b/lib/pr-detail/pullRequestDetail.ts
@@ -1,0 +1,109 @@
+import { getOctokit } from "@/lib/github";
+import { prisma } from "@/lib/prisma";
+import {
+  buildAccessiblePullRequestWhere,
+  getRepositoryPrimaryUser,
+} from "@/lib/repository-access";
+import type { PullRequest } from "@/types/pulls";
+
+function serializeDate(date: Date | null): string | null {
+  return date ? date.toISOString() : null;
+}
+
+export async function getPullRequestDetailForUser(
+  id: string,
+  userId: string
+): Promise<PullRequest | null> {
+  const pullRequestWhere = await buildAccessiblePullRequestWhere(userId);
+
+  const pr = await prisma.pullRequest.findFirst({
+    where: {
+      id,
+      ...pullRequestWhere,
+    },
+    include: {
+      repo: {
+        select: {
+          id: true,
+          name: true,
+          fullName: true,
+        },
+      },
+      reviews: {
+        select: {
+          id: true,
+          status: true,
+          qualityScore: true,
+          issueCount: true,
+          severity: true,
+          reviewedAt: true,
+        },
+        take: 1,
+        orderBy: { reviewedAt: "desc" },
+      },
+    },
+  });
+
+  if (!pr) {
+    return null;
+  }
+
+  const owner = await getRepositoryPrimaryUser(pr.repo.id);
+  let { additions, deletions, changedFiles } = pr;
+
+  if (additions === 0 && deletions === 0 && changedFiles === 0) {
+    try {
+      const octokit = await getOctokit(userId);
+      const [ownerName, repoName] = pr.repo.fullName.split("/");
+      const { data } = await octokit.pulls.get({
+        owner: ownerName,
+        repo: repoName,
+        pull_number: pr.number,
+      });
+
+      additions = data.additions;
+      deletions = data.deletions;
+      changedFiles = data.changed_files;
+
+      prisma.pullRequest
+        .update({
+          where: { id },
+          data: { additions, deletions, changedFiles },
+        })
+        .catch(() => {});
+    } catch {
+      // Keep stored values when GitHub hydration fails.
+    }
+  }
+
+  return {
+    id: pr.id,
+    githubId: Number(pr.githubId),
+    number: pr.number,
+    title: pr.title,
+    description: pr.description ?? "",
+    status: pr.status,
+    baseBranch: pr.baseBranch,
+    headBranch: pr.headBranch,
+    additions,
+    deletions,
+    changedFiles,
+    repoId: pr.repoId,
+    repo: {
+      id: pr.repo.id,
+      name: pr.repo.name,
+      fullName: pr.repo.fullName,
+      owner,
+    },
+    mergedAt: serializeDate(pr.mergedAt),
+    closedAt: serializeDate(pr.closedAt),
+    githubCreatedAt: serializeDate(pr.githubCreatedAt),
+    githubUpdatedAt: serializeDate(pr.githubUpdatedAt),
+    createdAt: pr.createdAt.toISOString(),
+    updatedAt: pr.updatedAt.toISOString(),
+    reviews: pr.reviews.map((review) => ({
+      ...review,
+      reviewedAt: serializeDate(review.reviewedAt),
+    })),
+  };
+}

--- a/types/pulls.ts
+++ b/types/pulls.ts
@@ -7,6 +7,15 @@ export interface PullRequestRepo {
   owner: { id: string; name: string | null; image: string | null } | null;
 }
 
+export interface PullRequestReviewSummary {
+  id: string;
+  status: string;
+  qualityScore: number | null;
+  issueCount: number;
+  severity: string | null;
+  reviewedAt: string | null;
+}
+
 export interface PullRequest {
   id: string;
   githubId: number;
@@ -27,6 +36,7 @@ export interface PullRequest {
   githubUpdatedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  reviews?: PullRequestReviewSummary[];
 }
 
 export interface PullRequestPagination {


### PR DESCRIPTION
## 작업 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일/UI (style)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 설정/환경 (chore)

## 관련 마일스톤

- [ ] Week 1-2: 프로젝트 기반 & 인증
- [ ] Week 3-4: GitHub 연동
- [x] Week 5-6: AI 코드 리뷰
- [ ] Week 7-8: 실시간 작업
- [ ] Week 9-10: 대시보드 & 배포

## 개요

PR 상세 페이지의 헤더 데이터가 클라이언트 fetch 이후에만 렌더링되던 흐름을 개선했습니다. 서버에서 접근 권한이 확인된 PR 상세 데이터를 먼저 로드해 React Query 초기 데이터와 헤더 렌더링에 재사용합니다.

Closes #174

## 변경 사항

- PR 상세 조회 로직을 `lib/pr-detail/pullRequestDetail.ts`로 추출했습니다.
- `/api/pulls/[id]` route가 같은 서버 로더를 사용하도록 정리하면서 기존 `reviews` 응답 계약은 유지했습니다.
- PR 상세 페이지 서버 컴포넌트에서 초기 PR 데이터를 가져와 `PRDetailContainer`에 전달합니다.
- `PRDetailHeader`까지 초기 데이터를 내려 첫 렌더에서 제목, 번호, 상태, 브랜치, 변경량을 표시할 수 있게 했습니다.
- 초기 데이터가 있을 때 React Query에 짧은 `staleTime`을 부여해 마운트 직후 중복 상세 요청을 줄였습니다.

## 스크린샷 (선택)

N/A - 데이터 로딩 경로 개선이며 UI 모양 변경은 없습니다.

## 테스트

- [ ] 로컬 개발 서버에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] 타입 에러 없음 (`npm.cmd run build`)
- [x] ESLint 경고/에러 없음 (`npm.cmd run lint`) - 통과, 기존 `hooks/useRealtimeComments.ts` 미사용 변수 warning 1건 유지
- [x] Jest 전체 테스트 통과 (`npm.cmd test -- --runInBand`) - 23 suites / 133 tests passed

## 참고 사항

- 검증용 `npm.cmd ci --prefer-offline --ignore-scripts` 실행 중 기존 peer dependency warning 및 audit 취약점 리포트가 출력되었지만, lockfile 변경은 없습니다.
- 서버 로더는 기존 API의 GitHub 변경량 보강 로직을 그대로 공유합니다.